### PR TITLE
Update mocha to version 10.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "async": "^3.2.3",
     "qs": "^6.10.3",
-    "mocha": "9.2.0"
+    "mocha": "^10.1.0"
   },
   "overrides": {
     "@azure/storage-blob": {


### PR DESCRIPTION
Update mocha to 10.1.0 to resolve dependency vulnerability (https://github.com/advisories/GHSA-f8q6-p94x-37v3) found in https://github.com/snowflakedb/snowflake-connector-nodejs/pull/352