### PR TITLE
Use the session token when closing the connection

### DIFF
--- a/lib/services/sf.js
+++ b/lib/services/sf.js
@@ -1378,11 +1378,14 @@ StateConnected.prototype.request = function (options)
  */
 StateConnected.prototype.destroy = function (options)
 {
-  // send out a master token request to terminate the current connection
-  this.createMasterTokenRequest(
+  var requestID = uuidv4();
+  var requestGUID = uuidv4();
+
+  // send out a session token request to terminate the current connection
+  this.createSessionTokenRequest(
     {
       method: 'POST',
-      url: '/session/logout-request',
+      url: `/session?delete=true&requestId=${requestID}&request_guid=${requestGUID}`,
       scope: this,
       callback: function (err, body)
       {

--- a/lib/services/sf.js
+++ b/lib/services/sf.js
@@ -1379,13 +1379,12 @@ StateConnected.prototype.request = function (options)
 StateConnected.prototype.destroy = function (options)
 {
   var requestID = uuidv4();
-  var requestGUID = uuidv4();
 
   // send out a session token request to terminate the current connection
   this.createSessionTokenRequest(
     {
       method: 'POST',
-      url: `/session?delete=true&requestId=${requestID}&request_guid=${requestGUID}`,
+      url: `/session?delete=true&requestId=${requestID}`,
       scope: this,
       callback: function (err, body)
       {

--- a/test/unit/mock/mock_http_client.js
+++ b/test/unit/mock/mock_http_client.js
@@ -40,11 +40,11 @@ MockHttpClient.prototype.request = function (request)
       buildRequestToOutputMap(buildRequestOutputMappings(this._clientInfo));
   }
 
-  // Closing a session includes a unique uuid for requestID and requestGUID as query parameters in the url
-  // Example: http://fake504.snowflakecomputing.com/session?delete=true&requestId=a40454c6-c3bb-4824-b0f3-bae041d9d6a2&request_guid=32443e0d-4080-457e-8678-561ed346e4e0
+  // Closing a connection includes a requestID as a query parameter in the url
+  // Example: http://fake504.snowflakecomputing.com/session?delete=true&requestId=a40454c6-c3bb-4824-b0f3-bae041d9d6a2
   if (request.url.includes('session?delete=true'))
   {
-    // Remove the requestID and requestGUID query parameter for the mock HTTP client
+    // Remove the requestID query parameter for the mock HTTP client
     request.url = request.url.substring(0, request.url.indexOf('&requestId='));
   }
 

--- a/test/unit/mock/mock_http_client.js
+++ b/test/unit/mock/mock_http_client.js
@@ -40,7 +40,6 @@ MockHttpClient.prototype.request = function (request)
       buildRequestToOutputMap(buildRequestOutputMappings(this._clientInfo));
   }
 
-
   // Closing a session includes a unique uuid for requestID and requestGUID as query parameters in the url
   // Example: http://fake504.snowflakecomputing.com/session?delete=true&requestId=a40454c6-c3bb-4824-b0f3-bae041d9d6a2&request_guid=32443e0d-4080-457e-8678-561ed346e4e0
   if (request.url.includes('session?delete=true'))
@@ -1722,7 +1721,8 @@ function buildRequestOutputMappings(clientInfo)
             {
               'Accept': 'application/json',
               'Authorization': 'Snowflake Token="SESSION_TOKEN"',
-              'Content-Type': 'application/json'
+              'Content-Type': 'application/json',
+              "X-Snowflake-Service": "fakeservicename2"
             }
         },
       output:

--- a/test/unit/mock/mock_http_client.js
+++ b/test/unit/mock/mock_http_client.js
@@ -1717,11 +1717,11 @@ function buildRequestOutputMappings(clientInfo)
       request:
         {
           method: 'POST',
-          url: 'http://fake504.snowflakecomputing.com/session/logout-request',
+          url: 'http://fake504.snowflakecomputing.com/session?delete=true',
           headers:
             {
               'Accept': 'application/json',
-              'Authorization': 'Snowflake Token="MASTER_TOKEN"',
+              'Authorization': 'Snowflake Token="SESSION_TOKEN"',
               'Content-Type': 'application/json'
             }
         },

--- a/test/unit/mock/mock_http_client.js
+++ b/test/unit/mock/mock_http_client.js
@@ -40,8 +40,18 @@ MockHttpClient.prototype.request = function (request)
       buildRequestToOutputMap(buildRequestOutputMappings(this._clientInfo));
   }
 
+
+  // Closing a session includes a unique uuid for requestID and requestGUID as query parameters in the url
+  // Example: http://fake504.snowflakecomputing.com/session?delete=true&requestId=a40454c6-c3bb-4824-b0f3-bae041d9d6a2&request_guid=32443e0d-4080-457e-8678-561ed346e4e0
+  if (request.url.includes('session?delete=true'))
+  {
+    // Remove the requestID and requestGUID query parameter for the mock HTTP client
+    request.url = request.url.substring(0, request.url.indexOf('&requestId='));
+  }
+
   // get the output of the specified request from the map
   var requestOutput = this._mapRequestToOutput[serializeRequest(request)];
+
   Errors.assertInternal(Util.isObject(requestOutput),
     'no response available for: ' + serializeRequest(request));
 
@@ -263,12 +273,42 @@ function buildRequestOutputMappings(clientInfo)
       request:
         {
           method: 'POST',
-          url: 'http://fakeaccount.snowflakecomputing.com/session/logout-request',
+          url: 'http://fakeaccount.snowflakecomputing.com/session?delete=true',
           headers:
             {
               'Accept': 'application/json',
-              'Authorization': 'Snowflake Token="MASTER_TOKEN"',
-              'Content-Type': 'application/json'
+              'Authorization': 'Snowflake Token="SESSION_TOKEN"',
+              'Content-Type': 'application/json',
+            }
+        },
+      output:
+        {
+          err: null,
+          response:
+            {
+              statusCode: 200,
+              statusMessage: "OK",
+              body:
+                {
+                  code: null,
+                  data: null,
+                  message: null,
+                  success: true
+                }
+            }
+        }
+    },
+    {
+      request:
+        {
+          method: 'POST',
+          url: 'http://fakeaccount.snowflakecomputing.com/session?delete=true',
+          headers:
+            {
+              'Accept': 'application/json',
+              'Authorization': 'Snowflake Token="SESSION_TOKEN"',
+              'Content-Type': 'application/json',
+              "X-Snowflake-Service": "fakeservicename2"
             }
         },
       output:
@@ -1518,12 +1558,13 @@ function buildRequestOutputMappings(clientInfo)
       request:
         {
           method: 'POST',
-          url: 'http://fakeaccount.snowflakecomputing.com/session/logout-request',
+          url: 'http://fakeaccount.snowflakecomputing.com/session?delete=true',
           headers:
             {
               'Accept': 'application/json',
-              'Authorization': 'Snowflake Token="SESSION_GONE_MASTER_TOKEN"',
-              'Content-Type': 'application/json'
+              'Authorization': 'Snowflake Token="SESSION_GONE_TOKEN"',
+              'Content-Type': 'application/json',
+              "X-Snowflake-Service": "fakeservicename2"
             }
         },
       output:


### PR DESCRIPTION
Regarding issue 358

When multiple connections are opened using the OAuth authenticator, closing one of those connections lead to the other connections being terminated as well

The PR closes the connection using the session token instead of the master token so that all OAuth connections will not be terminated if one of the connections are closed