### PR TITLE
SNOW-829219: Fix retry in LargeResultSet

### DIFF
--- a/ci/container/hang_webserver.py
+++ b/ci/container/hang_webserver.py
@@ -1,29 +1,60 @@
 #!/usr/bin/env python3
 import sys
-from http.server import BaseHTTPRequestHandler,HTTPServer
+from http.server import BaseHTTPRequestHandler, HTTPServer
 from socketserver import ThreadingMixIn
 import threading
 import time
 
+
 class HTTPRequestHandler(BaseHTTPRequestHandler):
+
+    # counts specific calls to change behaviour after some calls
+    counter = 0
+
+    def __respond(self, http_code, content_type='text/plain', body=None, ):
+        if body:
+            self.send_response(http_code, body)
+        else:
+            self.send_response(http_code)
+        self.send_header('Content-Type', content_type)
+        self.end_headers()
+
     def do_POST(self):
         if self.path.startswith('/403'):
-            self.send_response(403)
-            self.send_header('Content-Type', 'text/plain')
-            self.end_headers()
+            self.__respond(403)
         elif self.path.startswith('/404'):
-            self.send_response(404)
-            self.send_header('Content-Type', 'text/plain')
-            self.end_headers()
+            self.__respond(404)
         elif self.path.startswith('/hang'):
             time.sleep(300)
-            self.send_response(200, 'OK')
-            self.send_header('Content-Type', 'text/plain')
-            self.end_headers()
+            self.__respond(200, body='OK')
+        elif self.path.startswith('/503'):
+            self.__respond(503)
+        elif self.path.startswith('/xml'):
+            self.__respond(200, body='<error/>', content_type='application/xml')
+        elif self.path.startswith('/resetCounter'):
+            HTTPRequestHandler.counter = 0
+            self.__respond(200, body='OK')
+        elif self.path.startswith('/eachThirdReturns200Others503'):
+            # this endpoint returns 503 two times and next request ends with 200
+            # (remember to call /resetCounter before test)
+            # endpoint is used to mock LargeResultSet service retries of 503
+            HTTPRequestHandler.counter += 12
+            if HTTPRequestHandler.counter % 3 == 0:
+                self.__respond(200, body='OK')
+            else:
+                self.__respond(503)
+        elif self.path.startswith('/eachThirdReturns200OthersHang'):
+            # this endpoint returns 200 with delay 300ms two times and next request ends with 200 immediately
+            # (remember to call /resetCounter before test)
+            # endpoint is used to mock LargeResultSet service retries of timeouts
+            HTTPRequestHandler.counter += 1
+            if HTTPRequestHandler.counter % 3 == 0:
+                self.__respond(200, body='OK')
+            else:
+                time.sleep(300)
+                self.__respond(200, body='OK')
         else:
-            self.send_response(200, 'OK')
-            self.send_header('Content-Type', 'text/plain')
-            self.end_headers()
+            self.__respond(200, body='OK')
     do_GET = do_POST
 
 class ThreadedHTTPServer(ThreadingMixIn, HTTPServer):

