### PR TITLE
SNOW-727386: bug fix for ocsp cache refresh

### DIFF
--- a/lib/agent/ocsp_response_cache.js
+++ b/lib/agent/ocsp_response_cache.js
@@ -25,7 +25,7 @@ const status = {
 // validate input
 const sizeLimit = GlobalConfig.getOcspResponseCacheSizeLimit();
 // ocsp cache max age in second
-const maxAgeSec = GlobalConfig.getOcspResponseCacheMaxAge();
+var maxAgeSec = GlobalConfig.getOcspResponseCacheMaxAge();
 
 Errors.assertInternal(Util.number.isPositiveInteger(sizeLimit));
 Errors.assertInternal(Util.number.isPositiveInteger(maxAgeSec));
@@ -153,6 +153,9 @@ function OcspResponseCache()
       return false;
     }
 
+    // Update maxAge in case it could be changed through environment variable
+    maxAgeSec = GlobalConfig.getOcspResponseCacheMaxAge();
+
     // Current time in seconds
     const currentTimeSec = Date.now() / 1000;
 
@@ -160,7 +163,7 @@ function OcspResponseCache()
     {
       Logger.getInstance().debug(
         "OCSP local cache validity is out of range. currentTime: %s, timestamp: %s, maxAge: %s",
-        currentTimeSec, cacheUpdateTime, maxAgeSec);
+        currentTimeSec, cacheUpdateTimeSec, maxAgeSec);
       return true;
     }
 
@@ -391,8 +394,6 @@ function OcspResponseCache()
 
   function updateCache(jsonObject)
   {
-    // initialize cache update time
-    cacheUpdateTimeSec = Date.now() / 1000;
     // Get the size of cache retrieved from the cache server
     var responseCacheSize = Object.keys(jsonObject).length;
 
@@ -434,6 +435,8 @@ function OcspResponseCache()
       // Add new entries
       setCacheEntries(jsonObject);
     }
+    // set cache update time
+    cacheUpdateTimeSec = Date.now() / 1000;
     cacheInitialized = true;
   }
 

--- a/lib/global_config.js
+++ b/lib/global_config.js
@@ -102,7 +102,7 @@ exports.getOcspResponseCacheMaxAge = function ()
   // already and we need to keep that valid with new version of the driver.
   // use small value for test only
   var maxage = Number(process.env.SF_OCSP_TEST_CACHE_MAXAGE) || 86400;
-  if (maxage > 86400)
+  if ((maxage > 86400) || (maxage <= 0))
   {
     maxage = 86400;
   }


### PR DESCRIPTION
https://github.com/snowflakedb/snowflake-sdks-drivers-issues-teamwork/issues/129
This is further fix for the changes made in [PR#442](https://github.com/snowflakedb/snowflake-connector-nodejs/pull/442)
There was a typo in logging when changing the variable name from cacheUpdateTime to cacheUpdateTimeSec
The test case added in PR#442 didn't work as expected and passed with the bug while the functionality actually did work.
The reason is that the variable maxAgeSec (for the life time of local cache) is initialized when application starts and can't be updated later. So changing environment variable after it's initialized won't work.
Fix the typo, also update maxAgeSec per request to make the test case work.