### PR TITLE
Replace eval() for parsing JSON strings

### DIFF
--- a/lib/connection/result/column.js
+++ b/lib/connection/result/column.js
@@ -550,7 +550,7 @@ function convertRawVariant(rawColumnValue, column, context)
   {
     try
     {
-      ret = eval("(" + rawColumnValue + ")");
+      ret = JSON.parse(rawColumnValue);
     }
     catch (parseError)
     {


### PR DESCRIPTION
Regarding issue 271


The PR replaces eval() which is considered [unsafe](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval#never_use_eval!) with JSON.parse() which is specifically for parsing and does not execute functions in strings
