### PR TITLE
Increase OCSP cache size

### DIFF
--- a/lib/agent/ocsp_response_cache.js
+++ b/lib/agent/ocsp_response_cache.js
@@ -23,18 +23,16 @@ const status = {
 };
 
 // validate input
-const capacity = GlobalConfig.getOcspResponseCacheMaxSize();
 const maxAge = GlobalConfig.getOcspResponseCacheMaxAge();
 
-Errors.assertInternal(Util.number.isPositiveInteger(capacity));
 Errors.assertInternal(Util.number.isPositiveInteger(maxAge));
 
 const cacheDir = GlobalConfig.mkdirCacheDir();
 const cacheFileName = path.join(cacheDir, "ocsp_response_cache.json");
-// create a cache to store the responses
-const cache = new SimpleCache({maxSize: capacity});
-// store previous cache's responses
-var prevCacheJSON;
+// create a cache to store the responses, dynamically changes in size
+var cache;
+// JSON object with previous cache's responses
+var prevCacheObj;
 
 function deleteCache()
 {
@@ -61,6 +59,7 @@ function OcspResponseCache()
 {
   let downloadStatus = status.NOT_START;
   let cacheUpdated = false;
+  let cacheInitialized = false;
 
   /**
    * Reads OCSP cache file.
@@ -76,24 +75,24 @@ function OcspResponseCache()
   {
     Logger.getInstance().debug("Reading OCSP cache file. %s", cacheFileName);
     const contents = fs.readFileSync(cacheFileName, 'utf-8');
-    let jsonParsed = JSON.parse(contents);
-    prevCacheJSON = jsonParsed;
-    for (let entry in jsonParsed)
-    {
-      if (jsonParsed.hasOwnProperty(entry))
-      {
-        const status = validateCacheEntry(entry, jsonParsed[entry]);
-        if (!status.err)
-        {
-          cache.set(status.key, status.value);
-        }
-      }
-    }
+    prevCacheObj = JSON.parse(contents);
+    cache = new SimpleCache({ maxSize: Object.keys(prevCacheObj).length });
+    setCacheEntries(prevCacheObj);
+    cacheInitialized = true;
   }
   catch (e)
   {
     Logger.getInstance().debug("Failed to read OCSP cache file: %s, err: %s", cacheFileName, e);
   }
+
+  /**
+   * Is OCSP Cache initialized?
+   * @returns {boolean}
+   */
+  this.isInitialized = function ()
+  {
+    return cacheInitialized;
+  };
 
   /**
    * Is OCSP Cache download finished?
@@ -131,7 +130,6 @@ function OcspResponseCache()
         cacheOutput[certIdInBase64] = [currentTime, ocspResponseInBase64];
       });
       const writeContent = JSON.stringify(cacheOutput);
-
       Logger.getInstance().debug("Writing OCSP cache file. %s", cacheFileName);
       try
       {
@@ -206,11 +204,7 @@ function OcspResponseCache()
       try
       {
         let jsonParsed = JSON.parse(cacheContent);
-        setCacheEntries(jsonParsed);
-        if (prevCacheJSON)
-        {
-          setCacheEntries(prevCacheJSON);
-        }
+        updateCache(jsonParsed);
         cacheUpdated = true;
         return cb(null, false);
       }
@@ -287,22 +281,27 @@ function OcspResponseCache()
   {
     const maxAge = GlobalConfig.getOcspResponseCacheMaxAge();
 
+    var err;
     if (ocspResponseBase64.length !== 2)
     {
       Logger.getInstance()
         .debug("OCSP cache value doesn't consist of two elements. Ignored.");
-      return {err: Errors.createOCSPError(ErrorCodes.ERR_OCSP_NOT_TWO_ELEMENTS)};
+      err = Errors.createOCSPError(ErrorCodes.ERR_OCSP_NOT_TWO_ELEMENTS);
     }
     if ((currentTime - ocspResponseBase64[0]) > maxAge)
     {
       Logger.getInstance().debug(
         "OCSP cache validity is out of range. currentTime: %s, timestamp: %s",
         currentTime, ocspResponseBase64[0]);
-      return {err: Errors.createOCSPError(ErrorCodes.ERR_OCSP_CACHE_EXPIRED)};
+      err = Errors.createOCSPError(ErrorCodes.ERR_OCSP_CACHE_EXPIRED);
     }
     try
     {
       const k = CertUtil.encodeKey(certIdBase64);
+      if (err)
+      {
+        return { err: err, key: k };
+      }
       const rawOCSPResponse = Buffer.from(ocspResponseBase64[1], 'base64');
       const status = CertUtil.verifyOCSPResponse(null, rawOCSPResponse);
       if (!status.err)
@@ -319,19 +318,91 @@ function OcspResponseCache()
     }
   }
 
+  function updateCache(jsonObject)
+  {
+    // Get the size of cache retrieved from the cache server
+    var responseCacheSize = Object.keys(jsonObject).length;
+
+    // Check if there are previous entries to append
+    if (prevCacheObj)
+    {
+      // Count overlap between previous cache and response cache
+      var cacheOverlapCount = 0;
+      for (let entry in jsonObject)
+      {
+        if (entryExists(prevCacheObj, entry))
+        {
+          cacheOverlapCount++;
+        }
+      }
+
+      // Count entries from previous cache
+      var prevCacheSize = Object.keys(prevCacheObj).length;
+
+      // New cache size = previous cache size + response cache size - overlap between the two caches
+      var newCacheSize = prevCacheSize + responseCacheSize - cacheOverlapCount;
+      // Create cache with max size equal to the new cache size
+      cache = new SimpleCache({ maxSize: newCacheSize });
+
+      // Add new entries
+      setCacheEntries(jsonObject);
+
+      // Append older unique entries to cache
+      for (let entry in prevCacheObj)
+      {
+        if (prevCacheObj.hasOwnProperty(entry) && !entryExists(jsonObject, entry))
+        {
+          updateOrDeleteEntry(prevCacheObj, entry);
+        }
+      }
+    }
+    else
+    {
+      // Create cache with max size equal to the response cache size
+      cache = new SimpleCache({ maxSize: responseCacheSize });
+
+      // Add new entries
+      setCacheEntries(jsonObject);
+    }
+    cacheInitialized = true;
+  }
+
   function setCacheEntries(jsonObject)
   {
     for (let entry in jsonObject)
     {
       if (jsonObject.hasOwnProperty(entry))
       {
-        const status = validateCacheEntry(entry, jsonObject[entry]);
-        if (!status.err)
-        {
-          cache.set(status.key, status.value);
-        }
+        updateOrDeleteEntry(jsonObject, entry);
       }
     }
+  }
+
+  function updateOrDeleteEntry(jsonObject, entry)
+  {
+    const status = validateCacheEntry(entry, jsonObject[entry]);
+    if (!status.err)
+    {
+      // Add new entry or update existing one
+      cache.set(status.key, status.value);
+    }
+    else if (status.err.code === ErrorCodes.ERR_OCSP_CACHE_EXPIRED)
+    {
+      // If timestamp expired, delete entry
+      cache.del(status.key);
+    }
+  }
+
+  function entryExists(jsonObject, entry)
+  {
+    for (let otherEntry in jsonObject)
+    {
+      if (entry === otherEntry)
+      {
+        return true;
+      }
+    }
+    return false;
   }
 }
 

--- a/lib/agent/ocsp_response_cache.js
+++ b/lib/agent/ocsp_response_cache.js
@@ -23,8 +23,10 @@ const status = {
 };
 
 // validate input
+const sizeLimit = GlobalConfig.getOcspResponseCacheSizeLimit();
 const maxAge = GlobalConfig.getOcspResponseCacheMaxAge();
 
+Errors.assertInternal(Util.number.isPositiveInteger(sizeLimit));
 Errors.assertInternal(Util.number.isPositiveInteger(maxAge));
 
 const cacheDir = GlobalConfig.mkdirCacheDir();
@@ -327,12 +329,14 @@ function OcspResponseCache()
     if (prevCacheObj)
     {
       // Count overlap between previous cache and response cache
+      // And delete entry if expired
       var cacheOverlapCount = 0;
       for (let entry in jsonObject)
       {
         if (entryExists(prevCacheObj, entry))
         {
           cacheOverlapCount++;
+          updateOrDeleteEntry(prevCacheObj, entry);
         }
       }
 
@@ -341,25 +345,20 @@ function OcspResponseCache()
 
       // New cache size = previous cache size + response cache size - overlap between the two caches
       var newCacheSize = prevCacheSize + responseCacheSize - cacheOverlapCount;
-      // Create cache with max size equal to the new cache size
-      cache = new SimpleCache({ maxSize: newCacheSize });
+
+      // Create cache using new cache size if it doesn't exceed the upper limit
+      cache = new SimpleCache({ maxSize: newCacheSize < sizeLimit ? newCacheSize : sizeLimit });
 
       // Add new entries
       setCacheEntries(jsonObject);
 
       // Append older unique entries to cache
-      for (let entry in prevCacheObj)
-      {
-        if (prevCacheObj.hasOwnProperty(entry) && !entryExists(jsonObject, entry))
-        {
-          updateOrDeleteEntry(prevCacheObj, entry);
-        }
-      }
+      setCacheEntries(prevCacheObj);
     }
     else
     {
-      // Create cache with max size equal to the response cache size
-      cache = new SimpleCache({ maxSize: responseCacheSize });
+      // Create cache using response cache size if it doesn't exceed the upper limit
+      cache = new SimpleCache({ maxSize: responseCacheSize < sizeLimit ? responseCacheSize : sizeLimit });
 
       // Add new entries
       setCacheEntries(jsonObject);

--- a/lib/agent/ocsp_response_cache.js
+++ b/lib/agent/ocsp_response_cache.js
@@ -197,8 +197,6 @@ function OcspResponseCache()
       }
       downloadStatus = status.FINISHED;
       Logger.getInstance().debug("Finish OCSP Cache Server: %s", OCSP_URL);
-
-
       if (err)
       {
         Logger.getInstance()
@@ -214,7 +212,6 @@ function OcspResponseCache()
           setCacheEntries(prevCacheJSON);
         }
         cacheUpdated = true;
-
         return cb(null, false);
       }
       catch (e)
@@ -308,7 +305,6 @@ function OcspResponseCache()
       const k = CertUtil.encodeKey(certIdBase64);
       const rawOCSPResponse = Buffer.from(ocspResponseBase64[1], 'base64');
       const status = CertUtil.verifyOCSPResponse(null, rawOCSPResponse);
-
       if (!status.err)
       {
         return {err: null, key: k, value: rawOCSPResponse};

--- a/lib/agent/ocsp_response_cache.js
+++ b/lib/agent/ocsp_response_cache.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2019 Snowflake Computing Inc. All rights reserved.
+ * Copyright (c) 2015-2021 Snowflake Computing Inc. All rights reserved.
  */
 
 const http = require('http');
@@ -33,6 +33,8 @@ const cacheDir = GlobalConfig.mkdirCacheDir();
 const cacheFileName = path.join(cacheDir, "ocsp_response_cache.json");
 // create a cache to store the responses
 const cache = new SimpleCache({maxSize: capacity});
+// store previous cache's responses
+var prevCacheJSON;
 
 function deleteCache()
 {
@@ -75,6 +77,7 @@ function OcspResponseCache()
     Logger.getInstance().debug("Reading OCSP cache file. %s", cacheFileName);
     const contents = fs.readFileSync(cacheFileName, 'utf-8');
     let jsonParsed = JSON.parse(contents);
+    prevCacheJSON = jsonParsed;
     for (let entry in jsonParsed)
     {
       if (jsonParsed.hasOwnProperty(entry))
@@ -128,6 +131,7 @@ function OcspResponseCache()
         cacheOutput[certIdInBase64] = [currentTime, ocspResponseInBase64];
       });
       const writeContent = JSON.stringify(cacheOutput);
+
       Logger.getInstance().debug("Writing OCSP cache file. %s", cacheFileName);
       try
       {
@@ -193,6 +197,8 @@ function OcspResponseCache()
       }
       downloadStatus = status.FINISHED;
       Logger.getInstance().debug("Finish OCSP Cache Server: %s", OCSP_URL);
+
+
       if (err)
       {
         Logger.getInstance()
@@ -202,18 +208,13 @@ function OcspResponseCache()
       try
       {
         let jsonParsed = JSON.parse(cacheContent);
-        for (let entry in jsonParsed)
+        setCacheEntries(jsonParsed);
+        if (prevCacheJSON)
         {
-          if (jsonParsed.hasOwnProperty(entry))
-          {
-            const status = validateCacheEntry(entry, jsonParsed[entry]);
-            if (!status.err)
-            {
-              cache.set(status.key, status.value);
-            }
-          }
+          setCacheEntries(prevCacheJSON);
         }
         cacheUpdated = true;
+
         return cb(null, false);
       }
       catch (e)
@@ -307,6 +308,7 @@ function OcspResponseCache()
       const k = CertUtil.encodeKey(certIdBase64);
       const rawOCSPResponse = Buffer.from(ocspResponseBase64[1], 'base64');
       const status = CertUtil.verifyOCSPResponse(null, rawOCSPResponse);
+
       if (!status.err)
       {
         return {err: null, key: k, value: rawOCSPResponse};
@@ -318,6 +320,21 @@ function OcspResponseCache()
       Logger.getInstance()
         .debug("Failed to parse OCSP response. %s. Ignored.", e);
       return {err: Errors.createOCSPError(ErrorCodes.ERR_OCSP_FAILED_PARSE_RESPONSE)};
+    }
+  }
+
+  function setCacheEntries(jsonObject)
+  {
+    for (let entry in jsonObject)
+    {
+      if (jsonObject.hasOwnProperty(entry))
+      {
+        const status = validateCacheEntry(entry, jsonObject[entry]);
+        if (!status.err)
+        {
+          cache.set(status.key, status.value);
+        }
+      }
     }
   }
 }

--- a/lib/agent/socket_util.js
+++ b/lib/agent/socket_util.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2019 Snowflake Computing Inc. All rights reserved.
+ * Copyright (c) 2015-2021 Snowflake Computing Inc. All rights reserved.
  */
 
 const Check = require('./check');
@@ -306,8 +306,13 @@ function validateCert(cert, cb)
       });
     }
 
