### PR TITLE
SNOW-329943: Bumped up the NodeJS Driver PATCH version from 1.6.0 to 1.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snowflake-sdk",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Node.js driver for Snowflake",
   "dependencies": {
     "agent-base": "^2.1.1",


### PR DESCRIPTION
@noreview - This is an automated process. No review is required.