### PR TITLE
Fix connection pool login retry with incorrect pwd/role

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -298,6 +298,11 @@ function Core(options)
       poolOptions
     );
 
+    // avoid infinite loop if factory creation fails
+    connectionPool.on('factoryCreateError', function(err) {
+        const clientResourceRequest = connectionPool._waitingClientsQueue.dequeue();
+    })
+
     return connectionPool;
   };
 

--- a/test/integration/testConnection.js
+++ b/test/integration/testConnection.js
@@ -1080,4 +1080,26 @@ describe('Connection test - connection pool', function ()
       });
     });
   });
+
+  it('wrong password', function (done)
+  {
+    var connectionPool = snowflake.createPool(connOption.wrongPwd,
+      {
+        max: 10,
+        min: 1
+      });
+
+    assert.equal(connectionPool.max, 10);
+    assert.equal(connectionPool.min, 1);
+    assert.equal(connectionPool.size, 1);
+
+    // Use the connection pool, automatically creates a new connection
+    connectionPool.use(async (connection) =>
+    {
+      assert.ok(connection.isUp(), "not active");
+      assert.equal(connectionPool.size, 1);
+    });
+    // no login loop with wrong password
+    done();
+  });
 });


### PR DESCRIPTION
Fix for issue raised in #355 .
If using a connection pool and the wrong password/role is specified, the connector gets stuck in an infinite loop instead of returning an error.

The issue is reported on the node-pool module github page: https://github.com/coopernurse/node-pool/issues/273.
And a workaround here https://github.com/coopernurse/node-pool/pull/221.