### PR TITLE
update package.json urllib from v2 to v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "string-similarity": "^4.0.4",
     "test-console": "^2.0.0",
     "tmp": "^0.2.1",
-    "urllib": "^2.38.0",
+    "urllib": "^3.11.0",
     "uuid": "^3.3.2",
     "winston": "^3.1.0"
   },


### PR DESCRIPTION
Updating the urllib package version from 2 to 3.

urllib looks to only be called once inside lib/http/base.js
`request = require('urllib').request(requestOptions.url, requestOptions, async function (err, data, response)`

unit tests ran fine for me, but I don't have any snowflake credentials to run snowflake_test.js.

Will add additional comments if able to do more testing/investigation.

Thanks