### PR TITLE
upgrade moment to 2.29.2 to fix CVE-2022-24785

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "mime-types": "^2.1.29",
     "mkdirp": "^1.0.3",
     "mock-require": "^3.0.3",
-    "moment": "^2.23.0",
+    "moment": "^2.29.2",
     "moment-timezone": "^0.5.15",
     "ocsp": "^1.2.0",
     "open": "^7.3.1",


### PR DESCRIPTION
`snowflake-connector-nodejs` has a dependency with a security patch:

![Screen Shot 2022-04-12 at 12 29 47 PM](https://user-images.githubusercontent.com/57361/163039103-4c1d8631-179b-4bf2-a373-5cd048b14d7c.png)

fixed in: https://github.com/moment/moment/commit/4211bfc8f15746be4019bba557e29a7ba83d54c5