### PR TITLE
Upgrade moment to ^2.29.4 (resolves CVE-2022-31129)

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "mime-types": "^2.1.29",
     "mkdirp": "^1.0.3",
     "mock-require": "^3.0.3",
-    "moment": "^2.29.3",
+    "moment": "^2.29.4",
     "moment-timezone": "^0.5.15",
     "@techteamer/ocsp": "1.0.0",
     "open": "^7.3.1",


### PR DESCRIPTION
Upgrades `moment` to `^2.29.4` to resolve [CVE-2022-31129](https://github.com/advisories/GHSA-wc69-rhjr-hc9g)