-    // if we already have an entry in the cache, use it
-    let ocspResponse = getOcspResponseCache().get(cert);
+    let ocspResponse;
+    // check if cache is initialized before getting entry
+    if (getOcspResponseCache().isInitialized())
+    {
+      // if we already have an entry in the cache, use it
+      ocspResponse = getOcspResponseCache().get(cert);
+    }
     if (ocspResponse)
     {
       Logger.getInstance().trace(

--- a/lib/global_config.js
+++ b/lib/global_config.js
@@ -77,6 +77,16 @@ exports.getOcspMode = function ()
 };
 
 /**
+ * Returns the upper limit for number of entries we can have in the OCSP response cache.
+ *
+ * @returns {number}
+ */
+exports.getOcspResponseCacheSizeLimit = function ()
+{
+  return 1000;
+};
+
+/**
  * Returns the maximum time in milliseconds that entries can live in the OCSP
  * response cache.
  *

--- a/lib/global_config.js
+++ b/lib/global_config.js
@@ -83,7 +83,7 @@ exports.getOcspMode = function ()
  */
 exports.getOcspResponseCacheMaxSize = function ()
 {
-  return 100;
+  return 150;
 };
 
 /**

--- a/lib/global_config.js
+++ b/lib/global_config.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2019 Snowflake Computing Inc. All rights reserved.
+ * Copyright (c) 2015-2021 Snowflake Computing Inc. All rights reserved.
  */
 
 const os = require('os');
@@ -74,16 +74,6 @@ exports.getOcspMode = function ()
     return ocspModes.FAIL_CLOSED;
   }
   return ocspModes.FAIL_OPEN;
-};
-
-/**
- * Returns the maximum number of entries we can have in the OCSP response cache.
- *
- * @returns {number}
- */
-exports.getOcspResponseCacheMaxSize = function ()
-{
-  return 150;
 };
 
 /**


### PR DESCRIPTION
By increasing the cache size, cache entries for already retrieved OCSP certificates will no longer be overwritten.