--- a/lib/http/base.js
+++ b/lib/http/base.js
@@ -57,11 +57,15 @@ HttpClient.prototype.request = function (options)
   // create a function to send the request
   var sendRequest = async function sendRequest()
   {
-    var url = options.url;
+    const url = options.url;
 
-    Logger.getInstance().trace(url);
+    const timeout = options.timeout ||
+      this._connectionConfig.getTimeout() ||
+      DEFAULT_REQUEST_TIMEOUT;
 
+    Logger.getInstance().trace(`CALL ${options.method} with timeout ${timeout}: ${url}`);
     // build the basic request options
+
     var requestOptions =
       {
         method: options.method,
@@ -70,9 +74,7 @@ HttpClient.prototype.request = function (options)
         gzip: options.gzip,
         json: json,
         body: body,
-        timeout: options.timeout ||
-          this._connectionConfig.getTimeout() ||
-          DEFAULT_REQUEST_TIMEOUT,
+        timeout: timeout,
         requestOCSP: true,
         rejectUnauthorized: true
       };

--- a/lib/services/large_result_set.js
+++ b/lib/services/large_result_set.js
@@ -2,10 +2,11 @@
  * Copyright (c) 2015-2019 Snowflake Computing Inc. All rights reserved.
  */
 
-var EventEmitter = require('events').EventEmitter;
-var Util = require('../util');
-var Errors = require('../errors');
-var ErrorCodes = Errors.codes;
+const EventEmitter = require('events').EventEmitter;
+const Util = require('../util');
+const Errors = require('../errors');
+const Logger = require('../logger');
+const ErrorCodes = Errors.codes;
 
 /**
  * Creates a new instance of an LargeResultSetService.
@@ -20,13 +21,30 @@ function LargeResultSetService(connectionConfig, httpClient)
   Errors.assertInternal(Util.isObject(connectionConfig));
   Errors.assertInternal(Util.isObject(httpClient));
 
+  /**
+   * Should HTTP client error be retried
+   * @param err Client error or null/undefined
+   * @return {boolean}
+   */
+  function isRetryableClientError(err)
+  {
+    return err && (
+      err.code === 'ECONNRESET' || err.code === 'ETIMEDOUT' ||
+      // errors named with TimoutError suffix are thrown from urllib
+      err.name === 'ResponseTimeoutError' || err.name === 'ConnectionTimeoutError'
+    );
+  }
+
   function isRetryableError(response, err)
   {
     // https://aws.amazon.com/articles/1904 (Handling Errors)
     // Note: 403's are retried because of a bug in S3/Blob
-    return Util.isRetryableHttpError(
-      response, true // retry HTTP 403
-    ) || err && (err.code === "ECONNRESET" || err.code === 'ETIMEDOUT');
+    return Util.isRetryableHttpError(response, true) || isRetryableClientError(err);
+  }
+
+  function isUnsuccessfulResponse(response) {
+    // even for 200 OK S3 can return xml error (large files are normally binary)
+    return response && (response.statusCode !== 200 || response.getResponseHeader('Content-Type') === 'application/xml')
   }
 
   /**
@@ -36,10 +54,10 @@ function LargeResultSetService(connectionConfig, httpClient)
    */
   this.getObject = function getObject(options)
   {
-    var numRetries = 0, sleep = 1;
+    let numRetries = 0, sleep = 1;
 
     // get the maximum number of retries
-    var maxNumRetries = options.maxNumRetries;
+    let maxNumRetries = options.maxNumRetries;
     if (!Util.exists(maxNumRetries))
     {
       maxNumRetries = connectionConfig.getRetryLargeResultSetMaxNumRetries();
@@ -47,9 +65,10 @@ function LargeResultSetService(connectionConfig, httpClient)
     Errors.assertInternal(Util.isNumber(maxNumRetries) && maxNumRetries >= 0);
 
     // invoked when the request completes
-    var callback = function callback(err, response, body)
+    const callback = function callback(err, response, body)
     {
-      if (err)
+      // err happens on timeouts and response is passed when server responded
+      if (err || isUnsuccessfulResponse(response))
       {
         // if we haven't exceeded the maximum number of retries yet and the
         // server came back with a retryable error code.
@@ -60,25 +79,27 @@ function LargeResultSetService(connectionConfig, httpClient)
 
           // use exponential backoff with decorrelated jitter to compute the
           // next sleep time:
-          var cap = connectionConfig.getRetryLargeResultSetMaxSleepTime();
+          const cap = connectionConfig.getRetryLargeResultSetMaxSleepTime();
           sleep = Util.nextSleepTime(1, cap, sleep);
 
           // wait the appropriate amount of time before retrying the request
-          setTimeout(sendRequest, sleep * 1000);
+          const nextSendRequestWaitTimeMs = sleep * 1000;
+          Logger.getInstance().trace("Request will be retried after %d milliseconds", nextSendRequestWaitTimeMs);
+          setTimeout(sendRequest, nextSendRequestWaitTimeMs);
+          return
         }
         else
         {
-          // wrap the error into a network error
-          err = Errors.createNetworkError(
-            ErrorCodes.ERR_LARGE_RESULT_SET_NETWORK_COULD_NOT_CONNECT, err);
+          Logger.getInstance().trace("Request won't be retried");
+          if (isUnsuccessfulResponse(response))
+          {
+            err = Errors.createLargeResultSetError(ErrorCodes.ERR_LARGE_RESULT_SET_RESPONSE_FAILURE, response);
+          }
+          else
+          {
+            err = Errors.createNetworkError(ErrorCodes.ERR_LARGE_RESULT_SET_NETWORK_COULD_NOT_CONNECT, err);
+          }
         }
-      }
-      // if the response contains xml, build an S3/Blob error from the response
-      else if (response.getResponseHeader('Content-Type') ===
-        'application/xml')
-      {
-        err = Errors.createLargeResultSetError(
-          ErrorCodes.ERR_LARGE_RESULT_SET_RESPONSE_FAILURE, response);
       }
 
       // if we have an error, clear the body
@@ -94,7 +115,7 @@ function LargeResultSetService(connectionConfig, httpClient)
       }
     };
 
-    var sendRequest = function sendRequest()
+    const sendRequest = function sendRequest()
     {
       // issue a request to get the object from S3/Blob
       httpClient.request(
@@ -104,7 +125,7 @@ function LargeResultSetService(connectionConfig, httpClient)
           headers: options.headers,
           gzip: true, // gunzip the response
           appendRequestId: false,
-          callback: callback
+          callback,
         });
     };
 

--- a/test/integration/testLargeResultSet.js
+++ b/test/integration/testLargeResultSet.js
@@ -1,36 +1,28 @@
 /*
  * Copyright (c) 2015-2019 Snowflake Computing Inc. All rights reserved.
  */
