### PR TITLE
Use HttpProxyAgent on top of axios when a proxy is configured

### DIFF
--- a/lib/authentication/auth_web.js
+++ b/lib/authentication/auth_web.js
@@ -18,10 +18,15 @@ var querystring = require('querystring');
  * @returns {Object}
  * @constructor
  */
-function auth_web(host, webbrowser, httpclient)
+function auth_web(host, proxy, webbrowser, httpclient)
 {
   var open = typeof webbrowser !== "undefined" ? webbrowser : require('open');
   var axios = typeof httpclient !== "undefined" ? httpclient : require('axios');
+
+  if (proxy) {
+    var agentClass = require('../agent/https_proxy_ocsp_agent')
+    axios = axios.create({httpsAgent: new agentClass(proxy), proxy: false});
+  }
 
   var host = host;
   var port = rest.HTTPS_PORT;

--- a/lib/authentication/authentication.js
+++ b/lib/authentication/authentication.js
@@ -79,7 +79,7 @@ exports.getAuthenticator = function getAuthenticator(connectionConfig)
   }
   else if (auth == authenticationTypes.EXTERNAL_BROWSER_AUTHENTICATOR)
   {
-    return new auth_web(connectionConfig.host);
+    return new auth_web(connectionConfig.host, connectionConfig.getProxy());
   }
   if (auth == authenticationTypes.KEY_PAIR_AUTHENTICATOR)
   {


### PR DESCRIPTION
Axios has a bug when running behind http proxies (https://github.com/axios/axios/issues/3384) which is a very common setup in many organizations. As suggested [here](https://github.com/axios/axios/issues/2072#issuecomment-609650888) I propose using snowflake-sdk's own HttpProxyAgent.

This PR is related with #159 