### PR TITLE
fix: initialise maskedtxt variable prior to trying to mask secrets

### DIFF
--- a/lib/secret_detector.js
+++ b/lib/secret_detector.js
@@ -138,6 +138,7 @@ function secret_detector(customPatterns, mock)
     }
 
     var masked = false;
+    var maskedtxt = '';
     var errstr = null;
     try
     {


### PR DESCRIPTION
Fixes a failure that occurs when logging is turned on. 

Without this, `maskedtxt` is never defined, so you get a `ReferenceError: maskedtxt is not defined`. 