### PR TITLE
update `uuid` to `^8.3.2`

### DIFF
--- a/lib/connection/connection.js
+++ b/lib/connection/connection.js
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2015-2021 Snowflake Computing Inc. All rights reserved.
  */
-const uuidv4 = require('uuid/v4');
+const { v4: uuidv4 } = require('uuid');
 
 var Util = require('../util');
 var Errors = require('../errors');

--- a/lib/connection/statement.js
+++ b/lib/connection/statement.js
@@ -2,7 +2,7 @@
  * Copyright (c) 2015-2019 Snowflake Computing Inc. All rights reserved.
  */
 
-const uuidv4 = require('uuid/v4');
+const { v4: uuidv4 } = require('uuid');
 
 var Url = require('url');
 var QueryString = require('querystring');

--- a/lib/services/sf.js
+++ b/lib/services/sf.js
@@ -45,7 +45,7 @@
  */
 
 const axios = require('axios');
-const uuidv4 = require('uuid/v4');
+const { v4: uuidv4 } = require('uuid');
 const EventEmitter = require('events').EventEmitter;
 const Util = require('../util');
 const Errors = require('../errors');

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "string-similarity": "^4.0.4",
     "test-console": "^2.0.0",
     "tmp": "^0.2.1",
-    "uuid": "^3.3.2",
+    "uuid": "^8.3.2",
     "winston": "^3.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
npm complain about the `uuid` package, which I think we should upgrade it.

```
 WARN  deprecated uuid@3.3.2: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
```

Follow the upgrade guideline from: https://www.npmjs.com/package/uuid#upgrading-from-uuid3x