### PR TITLE
Bump dependencies - requestretry

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "open": "^7.3.1",
     "python-struct": "^1.1.3",
     "request": "^2.88.2",
-    "requestretry": "^6.0.0",
+    "requestretry": "^7.0.0",
     "simple-lru-cache": "^0.0.2",
     "string-similarity": "^4.0.4",
     "test-console": "^2.0.0",


### PR DESCRIPTION
There is [high severity vulnerability ](https://github.com/advisories/GHSA-hjp8-2cm3-cc45) in <7.0.0 version of `requestretry`. This PR upgrades the version of `requestretry` to overcome security vulnerability.