### PR TITLE
Fix multi-file download 

### DIFF
--- a/.github/workflows/cla_bot.yml
+++ b/.github/workflows/cla_bot.yml
@@ -6,19 +6,25 @@ on:
     types: [opened,closed,synchronize]
 
 jobs:
-  CLAssistant:
+  CLAAssistant:
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: write
+      pull-requests: write
+      statuses: write
     steps:
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
-        uses: cla-assistant/github-action@master
+        uses: contributor-assistant/github-action/@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PERSONAL_ACCESS_TOKEN : ${{ secrets.CLA_BOT_TOKEN }}
         with:
           path-to-signatures: 'signatures/version1.json'
-          path-to-document: 'https://github.com/Snowflake-Labs/CLA/blob/main/README.md'
+          path-to-document: 'https://github.com/snowflakedb/CLA/blob/main/README.md'
           branch: 'main'
           allowlist: 'dependabot[bot],github-actions'
           remote-organization-name: 'snowflakedb'
           remote-repository-name: 'cla-db'
+          

--- a/lib/file_transfer_agent/file_transfer_agent.js
+++ b/lib/file_transfer_agent/file_transfer_agent.js
@@ -688,8 +688,6 @@ function file_transfer_agent(context)
     var data = response['data'];
     commandType = data['command'];
 
-    initEncryptionMaterial();
-
     if (commandType === CMD_TYPE_UPLOAD)
     {
       var src = data['src_locations'][0];
@@ -719,6 +717,8 @@ function file_transfer_agent(context)
 
             for (var matchingFileName of matchingFileNames)
             {
+              initEncryptionMaterial();
+
               var fileInfo = fs.statSync(matchingFileName);
               var currFileObj = {};
               currFileObj['srcFileName'] = matchingFileName.substring(matchingFileName.lastIndexOf('/') + 1);
@@ -733,6 +733,8 @@ function file_transfer_agent(context)
             // No wildcard, get single file
             if (fs.existsSync(root))
             {
+              initEncryptionMaterial();
+
               var fileInfo = fs.statSync(fileNameFullPath);
 
               var currFileObj = {};
@@ -755,6 +757,7 @@ function file_transfer_agent(context)
     }
     else if (commandType === CMD_TYPE_DOWNLOAD)
     {
+      initEncryptionMaterial();
       srcFiles = data['src_locations'];
 
       if (srcFiles.length == encryptionMaterial.length)

--- a/lib/file_transfer_agent/file_transfer_agent.js
+++ b/lib/file_transfer_agent/file_transfer_agent.js
@@ -856,9 +856,11 @@ function file_transfer_agent(context)
 
     if (encryptionMaterial.length > 0)
     {
+      var i=0;
       for (var file of fileMetadata)
       {
         file['encryptionMaterial'] = encryptionMaterial[0];
+        i++;
       }
     }
   }

--- a/lib/file_transfer_agent/file_transfer_agent.js
+++ b/lib/file_transfer_agent/file_transfer_agent.js
@@ -859,7 +859,7 @@ function file_transfer_agent(context)
       var i=0;
       for (var file of fileMetadata)
       {
-        file['encryptionMaterial'] = encryptionMaterial[0];
+        file['encryptionMaterial'] = encryptionMaterial[i];
         i++;
       }
     }

--- a/test/integration/testPutGet.js
+++ b/test/integration/testPutGet.js
@@ -854,6 +854,11 @@ describe('PUT GET test multiple files', function ()
     }
 
     var putQuery = `PUT file://${os.tmpdir()}/testUploadDownloadMultifiles* ${stage}`;
+    // Windows user contains a '~' in the path which causes an error
+    if (process.platform == "win32")
+    {
+      putQuery = `PUT file://${process.env.USERPROFILE}\\AppData\\Local\\Temp\\testUploadDownloadMultifiles* ${stage}`;
+    }
 
     async.series(
       [

--- a/test/integration/testPutGet.js
+++ b/test/integration/testPutGet.js
@@ -869,14 +869,14 @@ describe('PUT GET test multiple files', function ()
       getQuery = `GET @${DATABASE_NAME}.${SCHEMA_NAME}.%${TEMP_TABLE_NAME} file://${process.env.USERPROFILE}\\AppData\\Local\\Temp\\${dirName}`;
     }
 
-    // Create two temp file with specified file extension
+    // Create temp files with specified prefix
     for (let i = 0; i < count; i++) {
       var tmpFile = tmp.fileSync({ prefix: 'testUploadDownloadMultifiles'});
       fs.writeFileSync(tmpFile.name, ROW_DATA);
       tmpFiles.push(tmpFile);
     }
 
-    var putQuery = `PUT file://testUploadDownloadMultifiles* @${DATABASE_NAME}.${SCHEMA_NAME}.%${TEMP_TABLE_NAME}`;
+    var putQuery = `PUT file://${os.tmpdir()}/testUploadDownloadMultifiles* @${DATABASE_NAME}.${SCHEMA_NAME}.%${TEMP_TABLE_NAME}`;
     // Windows user contains a '~' in the path which causes an error
     if (process.platform == "win32")
     {


### PR DESCRIPTION
issue [175](https://github.com/snowflakedb/snowflake-sdks-drivers-issues-teamwork/issues/175)
The cause of the issue: uploads uses the metadata from the first file to encrypt, and it also reads from the first file to decrypt for downloads. This method works when uploading files all together and then download them all together. But when uploading files one by one, it will use different encryption material, then it cannot download all the files together. That's why only the first file succedded to download. The fix is to set the download to read the encryption material from each file and make sure all the files has its own encryption material when uploading it.