### PR TITLE
[Connection pool] skip heartbeat check in keep-alive mode

### DIFF
--- a/lib/connection/connection.js
+++ b/lib/connection/connection.js
@@ -98,38 +98,43 @@ function Connection(context)
     return id;
   };
 
-  this.heartbeat = function (self)
+  /**
+  * Runs a "select 1" query.
+  *
+  * @returns {undefined}
+  */
+  this.heartbeat = function (self, complete = function () {})
   {
     self.execute({
       sqlText: 'select /* nodejs:heartbeat */ 1;',
-      complete: function ()
-      {
-      },
+      complete,
       internal: true,
     });
   };
 
   /**
-  * Runs a "select 1" query.
+  * Check if the connection is actually alive using a hearbeat query.
   *
-  * @returns {null}
+  * @returns {Promise<Boolean>}
   */
-  this.heartbeatAsync = async function ()
+  this.checkHeartbeat = function ()
   {
-    return await new Promise((resolve, reject) =>
+    return new Promise((resolve) =>
     {
-      this.execute({
-        sqlText: 'select /* nodejs:heartbeat */ 1;',
-        complete: function (err, stmt, rows)
+      this.heartbeat(
+        this,
+        function (err, stmt, rows)
         {
           if (err)
           {
-            reject(err);
+            resolve(false);
           }
-          resolve(rows);
+          else
+          {
+            resolve(rows[0][1] == 1);
+          }
         },
-        internal: true,
-      });
+      );
     });
   };
 

--- a/lib/core.js
+++ b/lib/core.js
@@ -272,14 +272,14 @@ function Core(options)
     /**
     * Returns the status of the connection.
     *
-    * @param {Object} connection
+    * @param {Connection} connection
     *
-    * @returns {Boolean}
+    * @returns {Promise<Boolean>}
     */
     this.validate = async function (connection)
     {
-      var heartbeat = await connection.heartbeatAsync();
-      return ((heartbeat[0][1] == 1) && connection.isUp());
+      return connection.isUp() && connection.isTokenValid() &&
+        (connection.getClientSessionKeepAlive() || await connection.checkHeartbeat());
     }
   }
 


### PR DESCRIPTION
## Summary
In connection pool, skip heartbeat check when keep-alive is enabled.

## Description
* Before:
    * Every `acquire()` call on the connection pool runs a heartbeat query (given that `testOnBorrow` of the pool is kept as `true`)
        * One big purpose of a connection pool is to avoid the overhead of the initial connection step. However, this heartbeat query execution results in an equivalent or even higher overhead, especially when the heartbeat query fails and the pool has to make a new connection.
 * After:
    * When `clientSessionKeepAlive` is true, skip the heartbeat query check and check only the client-side connection status.

## Other changes
* Refactor `heartbeatAsync` into `checkHeartbeat`:
    * When the heartbeat query fails, resolve the returned Promise into `false` instead of raising an Error.
    * Reuse the function `heartbeat` to reduce code duplication and ensure the consistency of "heartbeat" queries.
 * Check client-side connection status first (i.e. short-circuiting the logic) to avoid unnecessary heartbeat query executions.