### PR TITLE
Bump jsonwebtoken to v9.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "extend": "^3.0.2",
     "generic-pool": "^3.8.2",
     "glob": "^7.1.6",
-    "jsonwebtoken": "^8.5.1",
+    "jsonwebtoken": "^9.0.0",
     "mime-types": "^2.1.29",
     "mkdirp": "^1.0.3",
     "mock-require": "^3.0.3",


### PR DESCRIPTION
Based off [PR 391](https://github.com/snowflakedb/snowflake-connector-nodejs/pull/391)

The latest version of `jsonwebtoken@v9.0.0` fixes a number of security issues ranging from `moderate` to `high` severity.
 
https://github.com/advisories/GHSA-27h2-hvpr-p74q
https://github.com/advisories/GHSA-hjrf-2m68-5959
https://github.com/advisories/GHSA-qwph-4952-7xr6
https://github.com/advisories/GHSA-8cf7-32gw-wr33