### PR TITLE
SNOW-831683: Fix flaky test

### DIFF
--- a/ci/container/test_component.sh
+++ b/ci/container/test_component.sh
@@ -65,7 +65,7 @@ env | grep SNOWFLAKE_ | grep -v PASS
 [[ -n "$PROXY_PORT" ]] && echo "[INFO] SNOWFLAKE_TEST_PROXY_PORT=$PROXY_PORT" && export SNOWFLAKE_TEST_PROXY_PORT=$PROXY_PORT
 
 echo "[INFO] Starting hang_webserver.py 12345"
-python3 $THIS_DIR/hang_webserver.py 12345 &
+python3 $THIS_DIR/hang_webserver.py 12345 > hang_webserver.out 2>&1 &
 MOCHA_CMD=(
     "mocha" "--timeout" "$TIMEOUT" "--recursive" "--full-trace"
 )

--- a/ci/test_windows.bat
+++ b/ci/test_windows.bat
@@ -48,7 +48,7 @@ if %ERRORLEVEL% NEQ 0 (
 )
 echo [INFO] Starting hang_webserver.py 12345
 pushd %GITHUB_WORKSPACE%\ci\container
-start /b python hang_webserver.py 12345
+start /b python hang_webserver.py 12345 > hang_webserver.out 2>&1
 popd
 
 echo [INFO] Testing

--- a/lib/connection/connection.js
+++ b/lib/connection/connection.js
@@ -124,9 +124,11 @@ function Connection(context)
           if (err)
           {
             Logger.getInstance().error('Error issuing heartbeat call: %s', err.message);
-            throw err;
           }
-          Logger.getInstance().debug('Heartbeat response %s', JSON.stringify(body));
+          else
+          {
+            Logger.getInstance().debug('Heartbeat response %s', JSON.stringify(body));
+          }
         }
       }
     );

