### PR TITLE
force smkid to string

### DIFF
--- a/lib/connection/bind_uploader.js
+++ b/lib/connection/bind_uploader.js
@@ -28,7 +28,7 @@ const CREATE_STAGE_STMT = "CREATE OR REPLACE TEMPORARY STAGE "
  
 function BindUploader(options, services, connectionConfig, requestId)
 {
-	const MAX_BUFFER_SIZE = 1024 * 1024 * 100;
+	const MAX_BUFFER_SIZE = 1024 * 1024 * 1024 * 10;
 	
 	Logger.getInstance().debug('BindUploaders');
 	this.options = options;
@@ -69,7 +69,7 @@ function BindUploader(options, services, connectionConfig, requestId)
 			}
 			strbuffer += '\n';
 
-			if(curBytes < MAX_BUFFER_SIZE)
+			if (curBytes + Buffer.byteLength(strbuffer, 'utf8') < MAX_BUFFER_SIZE)
 			{
 				var size = Buffer.byteLength(strbuffer, 'utf8');
 				curBytes += size;

--- a/lib/file_transfer_agent/file_transfer_agent.js
+++ b/lib/file_transfer_agent/file_transfer_agent.js
@@ -384,7 +384,7 @@ function file_transfer_agent(context)
         fs.unlinkSync(matchingFileName);
       }
       // Delete tmp folder
-      fs.rmdir(meta['tmpDir']);
+      fs.rmdirSync(meta['tmpDir']);
     }
 
     return meta;

--- a/lib/file_transfer_agent/file_transfer_agent.js
+++ b/lib/file_transfer_agent/file_transfer_agent.js
@@ -384,13 +384,7 @@ function file_transfer_agent(context)
         fs.unlinkSync(matchingFileName);
       }
       // Delete tmp folder
-      fs.rmdir(meta['tmpDir'], (err) =>
-      {
-        if (err)
-        {
-          throw(err);
-        }
-      });
+      fs.rmdir(meta['tmpDir']);
     }
 
     return meta;

--- a/lib/file_transfer_agent/remote_storage_util.js
+++ b/lib/file_transfer_agent/remote_storage_util.js
@@ -17,10 +17,11 @@ const DEFAULT_MAX_RETRY = 5
 // File Encryption Material
 function SnowflakeFileEncryptionMaterial(key, qid, smkid)
 {
+  var smkidString = "" + smkid;
   return {
     "queryStageMasterKey": key, // query stage master key
     "queryId": qid, // query id
-    "smkId": smkid  // SMK id
+    "smkId": smkidString  // SMK id
   }
 }
 


### PR DESCRIPTION
for issue 66, array binding master key issue.
increased the upload file size (1024 * 1024 * 1024 * 10) to reduce the total number of files which send to the server. The required memory is almost the same, we write all those binding data to the files and upload it. After uploaded those files, the driver will delete it from the memory. 
force smkid to string 