### PR TITLE
Add error details to OCSP warning message

### DIFF
--- a/lib/agent/socket_util.js
+++ b/lib/agent/socket_util.js
@@ -16,7 +16,7 @@ const REGEX_SNOWFLAKE_ENDPOINT = /.snowflakecomputing.com$/;
 const ocspFailOpenWarning =
   'WARNING!!! using fail-open to connect. Driver is connecting to an HTTPS endpoint ' +
   'without OCSP based Certificated Revocation checking as it could not obtain a valid OCSP Response to use from ' +
-  'the CA OCSP responder. Details:';
+  'the CA OCSP responder. Details: ';
 
 const rawOcspFlag =
   process.env.SF_OCSP_RESPONSE_CACHE_SERVER_ENABLED;
@@ -171,7 +171,7 @@ function canEarlyExitForOCSP(errors)
       if (err && !isValidOCSPError(err))
       {
         // any of the errors is NOT good/revoked/unknown
-        Logger.getInstance().info(ocspFailOpenWarning);
+        Logger.getInstance().info(ocspFailOpenWarning + err);
         return null;
       }
       else if (err && err.code === ErrorCodes.ERR_OCSP_REVOKED)

--- a/lib/agent/socket_util.js
+++ b/lib/agent/socket_util.js
@@ -171,7 +171,7 @@ function canEarlyExitForOCSP(errors)
       if (err && !isValidOCSPError(err))
       {
         // any of the errors is NOT good/revoked/unknown
-        Logger.getInstance().info(ocspFailOpenWarning + err);
+        Logger.getInstance().warn(ocspFailOpenWarning + err);
         return null;
       }
       else if (err && err.code === ErrorCodes.ERR_OCSP_REVOKED)


### PR DESCRIPTION
Regarding https://github.com/snowflakedb/snowflake-sdks-drivers-issues-teamwork/issues/99

Add error details when logging the OCSP fail open warning message and change log level from 'info' to 'warn'