### PR TITLE
actions/jira: Fix team id in jira ticket creation

### DIFF
--- a/.github/workflows/jira_issue.yml
+++ b/.github/workflows/jira_issue.yml
@@ -35,7 +35,7 @@ jobs:
           summary: '${{ github.event.issue.title }}'
           description: |
             ${{ github.event.issue.body }} \\ \\ _Created from GitHub Action_ for ${{ github.event.issue.html_url }}
-          fields: '{ "customfield_11401": {"id": "13475"}, "assignee": {"id": "61027a219798100070592b20"} }'
+          fields: '{ "customfield_11401": {"id": "14583"}, "assignee": {"id": "61027a219798100070592b20"} }'
 
       - name: Update GitHub Issue
         uses: ./jira/gajira-issue-update


### PR DESCRIPTION
Following https://github.com/snowflakedb/gosnowflake/pull/615

This issue currently causes github actions to fail https://github.com/snowflakedb/snowflake-connector-nodejs/actions/runs/3759281162/jobs/6388653959