### PR TITLE
Set the callback function for HttpsProxyAgent

### DIFF
--- a/lib/agent/https_proxy_ocsp_agent.js
+++ b/lib/agent/https_proxy_ocsp_agent.js
@@ -10,7 +10,7 @@ var net = require('net');
 var tls = require('tls');
 var url = require('url');
 var extend = require('extend');
-var Agent = require('agent-base');
+var createAgent = require('agent-base');
 var inherits = require('util').inherits;
 var debug = require('debug')('https-proxy-agent');
 
@@ -44,7 +44,10 @@ function HttpsProxyAgent(opts)
     throw new Error('an HTTP(S) proxy server `host` and `port` must be specified!');
   }
   debug('creating new HttpsProxyAgent instance: %o', opts);
-  Agent.call(this, connect);
+  var Agent = createAgent.call(this, connect);
+  this.callback = Agent.callback;
+  this.timeout = Agent.timeout;
+  this.options = Agent.opts;
 
   var proxy = extend({}, opts);
 
@@ -80,7 +83,7 @@ function HttpsProxyAgent(opts)
   this.proxy = proxy;
 }
 
-inherits(HttpsProxyAgent, Agent);
+inherits(HttpsProxyAgent, createAgent);
 
 /**
  * Called when the node-core HTTP client library is creating a new HTTP request.


### PR DESCRIPTION
Based on SF# 00384830

Modify HttpsProxyAgent due to an API change in agent-base from 4.3.0 to 5.0.0

Previously, agent-base will not create a new agent and use the existing one where it sets the callback, timeout, and options.
4.3.0: https://github.com/TooTallNate/node-agent-base/blob/560f111674af84dec46a4c3070ddf3b22edd3e76/index.js#L20

Now, it always creates a new agent even if an agent already exists, so the callback needs to be set directly
5.0.0: https://github.com/TooTallNate/node-agent-base/blob/512557bf07f6088594b8deb3315a4f934c81af47/src/index.ts#L25