### PR TITLE
SNOW-148046: Fix Date bind parameters

### DIFF
--- a/lib/connection/statement.js
+++ b/lib/connection/statement.js
@@ -1124,7 +1124,11 @@ function buildBindsMap(bindsArray)
     {
       if (value !== null && !Util.isString(value))
       {
-        value = JSON.stringify(value);
+        if (value instanceof Date) {
+          value = value.toJSON();
+        } else {
+          value = JSON.stringify(value);
+        }
       }
     }
     else
@@ -1135,7 +1139,11 @@ function buildBindsMap(bindsArray)
         var value0 = bindsArray[rowIndex][index];
         if (value0 !== null && !Util.isString(value0))
         {
-          value0 = JSON.stringify(value0);
+          if (value0 instanceof Date) {
+            value0 = value0.toJSON();
+          } else {
+            value0 = JSON.stringify(value0);
+          }
         }
         value.push(value0);
       }

--- a/test/integration/testBind.js
+++ b/test/integration/testBind.js
@@ -599,7 +599,7 @@ describe('Test Bind Varible', function ()
       testingFunc(
         'timestamp_ntz',
         [new Date('Thu, 21 Jan 2016 06:32:44 -0800')],
-        [{'COLA': '2016-01-21T14:32:44.000Z'}],
+        [{'COLA': '2016-01-21 14:32:44.000'}],
         done
       );
     });

--- a/test/integration/testBind.js
+++ b/test/integration/testBind.js
@@ -594,6 +594,16 @@ describe('Test Bind Varible', function ()
       );
     });
 
+    it('testBindingTimestampNTZDate', function (done)
+    {
+      testingFunc(
+        'timestamp_ntz',
+        [new Date('Thu, 21 Jan 2016 06:32:44 -0800')],
+        [{'COLA': '2016-01-21T14:32:44.000Z'}],
+        done
+      );
+    });
+
     /*it('testBindingVariantSimple', function(done){
       var variant = {'a':1 , 'b':[1], 'c':{'a':1}};
       testingFunc(


### PR DESCRIPTION
Fixes https://github.com/snowflakedb/snowflake-connector-nodejs/issues/89

In `lib/connection/statement.js#createStatementContext` checks for `instanceof Date` and uses `toJSON` instead of `JSON.stringify`, to avoid surrounding the date with quotes, as demonstrated in sample code below. 

```javascript
const date = new Date('Thu, 21 Jan 2016 06:32:44 -0800');
console.log(JSON.stringify(date));
console.log(date.toJSON())
```
Outputs:
```
"2016-01-21T14:32:44.000Z"
2016-01-21T14:32:44.000Z
```

Also adds integration test, fixed by this change.