### PR TITLE
Fixes missing peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,11 +4,13 @@
   "description": "Node.js driver for Snowflake",
   "dependencies": {
     "agent-base": "^2.1.1",
+    "asn1.js": "^5.0.0",
     "asn1.js-rfc2560": "^5.0.0",
     "asn1.js-rfc5280": "^3.0.0",
     "axios": "^0.21.1",
     "big-integer": "^1.6.43",
     "bignumber.js": "^2.4.0",
+    "bn.js": "^4.0.0",
     "browser-request": "^0.3.3",
     "debug": "^3.2.6",
     "extend": "^3.0.2",


### PR DESCRIPTION
In older npm/yarn setups a peer dependency can be satisfied anywhere to function, and its resolution is ambiguous; however in yarn berry (yarn v2) dependency resolution is strictly and unambiguously enforced.

In yarn berry environments snowflake-connector-nodejs fails to function due to missing peer dependencies; in this case "asn1.js" and "bn.js" are peerDependencies of some of snowflake-connector-nodejs's dependencies. This can be resolved in two ways:

- Making the missing peerDependencies dependencies of snowflake-connector-nodejs
- Making the missing peerDependencies into peerDependencies of snowflake-connector-nodejs (allowing the importing project to satisfy them).

Trying to set them as dependencies of the importing project without setting them as peerDependencies of snowflake-connector-nodejs (the traditional solution) will fail to unambiguously resolve the dependencies (due to broken dependency chain).

This PR resolves the issue with the first fix, that is to resolve the peerDependencies in this project.