### PR TITLE
Update auth_web, to avoid error message #217

### DIFF
--- a/lib/authentication/auth_web.js
+++ b/lib/authentication/auth_web.js
@@ -30,7 +30,21 @@ function auth_web(host, webbrowser, httpclient)
   var token;
   var data;
 
-  var successResponse = Buffer.from('Your identity was confirmed and propagated to Snowflake Node.js driver. You can close this window now and go back where you started from.', 'utf8');
+  var content = [
+      "HTTP/1.1 200 OK",
+      "Content-Type: text/html"];
+  var msg = `
+<!DOCTYPE html><html><head><meta charset="UTF-8"/>
+<title>SAML Response for Snowflake</title></head>
+<body>
+Your identity was confirmed and propagated to Snowflake NODE JS Driver.
+You can close this window now and go back where you started from.
+</body></html>`;
+  content.push("Content-Length: "+ msg.length);
+  content.push("");
+  content.push(msg);
+  
+  var successResponse = content.join("\r\n");
 
   /**
    * Update JSON body with token and proof_key.


### PR DESCRIPTION
In the current implementation the success message that is returned will be reported as an error.

I looked at the Python Connector and adapted it to return the same msg