### PR TITLE
for issue 135, upgrade urllib to 2.40.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "string-similarity": "^4.0.4",
     "test-console": "^2.0.0",
     "tmp": "^0.2.1",
-    "urllib": "^2.38.0",
+    "urllib": "^2.40.0",
     "uuid": "^3.3.2",
     "winston": "^3.1.0"
   },


### PR DESCRIPTION
https://github.com/snowflakedb/snowflake-sdks-drivers-issues-teamwork/issues/135
using urllib 2.40.0 which will pick up formstream 1.2.0 instead of 1.1.1
if we use urllib 3.x.x which will need more refactoring work.