### PR TITLE
not use orders table

### DIFF
--- a/system_test/testToken.js
+++ b/system_test/testToken.js
@@ -115,7 +115,7 @@ describe('testLoginTokenExpire', function ()
           // the session should refreshed and the sql should succeed
           testUtil.executeCmd(
             connection,
-            'select * from orders limit 10',
+            'select seq8() from table(generator(rowcount=>10))',
             callback
           );
         }


### PR DESCRIPTION
The test table `ORDERS` is no longer used in the NodeJS tests.