### PR TITLE
Move aws-sdk to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,12 +2,14 @@
   "name": "snowflake-sdk",
   "version": "1.6.8",
   "description": "Node.js driver for Snowflake",
+  "peerDependencies": {
+    "aws-sdk": "^2.878.0"
+  },
   "dependencies": {
     "@azure/storage-blob": "^12.5.0",
     "agent-base": "^6.0.2",
     "asn1.js-rfc2560": "^5.0.0",
     "asn1.js-rfc5280": "^3.0.0",
-    "aws-sdk": "^2.878.0",
     "axios": "^0.21.4",
     "big-integer": "^1.6.43",
     "bignumber.js": "^2.4.0",


### PR DESCRIPTION
aws-sdk is now a peer dependency. Users of this library's S3 functionality will now have to install a compatible version of aws-sdk alongside it. As such, you could argue this is a breaking change.

I haven't tried running the tests yet, and so it may be that aws-sdk should also be listed as a dev dependency, if it is used there.

Fixes #216.