### PR TITLE
Bump dependencies - https-proxy-agent & agent-base

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Node.js driver for Snowflake",
   "dependencies": {
     "@azure/storage-blob": "^12.5.0",
-    "agent-base": "^4.3.0",
+    "agent-base": "^6.0.0",
     "asn1.js-rfc2560": "^5.0.0",
     "asn1.js-rfc5280": "^3.0.0",
     "aws-sdk": "^2.878.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "generic-pool": "^3.8.2",
     "glob": "^7.1.6",
     "http-signature": "^1.3.6",
-    "https-proxy-agent": "^3.0.0",
+    "https-proxy-agent": "^5.0.0",
     "jsonwebtoken": "^8.5.1",
     "json-schema": "^0.4.0",
     "jsprim": "^2.0.2",


### PR DESCRIPTION
Resolves #234

After importing `snowflake-sdk` all HTTPS requests from `got` result in `connect ECONNREFUSED 127.0.0.1:443` errors.

`https-proxy-agent` to `^5.0.0`
`agent-base` to `^6.0.0`