### PR TITLE
apply proxy settings for ocsp validation

### DIFF
--- a/lib/agent/https_ocsp_agent.js
+++ b/lib/agent/https_ocsp_agent.js
@@ -45,7 +45,7 @@ function HttpsOcspAgent(options)
     var socket = HttpsAgent.prototype.createConnection.apply(this, arguments);
 
     // secure the socket and return it
-    return SocketUtil.secureSocket(socket, host);
+    return SocketUtil.secureSocket(socket, host, null);
   };
 
   return agent;

--- a/lib/agent/https_proxy_ocsp_agent.js
+++ b/lib/agent/https_proxy_ocsp_agent.js
@@ -15,6 +15,7 @@ var createAgent = require('agent-base');
 var inherits = require('util').inherits;
 var debug = require('debug')('https-proxy-agent');
 var SocketUtil = require('./socket_util');
+const Logger = require('../logger');
 
 /**
  * Module exports.
@@ -95,8 +96,9 @@ inherits(HttpsProxyAgent, createAgent);
 
 function connect(req, opts, fn)
 {
-
   var proxy = this.proxy;
+  var agent = this;
+  Logger.getInstance().debug("Using proxy=%s for host %s", proxy.host, opts.host);
 
   // create a socket connection to the proxy server
   var socket;
@@ -200,7 +202,10 @@ function connect(req, opts, fn)
         opts.hostname = null;
         opts.port = null;
         sock = tls.connect(opts);
-        SocketUtil.secureSocket(sock, host);
+        // pass in proxy agent to apply proxy for ocsp connection
+        // ocsp connection won't be secureEndpoint so no worry for recursive
+        // ocsp validation
+        SocketUtil.secureSocket(sock, host, agent);
       }
 
       cleanup();

--- a/lib/agent/ocsp_response_cache.js
+++ b/lib/agent/ocsp_response_cache.js
@@ -62,6 +62,7 @@ function OcspResponseCache()
   let downloadStatus = status.NOT_START;
   let cacheUpdated = false;
   let cacheInitialized = false;
+  let proxyAgent = null;
 
   /**
    * Reads OCSP cache file.
@@ -85,6 +86,16 @@ function OcspResponseCache()
   catch (e)
   {
     Logger.getInstance().debug("Failed to read OCSP cache file: %s, err: %s", cacheFileName, e);
+  }
+
+  /**
+   * set proxy agent for ocsp validation
+   *
+   * @param agent
+   */
+  this.setAgent = function setAgent(agent)
+  {
+      proxyAgent = agent;
   }
 
   /**
@@ -272,6 +283,7 @@ function OcspResponseCache()
     const options = util._extend({
       timeout: Number(timeout),
       method: 'GET',
+      agent: proxyAgent,
     }, uri);
     const httpRequest = http.request(options, onResponse);
     httpRequest.on('error', function (e)

--- a/lib/agent/socket_util.js
+++ b/lib/agent/socket_util.js
@@ -55,13 +55,18 @@ exports.variables = variables;
  *
  * @returns {Object}
  */
-exports.secureSocket = function (socket, host, mock)
+exports.secureSocket = function (socket, host, agent, mock)
 {
   // if ocsp validation is disabled for the given host, return the socket as is
   if (isOcspValidationDisabled(host))
   {
     Logger.getInstance().debug('OCSP validation disabled for %s', host);
     return socket;
+  }
+
+  if (agent != null)
+  {
+    getOcspResponseCache().setAgent(agent);
   }
 
   const validate = function ()

--- a/test/integration/ocsp_mock/https_ocsp_mock_agent.js
+++ b/test/integration/ocsp_mock/https_ocsp_mock_agent.js
@@ -19,7 +19,7 @@ function HttpsMockAgentOcspRevoked(options)
   agent.createConnection = function (options)
   {
     const socket = HttpsAgent.prototype.createConnection.apply(this, arguments);
-    return SocketUtil.secureSocket(socket, options.host, {
+    return SocketUtil.secureSocket(socket, options.host, null, {
       validateCertChain: function (cert, cb)
       {
         cb(Errors.createOCSPError(ErrorCodes.ERR_OCSP_REVOKED));
@@ -40,7 +40,7 @@ function HttpsMockAgentOcspUnkwown(options)
   agent.createConnection = function (options)
   {
     const socket = HttpsAgent.prototype.createConnection.apply(this, arguments);
-    return SocketUtil.secureSocket(socket, options.host, {
+    return SocketUtil.secureSocket(socket, options.host, null, {
       validateCertChain: function (cert, cb)
       {
         cb(Errors.createOCSPError(ErrorCodes.ERR_OCSP_UNKNOWN));
@@ -61,7 +61,7 @@ function HttpsMockAgentOcspInvalid(options)
   agent.createConnection = function (options)
   {
     const socket = HttpsAgent.prototype.createConnection.apply(this, arguments);
-    return SocketUtil.secureSocket(socket, options.host, {
+    return SocketUtil.secureSocket(socket, options.host, null, {
       validateCertChain: function (cert, cb)
       {
         cb(Errors.createOCSPError(ErrorCodes.ERR_OCSP_INVALID_VALIDITY));


### PR DESCRIPTION
Fix for issue: NodeJS driver is not sending ocsp requests through proxies
https://github.com/snowflakedb/snowflake-sdks-drivers-issues-teamwork/issues/57

The root cause is proxy agent is not used when connect to ocsp server.
To fix the issue, pass in proxy agent for ocsp validation.

No test case added since proxy is not available on github test environment. There is no way to set global proxy setting in nodejs so the trick we used for ODBC, having invalid proxy settings in environment variables, doesn't work either. Confirmed with local test through log (added in HttpsProxyAgent.connect() ) that proxy is used for ocsp validation and connection can be made.