### PR TITLE
changed winston.logger to winston.createLogger

### DIFF
--- a/lib/logger/node.js
+++ b/lib/logger/node.js
@@ -32,7 +32,7 @@ function Logger(options)
     // initialize the winston logger if needed
     if (!winstonLogger)
     {
-      winstonLogger = new winston.Logger(
+      winstonLogger = new winston.createLogger(
       {
         transports:
         [


### PR DESCRIPTION
Winston was upgrade to 3.1.0 from 2.1.0 where they use winston.createLogger instead of winston.logger