### PR TITLE
Update auth_keypair authetnicate function to be async

### DIFF
--- a/lib/authentication/auth_keypair.js
+++ b/lib/authentication/auth_keypair.js
@@ -153,7 +153,7 @@ function auth_keypair(privateKey, privateKeyPath, privateKeyPass, cryptomod, jwt
    *
    * @returns {null}
    */
-  this.authenticate = function (authenticator, serviceName, account, username)
+  this.authenticate = async function (authenticator, serviceName, account, username)
   {
     var publicKeyFingerprint;
 


### PR DESCRIPTION
All function handlers require that this function is async because they are expecting a (.then, .catch) interface.

### Description
Related to issue: [#517](https://github.com/snowflakedb/snowflake-connector-nodejs/issues/517)

### Checklist
- [x] Format code according to the existing code style (there is no automatic linter yet)
- [] Create tests which fail without the change (if possible)
- [] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [] Extend the README / documentation and ensure is properly displayed (if necessary)
- [ ] Provide JIRA issue id (if possible) or GitHub issue id in commit message