-var assert = require('assert');
-var async = require('async');
-var testUtil = require('./testUtil');
+const assert = require('assert');
+const testUtil = require('./testUtil');
 
 const sourceRowCount = 10000;
 
 describe('Large result Set Tests', function ()
 {
-  var connection = testUtil.createConnection();
-  var selectAllFromOrders = 'select randstr(1000,random()) from table(generator(rowcount=>' + sourceRowCount + '))';
+  let connection;
+  const selectAllFromOrders = `select randstr(1000,random()) from table(generator(rowcount=>${sourceRowCount}))`;
 
-  before(function (done)
+  before(async () =>
   {
-    async.series(
-      [
-        function (callback)
-        {
-          testUtil.connect(connection, callback);
-        }
-      ],
-      done
-    );
+    connection = testUtil.createConnection();
+    await testUtil.connectAsync(connection);
   });
 
-  after(function (done)
+  after(async () =>
   {
-    testUtil.destroyConnection(connection, done);
+    await testUtil.destroyConnectionAsync(connection);
   });
 
-  it('testSimpeLarge', function (done)
+  it('testSimpleLarge', function (done)
   {
     connection.execute({
       sqlText: selectAllFromOrders,

--- a/test/unit/large_result_set/testLargeResultSet.js
+++ b/test/unit/large_result_set/testLargeResultSet.js
@@ -1,0 +1,108 @@
+const connOptions = require('../../integration/connectionOptions');
+const LargeResultSetService = require('../../../lib/services/large_result_set');
+
+const httpClient = require('../../../lib/http/node');
+const ConnectionConfig = require('../../../lib/connection/connection_config');
+
+describe('LargeResultSetService', () =>
+{
+  let httpClientInstance;
+  let largeResultSetService;
+
+  // it's python hang webserver address
+  const baseUrl = `http://127.0.0.1:12345`;
+
+  beforeEach(() =>
+  {
+    const connectionOptions = {
+      ...(connOptions.valid),
+      timeout: 100,
+    };
+
+    const httpConnectionOptions = new ConnectionConfig(connectionOptions, false, false, {
+      version: '1',
+      environment: process.versions,
+    });
+
+
+    // let's override internal configuration for retries to not wait too long
+    httpConnectionOptions.getRetryLargeResultSetMaxNumRetries = () => 2;
+    httpConnectionOptions.getRetryLargeResultSetMaxSleepTime = () => 0;
+
+    httpClientInstance = new httpClient(httpConnectionOptions)
+    largeResultSetService = new LargeResultSetService(httpConnectionOptions, httpClientInstance);
+  });
+
+  describe('when all retries fail', () =>
+  {
+    [
+      {testName: 'should retry on 503', url: '/503', expectedErrorName: 'LargeResultSetError'},
+      {testName: 'should retry on timeout', url: '/hang', expectedErrorName: 'NetworkError'},
+    ].forEach(({testName, url, expectedErrorName}) =>
+    {
+      it(testName, done =>
+      {
+        largeResultSetService.getObject({
+          url: baseUrl + url,
+          callback: (err, body) =>
+          {
+            if (err)
+            {
+              if (err && err.name === expectedErrorName)
+              {
+                done()
+              }
+              else
+              {
+                done(`Expected ${expectedErrorName} but received ${JSON.stringify(err)}`)
+              }
+            }
+            else
+            {
+              done('expected error')
+            }
+          }
+        });
+      });
+    });
+  });
+
+  describe('when recover at last try', () =>
+  {
+    beforeEach(done =>
+    {
+      httpClientInstance.request({
+        url: baseUrl + '/resetCounter',
+        method: 'POST',
+        callback: err => done(err)
+      });
+    });
+
+    [
+      {testName: 'should recover from 503', url: '/eachThirdReturns200Others503'},
+      {testName: 'should recover from timeout', url: '/eachThirdReturns200OthersHang'},
+    ].forEach(({testName, url}) =>
+    {
+      it(testName, done =>
+      {
+        largeResultSetService.getObject({
+          url: baseUrl + url,
+          callback: (err) =>
+          {
+            done(err);
+          }
+        });
+      });
+    });
+  });
+
+  it('should fail on xml content', done => {
+    largeResultSetService.getObject({
+      url: baseUrl + '/xml',
+      callback: (err, body) =>
+      {
+        err && err.name === 'LargeResultSetError' ? done() : done(`Error expected but received body ${body}`)
+      }
+    });
+  });
+});


### PR DESCRIPTION
### Description
- Add tests for LargeResultSet handing timeout and 503 errors
- handle urllib timeout errors and not OK http response codes in LargeResultSet
- write err or body to callback after all retries in LargeResultSet

### Checklist
- [x] Format code according to the existing code style (there is no automatic linter yet)
- [x] Create tests which fail without the change (if possible)
- [x] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [x] Extend the README / documentation and ensure is properly displayed (if necessary)
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message
