### PR TITLE
Modify okta url length check

### DIFF
--- a/lib/authentication/auth_okta.js
+++ b/lib/authentication/auth_okta.js
@@ -136,8 +136,8 @@ function auth_okta(password, region, account, httpclient)
   function step2(authenticator, ssoUrl, tokenUrl)
   {
     authenticator = authenticator.toLowerCase();
-    if (!(authenticator.startsWith(ssoUrl.substring(0, 30)) &&
-      authenticator.startsWith(tokenUrl.substring(0, 30))))
+    if (!(authenticator.startsWith(ssoUrl.substring(0, authenticator.length)) &&
+      authenticator.startsWith(tokenUrl.substring(0, authenticator.length))))
     {
       throw new Error("The prefix of the SSO/token URL and the specified authenticator do not match.");
     }


### PR DESCRIPTION
Based on SF #00382081

Issue is due to the given url not containing the closing '/' character which causes the error
`https://testurl.okta.com` vs `https://testurl.okta.com/`

Check against the given url length instead so it works whether the closing '/' character is included