### PR TITLE
Set Windows test jobs to use Python 3.7

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -89,7 +89,7 @@ jobs:
                 node-version: '12.x'
             - uses: actions/setup-python@v1
               with:
-                python-version: '3.x'
+                python-version: '3.7'
                 architecture: 'x64'
             - name: Download Build Artifacts
               uses: actions/download-artifact@v1


### PR DESCRIPTION
Set all Windows test jobs to use Python 3.7 since we don't support Python 3.8 right now
