### PR TITLE
Unused deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,15 +18,9 @@
     "extend": "^3.0.2",
     "generic-pool": "^3.8.2",
     "glob": "^7.1.6",
-    "http-signature": "^1.3.6",
-    "https-proxy-agent": "^5.0.0",
     "jsonwebtoken": "^8.5.1",
-    "json-schema": "^0.4.0",
-    "jsprim": "^2.0.2",
-    "lodash": "^4.17.21",
     "mime-types": "^2.1.29",
     "mkdirp": "^1.0.3",
-    "mock-require": "^3.0.3",
     "moment": "^2.23.0",
     "moment-timezone": "^0.5.15",
     "ocsp": "^1.2.0",
@@ -36,18 +30,15 @@
     "requestretry": "^7.0.1",
     "simple-lru-cache": "^0.0.2",
     "string-similarity": "^4.0.4",
-    "test-console": "^2.0.0",
     "tmp": "^0.2.1",
     "uuid": "^3.3.2",
     "winston": "^3.1.0"
   },
   "devDependencies": {
     "async": "^2.6.1",
-    "follow-redirects": "1.14.8",
-    "insert-module-globals": "^7.2.0",
     "mocha": "9.2.0",
-    "vinyl-buffer": "^1.0.1",
-    "vinyl-source-stream": "^1.1.2"
+    "mock-require": "^3.0.3",
+    "test-console": "^2.0.0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "async": "^2.6.1",
-    "mocha": "9.2.0",
+    "mocha": "9.2.0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "jsonwebtoken": "^8.5.1",
     "mime-types": "^2.1.29",
     "mkdirp": "^1.0.3",
+    "mock-require": "^3.0.3",
     "moment": "^2.23.0",
     "moment-timezone": "^0.5.15",
     "ocsp": "^1.2.0",
@@ -37,7 +38,6 @@
   "devDependencies": {
     "async": "^2.6.1",
     "mocha": "9.2.0",
-    "mock-require": "^3.0.3",
     "test-console": "^2.0.0"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "requestretry": "^7.0.1",
     "simple-lru-cache": "^0.0.2",
     "string-similarity": "^4.0.4",
+    "test-console": "^2.0.0",
     "tmp": "^0.2.1",
     "uuid": "^3.3.2",
     "winston": "^3.1.0"
@@ -38,7 +39,6 @@
   "devDependencies": {
     "async": "^2.6.1",
     "mocha": "9.2.0",
-    "test-console": "^2.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Based on https://github.com/snowflakedb/snowflake-connector-nodejs/issues/275

Some of those dependencies was added in response to critical vulnerabilities that prevented the connector from building. They are now removed since the vulnerability is resolved.

ocsp is being used. test-console and mock-require are used when testing is done and needs to be under dependencies