### PR TITLE
Remove unhandled exception thrown for heartbeat error

### DIFF
--- a/lib/connection/connection.js
+++ b/lib/connection/connection.js
@@ -124,7 +124,6 @@ function Connection(context)
           if (err)
           {
             Logger.getInstance().error('Error issuing heartbeat call: %s', err.message);
-            throw err;
           }
           Logger.getInstance().debug('Heartbeat response %s', JSON.stringify(body));
         }


### PR DESCRIPTION
### Description
If a heartbeat fails it throws an unhandled exception which can cause the host Node.js process to exit:
```
Error issuing heartbeat call : Unable to perform operation using terminated connection.
<redacted>/node_modules/snowflake-sdk/lib/connection/connection.js:126
              throw err;
              ^
Error [ClientError]: Unable to perform operation using terminated connection.
    at createError (<redacted>/node_modules/snowflake-sdk/lib/errors.js:540:15)
    at exports.createClientError (<redacted>/node_modules/snowflake-sdk/lib/errors.js:355:10)
    at <redacted>/node_modules/snowflake-sdk/lib/services/sf.js:1538:21
    at processTicksAndRejections (node:internal/process/task_queues:77:11)
    at runNextTicks (node:internal/process/task_queues:64:3)
    at listOnTimeout (node:internal/timers:533:9)
    at process.processTimers (node:internal/timers:507:7) {
  code: 407002,
  sqlState: '08003',
  data: undefined,
  response: undefined,
  responseBody: undefined,
  cause: undefined,
  isFatal: true,
  externalize: [Function (anonymous)]
}
Node.js v18.12.1
```

### Checklist
- [ ] Format code according to the existing code style (there is no automatic linter yet)
- [ ] Create tests which fail without the change (if possible)
- [ ] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [ ] Extend the README / documentation and ensure is properly displayed (if necessary)
- [ ] Provide JIRA issue id (if possible) or GitHub issue id in commit message
