### PR TITLE
Properly destroy keepalive

### DIFF
--- a/lib/connection/connection.js
+++ b/lib/connection/connection.js
@@ -28,8 +28,6 @@ function Connection(context)
   // generate an id for the connection
   var id = uuidv4();
 
-  var keepalive = null;
-
   /**
    * Returns true if the connection is active otherwise false
    *

--- a/lib/connection/connection.js
+++ b/lib/connection/connection.js
@@ -99,7 +99,7 @@ function Connection(context)
       {
         if (Parameters.getValue(Parameters.names.CLIENT_SESSION_KEEP_ALIVE))
         {
-          keepalive = setInterval(self.heartbeat, Parameters.getValue(Parameters.names.CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY) * 1000, self);
+          self.keepalive = setInterval(self.heartbeat, Parameters.getValue(Parameters.names.CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY) * 1000, self);
         }
 
         if (Util.isFunction(callback))


### PR DESCRIPTION
In v1.1.12 it looks like the `clearInterval()` call in `.destroy()` never executes, so a connection with keepalive set to `true` will keep the process running forever even after it's destroyed.

For example, this will hang:

```js
snowflake
  .createConnection({ ...connectionOptions, clientSessionKeepAlive: true })
  .connect((error, connection) => connection.destroy());
```

whereas this successfully destroys the connection:

```js
snowflake
  .createConnection({ ...connectionOptions, clientSessionKeepAlive: false })
  .connect((error, connection) => connection.destroy());
```

I've also found that although the docs say the default value for `clientSessionKeepAlive` is `false`, the default actually seems to be `true`, though it's not obvious to me where that's set.