### PR TITLE
update requestretry to avoid missing package issues on snowflake

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "open": "^7.3.1",
     "python-struct": "^1.1.3",
     "request": "^2.88.0",
-    "requestretry": "^4.1.0",
+    "requestretry": "^6.0.0",
     "simple-lru-cache": "^0.0.2",
     "string-similarity": "^4.0.4",
     "test-console": "^2.0.0",


### PR DESCRIPTION
This is to resolve the following issue with a dependency, during webpack builds.

```
ERROR in ./node_modules/when/lib/env.js
Module not found: Error: Can't resolve 'vertx' in '/builds/.../node_modules/when/lib'
```