--- a/test/integration/testArrayBind.js
+++ b/test/integration/testArrayBind.js
@@ -29,8 +29,10 @@ describe('Test Array Bind', function ()
 
   before(function (done)
   {
-    connOption.valid.arrayBindingThreshold = 3;
-    connection = snowflake.createConnection(connOption.valid);
+    connection = snowflake.createConnection({
+      ...connOption.valid,
+      arrayBindingThreshold: 3,
+    });
     testUtil.connect(connection, function ()
     {
       connection.execute({
@@ -510,9 +512,11 @@ describe('Test Array Bind Force Error on Upload file', function ()
   var useWH = `use warehouse ${WAREHOUSE_NAME}`;
 
   before(function (done) {
-    connOption.valid.arrayBindingThreshold = 3;
-    connOption.valid.forceStageBindError = 1;
-    connection = snowflake.createConnection(connOption.valid);
+    connection = snowflake.createConnection({
+      ...connOption.valid,
+      arrayBindingThreshold: 3,
+      forceStageBindError: 1,
+    });
     testUtil.connect(connection, function () {
       connection.execute({
         sqlText: useWH,

--- a/test/integration/testArrayBind.js
+++ b/test/integration/testArrayBind.js
@@ -8,50 +8,45 @@ var testUtil = require('./testUtil');
 var connOption = require('./connectionOptions');
 const Logger = require('../../lib/logger');
 
-const DATABASE_NAME = connOption.valid.database;
-const SCHEMA_NAME = connOption.valid.schema;
-const WAREHOUSE_NAME = connOption.valid.warehouse;
-
 describe('Test Array Bind', function ()
 {
   this.timeout(300000);
   var connection;
-  var createABTable = `create or replace table  ${DATABASE_NAME}.${SCHEMA_NAME}.testAB(colA string, colB number, colC date, colD time, colE TIMESTAMP_NTZ, colF TIMESTAMP_TZ)`;
+  var createABTable = `create or replace table testAB(colA string, colB number, colC date, colD time, colE TIMESTAMP_NTZ, colF TIMESTAMP_TZ)`;
   var insertAB = `insert into testAB values(?, ?, ?, ?, ?, ?)`;
   var selectAB = `select * from testAB where colB = 1`;
-  var createNABTable = `create or replace table  ${DATABASE_NAME}.${SCHEMA_NAME}.testNAB(colA string, colB number, colC date, colD time, colE TIMESTAMP_NTZ, colF TIMESTAMP_TZ)`;
-  var insertNAB = `insert into  ${DATABASE_NAME}.${SCHEMA_NAME}.testNAB values(?, ?, ?, ?, ?, ?)`;
-  var selectNAB = `select * from  ${DATABASE_NAME}.${SCHEMA_NAME}.testNAB where colB = 1`;
-  var useWH = `use warehouse ${WAREHOUSE_NAME}`;
-  var createNullTable = `create or replace table  ${DATABASE_NAME}.${SCHEMA_NAME}.testNullTB(colA string, colB number, colC date, colD time, colE TIMESTAMP_NTZ, colF TIMESTAMP_TZ)`;
-  var insertNull = `insert into  ${DATABASE_NAME}.${SCHEMA_NAME}.testNullTB values(?, ?, ?, ?, ?, ?)`;
+  var createNABTable = `create or replace table testNAB(colA string, colB number, colC date, colD time, colE TIMESTAMP_NTZ, colF TIMESTAMP_TZ)`;
+  var insertNAB = `insert into testNAB values(?, ?, ?, ?, ?, ?)`;
+  var selectNAB = `select * from testNAB where colB = 1`;
+  var createNullTable = `create or replace table testNullTB(colA string, colB number, colC date, colD time, colE TIMESTAMP_NTZ, colF TIMESTAMP_TZ)`;
+  var insertNull = `insert into testNullTB values(?, ?, ?, ?, ?, ?)`;
   var selectNull = `select * from testNullTB where colB = 1`;
+
+  const usedTableNames = [
+    'testAB', 'testNAB', 'testNullTB',
+  ];
 
   before(function (done)
   {
+
     connection = snowflake.createConnection({
       ...connOption.valid,
       arrayBindingThreshold: 3,
     });
     testUtil.connect(connection, err =>
     {
-      if (err)
-      {
         done(err)
-      }
-      else
-      {
-        connection.execute({
-          sqlText: useWH,
-          complete: done
-        });
-      }
     });
   });
 
-  after(function (done)
+  afterEach(async () =>
   {
-    testUtil.destroyConnection(connection, done);
+    await testUtil.dropTablesIgnoringErrorsAsync(connection, usedTableNames);
+  });
+
+  after(async () =>
+  {
+    await testUtil.destroyConnectionAsync(connection);
   });
 
   it('testArrayBind', function (done)
@@ -168,11 +163,10 @@ describe('Test Array Bind', function ()
       [
         function(callback)
         {
-          var createNAB = connection.execute({
+          connection.execute({
             sqlText: createNullTable,
-            complete: function (err, stmt) {
-              testUtil.checkError(err);
-              callback();
+            complete: function (err) {
+              callback(err);
             }
           });
         },
@@ -185,23 +179,31 @@ describe('Test Array Bind', function ()
             arrBind.push([null, i, "2020-05-11", "12:35:41.3333333", "2022-04-01 23:59:59", "2022-07-08 12:05:30.9999999"]);
           }
           
-          var insertABStmt = connection.execute({
+          connection.execute({
             sqlText: insertNull,
             binds: arrBind,
             complete: function (err, stmt) {
-              testUtil.checkError(err);
-              assert.strictEqual(stmt.getNumUpdatedRows(), count);
-              callback();
+              if (err)
+              {
+                callback(err);
+              }
+              else if (stmt.getNumUpdatedRows() !== count)
+              {
+                callback(new Error(`Expected number of inserted rows to be ${count} but was ${stmt.getNumUpdatedRows()}`))
+              }
+              else
+              {
+                callback();
+              }
             }
           });
         },
         function(callback)
         {
-          var createNAB = connection.execute({
+          connection.execute({
             sqlText: createNABTable,
-            complete: function (err, stmt) {
-              testUtil.checkError(err);
-              callback();
+            complete: function (err) {
+              callback(err);
             }
           });
         },
@@ -209,55 +211,84 @@ describe('Test Array Bind', function ()
         {
           var arrBind = [];
           var count = 2;
-          for(var i = 0; i<count; i++)
+          for(let i = 0; i<count; i++)
           {
             arrBind.push(['string'+i, i, "2020-05-11", "12:35:41.3333333", "2022-04-01 23:59:59", "2022-07-08 12:05:30.9999999"]);
           }
-          var insertNABStmt = connection.execute({
+          connection.execute({
             sqlText: insertNAB,
             binds: arrBind,
             complete: function (err, stmt) {
-              testUtil.checkError(err);
-              assert.strictEqual(stmt.getNumUpdatedRows(), count);
-              callback();
+              if (err)
+              {
+                callback(err);
+              }
+              else if (stmt.getNumUpdatedRows() !== count)
+              {
+                callback(new Error(`Expected number of inserted rows to be ${count} but was ${stmt.getNumUpdatedRows()}`))
+              }
+              else
+              {
+                callback();
+              }
             }
           });
         },
         function(callback)
         {
-          var selectNABTable = connection.execute({
+          connection.execute({
             sqlText: selectNAB,
             complete: function (err, stmt, rows) {
-              testUtil.checkError(err);
-              NABData = rows[0];
-              callback();
+              if (err)
+              {
+                callback(err);
+              }
+              else
+              {
+                NABData = rows[0];
+                callback();
+              }
             }
           });
         },
-        function (callback) 
+        function (callback)
         {
-          var selectABTable = connection.execute({
+          connection.execute({
             sqlText: selectNull,
-            complete: function (err, stmt, rows) {
-              testUtil.checkError(err);
-              var ABData = rows[0];
+            complete: function (err, stmt, rows)
+            {
+              if (err)
+              {
+                callback(err);
+              }
+              else
+              {
+                try
+                {
+                  var ABData = rows[0];
 
-              var ABDate = new Date(ABData['COLC']);
-              var ABDataD = new Date(ABData['COLD']).getTime();
-              var ABDataE = new Date(ABData['COLE']).getTime();
-              var ABDataF = new Date(ABData['COLF']).getTime();
-              var NABDate = new Date(NABData['COLC']);
-              var NABDataD = new Date(NABData['COLD']).getTime();
-              var NABDataE = new Date(NABData['COLE']).getTime();
-              var NABDataF = new Date(NABData['COLF']).getTime();
+                  var ABDate = new Date(ABData['COLC']);
+                  var ABDataD = new Date(ABData['COLD']).getTime();
+                  var ABDataE = new Date(ABData['COLE']).getTime();
+                  var ABDataF = new Date(ABData['COLF']).getTime();
+                  var NABDate = new Date(NABData['COLC']);
+                  var NABDataD = new Date(NABData['COLD']).getTime();
+                  var NABDataE = new Date(NABData['COLE']).getTime();
+                  var NABDataF = new Date(NABData['COLF']).getTime();
 
-              assert.equal(ABData['COLA'], "");
-              assert.equal(ABData['COLB'], NABData['COLB']);
-              assert.equal(ABDate.toString(), NABDate.toString());
-              assert.equal(ABDataD.toString(), NABDataD.toString());
-              assert.equal(ABDataE.toString(), NABDataE.toString());
-              assert.equal(ABDataF.toString(), NABDataF.toString());
-              callback();
+                  assert.equal(ABData['COLA'], '');
+                  assert.equal(ABData['COLB'], NABData['COLB']);
+                  assert.equal(ABDate.toString(), NABDate.toString());
+                  assert.equal(ABDataD.toString(), NABDataD.toString());
+                  assert.equal(ABDataE.toString(), NABDataE.toString());
+                  assert.equal(ABDataF.toString(), NABDataF.toString());
+                  callback();
+                }
+                catch (e)
+                {
+                  callback(e);
+                }
+              }
             }
           });
         },
@@ -430,22 +461,24 @@ describe('Test Array Bind', function ()
   });
 });
 
-describe('testArrayBind - full path', function ()
+describe('Test Array Bind - full path', function ()
 {
+  const DATABASE_NAME = connOption.valid.database;
+  const SCHEMA_NAME = connOption.valid.schema;
+
   this.timeout(600000);
   var connection;
-  var createABTable = `create or replace table  ${DATABASE_NAME}.${SCHEMA_NAME}.testAB(colA string, colB number, colC date, colD time, colE TIMESTAMP_NTZ, colF TIMESTAMP_TZ)`;
-  var insertAB = `insert into  ${DATABASE_NAME}.${SCHEMA_NAME}.testAB values(?, ?, ?, ?, ?, ?)`;
+  const fullTableName = `${DATABASE_NAME}.${SCHEMA_NAME}.testAB`;
+  var createABTable = `create or replace table ${fullTableName}(colA string, colB number, colC date, colD time, colE TIMESTAMP_NTZ, colF TIMESTAMP_TZ)`;
+  var insertAB = `insert into ${fullTableName} values(?, ?, ?, ?, ?, ?)`;
   
   before(function (done)
   {
     connection = snowflake.createConnection({
-      accessUrl: connOption.valid.accessUrl,
-      account: connOption.valid.account,
-      username: connOption.valid.username,
-      password: connOption.valid.password,
-      warehouse: connOption.valid.warehouse,
-      role: connOption.valid.role,
+      ...connOption.valid,
+      // Set schema and database to null to ensure that full path to table is passed in commands
+      schema: undefined,
+      database: undefined,
       arrayBindingThreshold: 3
     });
     testUtil.connect(connection, function (err)
@@ -476,7 +509,7 @@ describe('testArrayBind - full path', function ()
       arrBind.push([null, i, "2020-05-11", "12:35:41.3333333", "2022-04-01 23:59:59", "2022-07-08 12:05:30.9999999"]);
     }
     
-    var insertABStmt = connection.execute({
+    connection.execute({
       sqlText: insertAB,
       binds: arrBind,
       complete: function (err, stmt) {
@@ -486,9 +519,11 @@ describe('testArrayBind - full path', function ()
       }
     });
   });
-  after(function (done)
+
+  after(async () =>
   {
-    testUtil.destroyConnection(connection, done);
+    await testUtil.dropTablesIgnoringErrorsAsync(connection, [fullTableName]);
+    await testUtil.destroyConnectionAsync(connection);
   });
 });
 
@@ -496,13 +531,14 @@ describe('Test Array Bind Force Error on Upload file', function ()
 {
   this.timeout(300000);
   var connection;
-  var createABTable = `create or replace table  ${DATABASE_NAME}.${SCHEMA_NAME}.testAB(colA string, colB number, colC date, colD time, colE TIMESTAMP_NTZ, colF TIMESTAMP_TZ)`;
+  var createABTable = `create or replace table testAB(colA string, colB number, colC date, colD time, colE TIMESTAMP_NTZ, colF TIMESTAMP_TZ)`;
   var insertAB = `insert into testAB values(?, ?, ?, ?, ?, ?)`;
   var selectAB = `select * from testAB where colB = 1`;
-  var createNABTable = `create or replace table  ${DATABASE_NAME}.${SCHEMA_NAME}.testNAB(colA string, colB number, colC date, colD time, colE TIMESTAMP_NTZ, colF TIMESTAMP_TZ)`;
-  var insertNAB = `insert into  ${DATABASE_NAME}.${SCHEMA_NAME}.testNAB values(?, ?, ?, ?, ?, ?)`;
-  var selectNAB = `select * from  ${DATABASE_NAME}.${SCHEMA_NAME}.testNAB where colB = 1`;
-  var useWH = `use warehouse ${WAREHOUSE_NAME}`;
+  var createNABTable = `create or replace table testNAB(colA string, colB number, colC date, colD time, colE TIMESTAMP_NTZ, colF TIMESTAMP_TZ)`;
+  var insertNAB = `insert into testNAB values(?, ?, ?, ?, ?, ?)`;
+  var selectNAB = `select * from testNAB where colB = 1`;
+
+  const usedTableNames = ['testAB', 'testNAB'];
 
   before(function (done) {
     connection = snowflake.createConnection({
@@ -510,19 +546,19 @@ describe('Test Array Bind Force Error on Upload file', function ()
       arrayBindingThreshold: 3,
       forceStageBindError: 1,
     });
-    testUtil.connect(connection, function () {
-      connection.execute({
-        sqlText: useWH,
-        complete: function (err) {
-          testUtil.checkError(err);
-          done();
-        }
-      });
+    testUtil.connect(connection, function (err)
+    {
+      done(err);
     });
   });
 
-  after(function (done) {
-    testUtil.destroyConnection(connection, done);
+  afterEach(async () =>
+  {
+  });
+
+  after(async () => {
+    await testUtil.dropTablesIgnoringErrorsAsync(connection, usedTableNames);
+    await testUtil.destroyConnectionAsync(connection);
   });
 
   it('testArrayBind force upload file error', function (done) {
@@ -624,9 +660,11 @@ describe('Test Array Bind Force Error on Upload file', function ()
   });
 });
 
-describe('testArrayBind - full path with cancel', function ()
+describe('Test Array Bind - full path with cancel', function ()
 {
   let connection;
+  const DATABASE_NAME = connOption.valid.database;
+  const SCHEMA_NAME = connOption.valid.schema;
   const tableName = `${DATABASE_NAME}.${SCHEMA_NAME}.testAB`;
 
   const rowsToInsert = 10;
@@ -645,12 +683,14 @@ describe('testArrayBind - full path with cancel', function ()
   {
     connection = snowflake.createConnection({
       ...connOption.valid,
+      // Set schema and database to null to ensure that full path to table is passed in commands
+      schema: undefined,
+      database: undefined,
       arrayBindingThreshold: 3,
       forceStageBindError: 0,
     });
     await testUtil.connectAsync(connection);
     await testUtil.executeCmdAsync(connection, createABTable);
-    await testUtil.executeCmdAsync(connection, 'drop stage if exists SYSTEM$BIND');
   });
 
   it('Full path array bind with cancel', done =>
@@ -700,7 +740,7 @@ describe('testArrayBind - full path with cancel', function ()
 
   after(async () =>
   {
-    await testUtil.executeCmdAsync(connection, `DROP TABLE IF EXISTS ${tableName}`);
+    await testUtil.dropTablesIgnoringErrorsAsync(connection, [tableName]);
     await testUtil.destroyConnectionAsync(connection);
   });
 });

--- a/test/integration/testArrayBind.js
+++ b/test/integration/testArrayBind.js
@@ -33,16 +33,19 @@ describe('Test Array Bind', function ()
       ...connOption.valid,
       arrayBindingThreshold: 3,
     });
-    testUtil.connect(connection, function ()
+    testUtil.connect(connection, err =>
     {
-      connection.execute({
-        sqlText: useWH,
-        complete: function (err)
-        {
-          testUtil.checkError(err);
-          done();
-        }
-      });
+      if (err)
+      {
+        done(err)
+      }
+      else
+      {
+        connection.execute({
+          sqlText: useWH,
+          complete: done
+        });
+      }
     });
   });
 
@@ -81,17 +84,8 @@ describe('Test Array Bind', function ()
             complete: function (err, stmt) {
               testUtil.checkError(err);
               assert.strictEqual(stmt.getNumUpdatedRows(), count);
-              console.log("sql text = " + insertABStmt.getSqlText());
               assert.strictEqual(insertABStmt.getSqlText(), insertAB);
-              console.log("num row inserted = " + insertABStmt.getNumUpdatedRows());
               assert.strictEqual(insertABStmt.getNumUpdatedRows(), count);
-              console.log("status = " + insertABStmt.getStatus());
-              console.log("columns = " + insertABStmt.getColumns());
-              console.log("column = " + insertABStmt.getColumn());
-              console.log("num rows = " + insertABStmt.getNumRows());
-              console.log("session state = " + insertABStmt.getSessionState());
-              console.log("request id = " + insertABStmt.getRequestId());
-              console.log("statement id = " + insertABStmt.getStatementId());
               callback();
             }
           });
@@ -295,13 +289,11 @@ describe('Test Array Bind', function ()
             binds: [JSON.stringify(arrBind)],
             complete: function (err, stmt) {
               if (err) {
-                console.error('1 Failed to execute statement due to the following error: ' + err.message);
-                done(err);
+                callback(err);
               }
               else {
-                console.log('inserted rows=' + stmt.getNumUpdatedRows());
                 assert.strictEqual(stmt.getNumUpdatedRows(), count);
-                done();
+                callback();
               }
             }
           });
@@ -333,13 +325,11 @@ describe('Test Array Bind', function ()
             binds: arrBind,
             complete: function (err, stmt) {
               if (err) {
-                console.error('1 Failed to execute statement due to the following error: ' + err.message);
-                done(err);
+                callback(err);
               }
               else {
-                console.log('inserted rows=' + stmt.getNumUpdatedRows());
                 assert.strictEqual(stmt.getNumUpdatedRows(), count);
-                done();
+                callback();
               }
             }
           });
@@ -413,11 +403,9 @@ describe('Test Array Bind', function ()
             fetchAsString: ['Number', 'Date', 'JSON'],
             complete: function (err, stmt) {
               if (err) {
-                console.error('1 Failed to execute statement due to the following error: ' + err.message);
-                done(err);
+                callback(err);
               }
               else {
-                console.log('inserted rows=' + stmt.getNumUpdatedRows());
                 callback();
               }
             }
@@ -432,7 +420,7 @@ describe('Test Array Bind', function ()
               testUtil.checkError(err);
               var result = rows[0];
               assert.equal(result['TYPE'], "SAMPLE");
-              done();
+              callback();
             }
           });
         },
@@ -460,16 +448,22 @@ describe('testArrayBind - full path', function ()
       role: connOption.valid.role,
       arrayBindingThreshold: 3
     });
-    testUtil.connect(connection, function ()
+    testUtil.connect(connection, function (err)
     {
-      connection.execute({
-        sqlText: createABTable,
-        complete: function (err)
-        {
-          testUtil.checkError(err);
-          done();
-        }
-      });
+      if (err)
+      {
+        done(err)
+      }
+      else
+      {
+        connection.execute({
+          sqlText: createABTable,
+          complete: function (err)
+          {
+            done(err);
+          }
+        });
+      }
     });
   });
 
@@ -487,7 +481,6 @@ describe('testArrayBind - full path', function ()
       binds: arrBind,
       complete: function (err, stmt) {
         testUtil.checkError(err);
-        console.log("stmt.getNumUpdatedRows()="+stmt.getNumUpdatedRows())
         assert.strictEqual(stmt.getNumUpdatedRows(), count);
         done();
       }
@@ -558,17 +551,8 @@ describe('Test Array Bind Force Error on Upload file', function ()
             complete: function (err, stmt) {
               testUtil.checkError(err);
               assert.strictEqual(stmt.getNumUpdatedRows(), count);
-              console.log("sql text = " + insertABStmt.getSqlText());
               assert.strictEqual(insertABStmt.getSqlText(), insertAB);
-              console.log("num row inserted = " + insertABStmt.getNumUpdatedRows());
               assert.strictEqual(insertABStmt.getNumUpdatedRows(), count);
-              console.log("status = " + insertABStmt.getStatus());
-              console.log("columns = " + insertABStmt.getColumns());
-              console.log("column = " + insertABStmt.getColumn());
-              console.log("num rows = " + insertABStmt.getNumRows());
-              console.log("session state = " + insertABStmt.getSessionState());
-              console.log("request id = " + insertABStmt.getRequestId());
-              console.log("statement id = " + insertABStmt.getStatementId());
               callback();
             }
           });

--- a/test/integration/testArrayBind.js
+++ b/test/integration/testArrayBind.js
@@ -646,8 +646,11 @@ describe('testArrayBind - full path with cancel', function ()
   const tableName = `${DATABASE_NAME}.${SCHEMA_NAME}.testAB`;
 
   const rowsToInsert = 10;
-  const delayPerRowMs = 5000;
-  const cancelInsertAfterMs = 2000;
+  // we need query to be executed long enough to be able to send cancel before it ends,
+  // but we cannot send it too early because its executing could not start yet
+  // (then we receive error that query is not running, so we cannot cancel it)
+  const delayPerRowMs = 10000;
+  const cancelInsertAfterMs = 4000;
 
   // SYSTEM$WAIT is not supported as insert with binds in regression test, so it's set as default for last column
   const createABTable = `create or replace table ${tableName}(colA string, colB number, colC date, colD time, colE TIMESTAMP_NTZ, colF TIMESTAMP_TZ, colG string default SYSTEM$WAIT(${delayPerRowMs}, 'MILLISECONDS'))`;

--- a/test/integration/testConnection.js
+++ b/test/integration/testConnection.js
@@ -32,8 +32,7 @@ describe('Connection test', function ()
         sessionTokenExpirationTime: undefined
       });
     }
-  )
-  ;
+  );
 
   it('does not return tokens when not in qaMode', function ()
     {
@@ -99,16 +98,17 @@ describe('Connection test', function ()
       done();
     });
   });
+
   it('Multiple Client', function (done)
   {
     const totalConnections = 10;
-    var connections = [];
-    for (var i = 0; i < totalConnections; i++)
+    const connections = [];
+    for (let i = 0; i < totalConnections; i++)
     {
       connections.push(snowflake.createConnection(connOption.valid));
     }
-    var completedConnection = 0;
-    for (i = 0; i < totalConnections; i++)
+    let completedConnection = 0;
+    for (let i = 0; i < totalConnections; i++)
     {
       connections[i].connect(function (err, conn)
       {
@@ -126,11 +126,28 @@ describe('Connection test', function ()
         });
       });
     }
-    setTimeout(function ()
+    const sleepMs = 500;
+    const maxSleep = 60000;
+    let sleepFromStartChecking = 0;
+
+    const timeout = () => setTimeout(() =>
     {
-      assert.strictEqual(completedConnection, totalConnections);
-      done();
-    }, 60000);
+      sleepFromStartChecking += sleepMs;
+      if (completedConnection === totalConnections)
+      {
+        done();
+      }
+      else if (sleepFromStartChecking <= maxSleep)
+      {
+        timeout();
+      }
+      else
+      {
+        done(`Max after ${maxSleep} it's expected to complete ${totalConnections} but completed ${completedConnection}`)
+      }
+    }, sleepMs);
+
+    timeout();
   });
 });
 

--- a/test/integration/testStatement.js
+++ b/test/integration/testStatement.js
@@ -13,8 +13,14 @@ var testUtil = require('./testUtil');
 
 describe('Statement Tests', function ()
 {
-  var connection = snowflake.createConnection(connectionOptions.valid);
-  var sqlText = 'select 1 as "c1";';
+  let connection;
+  const sqlText = 'select 1 as "c1";';
+
+  beforeEach(() =>
+  {
+    connection = snowflake.createConnection(connectionOptions.valid);
+  });
+
   it('with a valid token', function (done)
     {
 
@@ -118,8 +124,7 @@ describe('Statement Tests', function ()
           done();
         });
     }
-  )
-  ;
+  );
 
   it('with an invalid token', function (done)
   {
@@ -252,20 +257,20 @@ describe('Statement Tests', function ()
   });
 });
 
-
 describe('Call Statement', function ()
 {
-  this.timeout(10000);
-  var connection = snowflake.createConnection(connectionOptions.valid);
+  let connection;
+
+  beforeEach(async () =>
+  {
+    connection = snowflake.createConnection(connectionOptions.valid);
+    await testUtil.connectAsync(connection);
+  });
 
   it('call statement', function (done)
   {
     async.series(
       [
-        function (callback)
-        {
-          testUtil.connect(connection, callback);
-        },
         function (callback)
         {
           var statement = connection.execute({


### PR DESCRIPTION
### Description
- Don't create connection outside of mocha specific methods
- Speed up connection Multiple Client test
- Redirect hang webserver output to the file
- Don't throw exception from default heartbeat callback - there is no handler for it
- Don't write directly to shared connection options
- Set longer delays for cancel array bind test
- Call callback in series and done outside series and remove console logs
- Drop tables after array bind tests

### Checklist
- [x] Format code according to the existing code style (there is no automatic linter yet)
- [x] Create tests which fail without the change (if possible)
- [x] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [x] Extend the README / documentation and ensure is properly displayed (if necessary)
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message
