### PR TITLE
Send heartbeat call to heartbeat endpoint, instead of SELECT 1

### DIFF
--- a/lib/connection/connection.js
+++ b/lib/connection/connection.js
@@ -2,6 +2,9 @@
  * Copyright (c) 2015-2021 Snowflake Computing Inc. All rights reserved.
  */
 const uuidv4 = require('uuid/v4');
+const Url = require('url');
+const QueryString = require('querystring');
+const GSErrors = require('../constants/gs_errors')
 
 var Util = require('../util');
 var Errors = require('../errors');
@@ -10,6 +13,8 @@ var EventEmitter = require('events').EventEmitter;
 var Statement = require('./statement');
 var Parameters = require('../parameters');
 var Authenticator = require('../authentication/authentication');
+var Logger = require('../logger');
+
 
 const PRIVATELINK_URL_SUFFIX = ".privatelink.snowflakecomputing.com";
 
@@ -100,13 +105,29 @@ function Connection(context)
 
   this.heartbeat = function (self)
   {
-    self.execute({
-      sqlText: 'select /* nodejs:heartbeat */ 1;',
-      complete: function ()
-      {
-      },
-      internal: true,
-    });
+    Logger.getInstance().debug("Issuing heartbeat call");
+    var requestID = uuidv4();
+
+      const request = services.sf.request(
+        {
+          method: 'POST',
+          url: Url.format(
+            {
+              pathname: '/session/heartbeat',
+              search: QueryString.stringify(
+                {
+                  requestId: requestID
+                })
+            }),
+          callback: function (err, body)
+          {
+            if (err) {
+              console.error("Error issuing heartbeat call : " + err.message);
+              throw err;
+            }
+            Logger.getInstance().debug("heartbeat response %s", body);
+          }
+      });
   };
 
   /**

--- a/test/integration/testConnection.js
+++ b/test/integration/testConnection.js
@@ -1103,3 +1103,32 @@ describe('Connection test - connection pool', function ()
     done();
   });
 });
+
+describe('Heartbeat test', function ()
+{
+  var connection = snowflake.createConnection(connOption.valid);
+
+  it('call heartbeat url', function (done)
+  {
+    async.series(
+      [
+        function (callback)
+        {
+          connection.connect(function (err, conn)
+          {
+            assert.ok(!err, JSON.stringify(err));
+            callback();
+          });
+        },
+        function (callback)
+        {
+          connection.heartbeat();
+          callback();
+        }
+      ],
+      function ()
+      {
+        done();
+      });
+  });
+});


### PR DESCRIPTION
Send request to heartbeat endpoint instead of issuing a SELECT 1 query to keep the connection alive.
Resolves #354