### PR TITLE
SNOW-358605: Add isValidAsync to connection

### DIFF
--- a/lib/connection/connection.js
+++ b/lib/connection/connection.js
@@ -140,6 +140,16 @@ function Connection(context)
     });
   };
 
+  this.isValidAsync = async () =>
+  {
+    if (!this.isUp())
+    {
+      return false;
+    }
+    const heartbeatResult = await this.heartbeatAsync()
+    return heartbeatResult.success;
+  };
+
   /**
   * Set the private link as the OCSP cache server's URL.
   *

--- a/lib/core.js
+++ b/lib/core.js
@@ -278,8 +278,7 @@ function Core(options)
     */
     this.validate = async function (connection)
     {
-      var heartbeat = await connection.heartbeatAsync();
-      return ((heartbeat[0][1] == 1) && connection.isUp());
+      return await connection.isValidAsync();
     }
   }
 

--- a/test/integration/testConnection.js
+++ b/test/integration/testConnection.js
@@ -10,7 +10,7 @@ const Util = require('./../../lib/util');
 const Core = require('./../../lib/core');
 const stderr = require("test-console").stderr;
 
-xdescribe('Connection test', function ()
+describe('Connection test', function ()
 {
   it('return tokens in qaMode', function ()
     {

--- a/test/integration/testConnection.js
+++ b/test/integration/testConnection.js
@@ -10,7 +10,7 @@ const Util = require('./../../lib/util');
 const Core = require('./../../lib/core');
 const stderr = require("test-console").stderr;
 
-describe('Connection test', function ()
+xdescribe('Connection test', function ()
 {
   it('return tokens in qaMode', function ()
     {
@@ -1131,19 +1131,19 @@ describe('Connection test - connection pool', function ()
     });
 });
 
-describe('Connection Test - Heartbeat', function ()
+describe('Connection Test - Heartbeat', () =>
 {
   let connection;
 
-  beforeEach(done =>
+  before(async () =>
   {
     connection = snowflake.createConnection(connOption.valid);
-    testUtil.connect(connection, done);
+    await testUtil.connectAsync(connection);
   });
 
-  after(done =>
+  after(async () =>
   {
-    testUtil.destroyConnection(connection, done);
+    await testUtil.destroyConnectionAsync(connection);
   });
 
   it('call heartbeat url with default callback', () =>
@@ -1158,6 +1158,44 @@ describe('Connection Test - Heartbeat', function ()
 
   it('call heartbeat url as promise', async () =>
   {
-    await connection.heartbeatAsync();
+    const rows = await connection.heartbeatAsync();
+    assert.ok(rows.success);
   });
+});
+
+describe('Connection Test - isValid', () =>
+{
+  let connection;
+
+  beforeEach(async () =>
+  {
+    connection = snowflake.createConnection(connOption.valid);
+    await testUtil.connectAsync(connection);
+  });
+
+  afterEach(async () =>
+  {
+    if (connection.isUp())
+    {
+      await testUtil.destroyConnectionAsync(connection);
+    }
+  });
+
+  it('connection is valid after connect', async () =>
+  {
+    const result = await connection.isValidAsync();
+
+    assert.equal(result, true);
+  });
+
+  it('connection is invalid after destroy', async () =>
+  {
+    await testUtil.destroyConnectionAsync(connection);
+
+    const result = await connection.isValidAsync();
+
+    assert.equal(result, false);
+  });
+
+  // there is no way to test heartbeat fail to running instance of snowflake
 });


### PR DESCRIPTION
### Description
Add `connection.isValidAsync` as combination of `connection.isUp` and `connection.heartbeatAsync`

### Checklist
- [x] Format code according to the existing code style (there is no automatic linter yet)
- [x] Create tests which fail without the change (if possible)
- [x] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [x] Extend the README / documentation and ensure is properly displayed (if necessary)
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message
