### PR TITLE
fix web auth response

### DIFF
--- a/lib/authentication/auth_web.js
+++ b/lib/authentication/auth_web.js
@@ -5,7 +5,7 @@
 var util = require('../util');
 var rest = require('../global_config').rest;
 
-var net = require('net');
+var http = require('http');
 var querystring = require('querystring');
 
 /**
@@ -30,7 +30,7 @@ function auth_web(host, webbrowser, httpclient)
   var token;
   var data;
 
-  var successResponse = 'HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nConnection: close\r\n\r\nYour identity was confirmed and propagated to Snowflake Node.js driver. You can close this window now and go back where you started from.';
+  var successResponse = `<html><body>Your identity was confirmed and propagated to Snowflake Node.js driver. You can close this window now and go back where you started from.</body></html>`;
 
   /**
    * Update JSON body with token and proof_key.
@@ -95,23 +95,23 @@ function auth_web(host, webbrowser, httpclient)
    */
   function createServer(resolve)
   {
-    var server = net.createServer(function (socket)
+    var server = http.createServer(function (req, res)
     {
-      socket.on('data', function (chunk)
+      req.on('data', function (chunk)
       {
-        // User successfully entered credentials
-        socket.write(successResponse);
-
         // Receive the data and split by line
         var data = chunk.toString().split("\r\n");
 
-        // Stop accepting connections and close
-        socket.destroy();
-        server.close();
-
         resolve(data);
       });
-      socket.on('error', (socketErr) =>
+      req.on('end', function ()
+      {
+        res.writeHead(200, 'OK', {'Content-Type': 'text/html'});
+        res.write(successResponse);
+        server.close();
+      });
+
+      req.on('error', (socketErr) =>
       {
         if (socketErr['code'] === 'ECONNRESET')
         {


### PR DESCRIPTION
Using http.createServer instead of net.createServer is more idiomatic and allows us to not have to worry about http specifics.

In addition the response being sent was never terminated, thus the browser would think the response was still pending.

![image](https://user-images.githubusercontent.com/100240790/161648648-a3af3acb-43da-4349-a449-6b0eed09dd65.png)
