### PR TITLE
Bug fix: refresh ocsp local cache when expired

### DIFF
--- a/lib/agent/ocsp_response_cache.js
+++ b/lib/agent/ocsp_response_cache.js
@@ -35,6 +35,9 @@ const cacheFileName = path.join(cacheDir, "ocsp_response_cache.json");
 var cache;
 // JSON object with previous cache's responses
 var prevCacheObj;
+// Cache updated time, initialized as current time.
+// Will be updated when load from local cache file or refresh by downloading
+var cacheUpdateTime = Date.now() / 1000;
 
 function deleteCache()
 {
@@ -68,6 +71,7 @@ function OcspResponseCache()
    * Reads OCSP cache file.
    */
   const currentTime = Date.now() / 1000;
+  cacheUpdateTime = currentTime;
 
   let OCSP_URL = process.env.SF_OCSP_RESPONSE_CACHE_SERVER_URL;
   if (!OCSP_URL)
@@ -135,6 +139,30 @@ function OcspResponseCache()
   {
     downloadStatus = status.FINISHED;
   };
+
+  /**
+   * Is local OCSP Cache expired?
+   * @returns {boolean}
+   */
+  this.IsCacheExpired = function ()
+  {
+    if (!cacheInitialized)
+    {
+      return false;
+    }
+
+    const currentTime = Date.now() / 1000;
+
+    if ((currentTime - cacheUpdateTime) > maxAge)
+    {
+      Logger.getInstance().debug(
+        "OCSP local cache validity is out of range. currentTime: %s, timestamp: %s",
+        currentTime, cacheUpdateTime);
+      return true;
+    }
+
+    return false;
+  }
 
   /**
    * Resets OCSP Cache status
@@ -320,8 +348,6 @@ function OcspResponseCache()
    */
   function validateCacheEntry(certIdBase64, ocspResponseBase64)
   {
-    const maxAge = GlobalConfig.getOcspResponseCacheMaxAge();
-
     var err;
     if (ocspResponseBase64.length !== 2)
     {
@@ -361,6 +387,8 @@ function OcspResponseCache()
 
   function updateCache(jsonObject)
   {
+    // initialize cache update time
+    cacheUpdateTime = Date.now() / 1000;
     // Get the size of cache retrieved from the cache server
     var responseCacheSize = Object.keys(jsonObject).length;
 
@@ -423,6 +451,11 @@ function OcspResponseCache()
     {
       // Add new entry or update existing one
       cache.set(status.key, status.value);
+      // change cache update time if needed
+      if (jsonObject[entry][0] < cacheUpdateTime)
+      {
+        cacheUpdateTime = jsonObject[entry][0];
+      }
     }
     else if (status.err.code === ErrorCodes.ERR_OCSP_CACHE_EXPIRED)
     {

--- a/lib/agent/ocsp_response_cache.js
+++ b/lib/agent/ocsp_response_cache.js
@@ -24,10 +24,11 @@ const status = {
 
 // validate input
 const sizeLimit = GlobalConfig.getOcspResponseCacheSizeLimit();
-const maxAge = GlobalConfig.getOcspResponseCacheMaxAge();
+// ocsp cache max age in second
+const maxAgeSec = GlobalConfig.getOcspResponseCacheMaxAge();
 
 Errors.assertInternal(Util.number.isPositiveInteger(sizeLimit));
-Errors.assertInternal(Util.number.isPositiveInteger(maxAge));
+Errors.assertInternal(Util.number.isPositiveInteger(maxAgeSec));
 
 const cacheDir = GlobalConfig.mkdirCacheDir();
 const cacheFileName = path.join(cacheDir, "ocsp_response_cache.json");
@@ -35,9 +36,9 @@ const cacheFileName = path.join(cacheDir, "ocsp_response_cache.json");
 var cache;
 // JSON object with previous cache's responses
 var prevCacheObj;
-// Cache updated time, initialized as current time.
+// Cache updated time, in seconds, initialized as current time.
 // Will be updated when load from local cache file or refresh by downloading
-var cacheUpdateTime = Date.now() / 1000;
+var cacheUpdateTimeSec = Date.now() / 1000;
 
 function deleteCache()
 {
@@ -70,8 +71,9 @@ function OcspResponseCache()
   /**
    * Reads OCSP cache file.
    */
-  const currentTime = Date.now() / 1000;
-  cacheUpdateTime = currentTime;
+  // Current time in second
+  const currentTimeSec = Date.now() / 1000;
+  cacheUpdateTimeSec = currentTimeSec;
 
   let OCSP_URL = process.env.SF_OCSP_RESPONSE_CACHE_SERVER_URL;
   if (!OCSP_URL)
@@ -151,13 +153,14 @@ function OcspResponseCache()
       return false;
     }
 
-    const currentTime = Date.now() / 1000;
+    // Current time in seconds
+    const currentTimeSec = Date.now() / 1000;
 
-    if ((currentTime - cacheUpdateTime) > maxAge)
+    if ((currentTimeSec - cacheUpdateTimeSec) > maxAgeSec)
     {
       Logger.getInstance().debug(
-        "OCSP local cache validity is out of range. currentTime: %s, timestamp: %s",
-        currentTime, cacheUpdateTime);
+        "OCSP local cache validity is out of range. currentTime: %s, timestamp: %s, maxAge: %s",
+        currentTimeSec, cacheUpdateTime, maxAgeSec);
       return true;
     }
 
@@ -174,13 +177,14 @@ function OcspResponseCache()
     {
       Logger.getInstance().debug(cacheFileName);
 
-      const currentTime = Date.now() / 1000;
+      // current time in second
+      const currentTimeSec = Date.now() / 1000;
       const cacheOutput = {};
       cache.forEach(function (v, k)
       {
         const certIdInBase64 = CertUtil.decodeKey(k);
         const ocspResponseInBase64 = v.toString("BASE64");
-        cacheOutput[certIdInBase64] = [currentTime, ocspResponseInBase64];
+        cacheOutput[certIdInBase64] = [currentTimeSec, ocspResponseInBase64];
       });
       const writeContent = JSON.stringify(cacheOutput);
       Logger.getInstance().debug("Writing OCSP cache file. %s", cacheFileName);
@@ -355,11 +359,11 @@ function OcspResponseCache()
         .debug("OCSP cache value doesn't consist of two elements. Ignored.");
       err = Errors.createOCSPError(ErrorCodes.ERR_OCSP_NOT_TWO_ELEMENTS);
     }
-    if ((currentTime - ocspResponseBase64[0]) > maxAge)
+    if ((currentTimeSec - ocspResponseBase64[0]) > maxAgeSec)
     {
       Logger.getInstance().debug(
-        "OCSP cache validity is out of range. currentTime: %s, timestamp: %s",
-        currentTime, ocspResponseBase64[0]);
+        "OCSP cache validity is out of range. currentTime: %s, timestamp: %s, maxAge: %s",
+        currentTimeSec, ocspResponseBase64[0], maxAgeSec);
       err = Errors.createOCSPError(ErrorCodes.ERR_OCSP_CACHE_EXPIRED);
     }
     try
@@ -388,7 +392,7 @@ function OcspResponseCache()
   function updateCache(jsonObject)
   {
     // initialize cache update time
-    cacheUpdateTime = Date.now() / 1000;
+    cacheUpdateTimeSec = Date.now() / 1000;
     // Get the size of cache retrieved from the cache server
     var responseCacheSize = Object.keys(jsonObject).length;
 
@@ -452,9 +456,9 @@ function OcspResponseCache()
       // Add new entry or update existing one
       cache.set(status.key, status.value);
       // change cache update time if needed
-      if (jsonObject[entry][0] < cacheUpdateTime)
+      if (jsonObject[entry][0] < cacheUpdateTimeSec)
       {
-        cacheUpdateTime = jsonObject[entry][0];
+        cacheUpdateTimeSec = jsonObject[entry][0];
       }
     }
     else if (status.err.code === ErrorCodes.ERR_OCSP_CACHE_EXPIRED)

--- a/lib/agent/socket_util.js
+++ b/lib/agent/socket_util.js
@@ -321,8 +321,16 @@ function validateCert(cert, cb)
     // check if cache is initialized before getting entry
     if (getOcspResponseCache().isInitialized())
     {
-      // if we already have an entry in the cache, use it
-      ocspResponse = getOcspResponseCache().get(cert);
+      if (getOcspResponseCache().IsCacheExpired())
+      {
+        // reset cache status so it can be refreshed
+        getOcspResponseCache().resetCacheStatus();
+      }
+      else
+      {
+        // if we already have a valid entry in the cache, use it
+        ocspResponse = getOcspResponseCache().get(cert);
+      }
     }
     if (ocspResponse)
     {

--- a/lib/global_config.js
+++ b/lib/global_config.js
@@ -94,7 +94,19 @@ exports.getOcspResponseCacheSizeLimit = function ()
  */
 exports.getOcspResponseCacheMaxAge = function ()
 {
-  return 86400000; // 24 hours
+  // 24 hours, in seconds
+  // It was in millionseconds before but the timestamp we save in
+  // cache file was in seconds. Compare that with max age in millionseconds
+  // would makes the cache never expire.
+  // change max age here because customer would have local cache file exist
+  // already and we need to keep that valid with new version of the driver.
+  // use small value for test only
+  const maxage = process.env.SF_OCSP_TEST_CACHE_MAXAGE || 86400;
+  if (maxage > 86400)
+  {
+    maxage = 86400;
+  }
+  return maxage;
 };
 
 /**

--- a/lib/global_config.js
+++ b/lib/global_config.js
@@ -87,7 +87,7 @@ exports.getOcspResponseCacheSizeLimit = function ()
 };
 
 /**
- * Returns the maximum time in milliseconds that entries can live in the OCSP
+ * Returns the maximum time in seconds that entries can live in the OCSP
  * response cache.
  *
  * @returns {number}
@@ -101,7 +101,7 @@ exports.getOcspResponseCacheMaxAge = function ()
   // change max age here because customer would have local cache file exist
   // already and we need to keep that valid with new version of the driver.
   // use small value for test only
-  const maxage = process.env.SF_OCSP_TEST_CACHE_MAXAGE || 86400;
+  var maxage = Number(process.env.SF_OCSP_TEST_CACHE_MAXAGE) || 86400;
   if (maxage > 86400)
   {
     maxage = 86400;

--- a/test/integration/testOcsp.js
+++ b/test/integration/testOcsp.js
@@ -79,7 +79,7 @@ describe('OCSP validation', function ()
   it('OCSP validation expired local cache', function (done)
   {
     deleteCache();
-	process.env.SF_OCSP_TEST_CACHE_MAXAGE = 5;
+    process.env.SF_OCSP_TEST_CACHE_MAXAGE = 5;
     const connection = snowflake.createConnection(connOption.valid);
 
     async.series(

--- a/test/integration/testOcsp.js
+++ b/test/integration/testOcsp.js
@@ -71,6 +71,65 @@ describe('OCSP validation', function ()
       ], done);
   });
 
+  function deleteCache()
+  {
+    OcspResponseCache.deleteCache();
+  }
+
+  it('OCSP validation expired local cache', function (done)
+  {
+    deleteCache();
+	process.env.SF_OCSP_TEST_CACHE_MAXAGE = 5;
+    const connection = snowflake.createConnection(connOption.valid);
+
+    async.series(
+      [
+        function (callback)
+        {
+          connection.connect(function (err)
+          {
+            assert.ok(!err, JSON.stringify(err));
+            callback();
+          });
+        },
+        function (callback)
+        {
+          var numErrors = 0;
+          var numStmtsExecuted = 0;
+          var numStmtsTotal = 5;
+
+          // execute a simple statement several times
+          // and make sure there are no errors
+          for (var index = 0; index < numStmtsTotal; index++)
+          {
+            setTimeout(function () {
+              connection.execute(
+                {
+                  sqlText: 'select 1;',
+                  complete: function (err)
+                  {
+                    if (err)
+                    {
+                      numErrors++;
+                    }
+
+                    numStmtsExecuted++;
+                    if (numStmtsExecuted === (numStmtsTotal - 1))
+                    {
+                      delete process.env['SF_OCSP_TEST_CACHE_MAXAGE'];
+                      assert.strictEqual(numErrors, 0);
+                      callback();
+                    }
+                  }
+                });
+              // cache expire in 5 seconds while 3 seconds per query, so it
+              // would cover both case of expired and not expired
+              }, 3000);
+          }
+        }
+      ], done);
+  });
+
   const httpsEndpoints = [
     {
       accessUrl: "https://sfcsupport.snowflakecomputing.com",
@@ -124,11 +183,6 @@ describe('OCSP validation', function ()
         testOptions(i + 1);
       }
     });
-  }
-
-  function deleteCache()
-  {
-    OcspResponseCache.deleteCache();
   }
 
   it('Test Ocsp with different endpoints', function (done)


### PR DESCRIPTION
https://github.com/snowflakedb/snowflake-sdks-drivers-issues-teamwork/issues/129
The OCSP local cache won't be refreshed if the application run for a long time and the cache is expired during that, so query will fail after that.
The root cause is that the driver only check expiration and refresh the cache when the application start, no refresh logic afterwards.