### PR TITLE
SNOW-841052: Set moderate on npm audit during ci build

### DIFF
--- a/ci/container/build_component.sh
+++ b/ci/container/build_component.sh
@@ -11,11 +11,19 @@ THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd /mnt/host
 echo "[INFO] Building"
 rm -f snowflake-sdk*.tgz
+echo "[DEBUG] Version"
+npm version
+echo "[DEBUG] Installing newer node - bundled npm version 6.0.1 does not support setting audit level"
+export NVM_DIR=`pwd`/nvm
+cp -r /usr/local/nvm $NVM_DIR
+source $NVM_DIR/nvm.sh && nvm install 10
+echo "[DEBUG] Packing"
 npm pack
+echo "[DEBUG] Installing"
 npm install
 rm -f ~/.npmrc
-npm audit
-
+echo "[DEBUG] Auditing"
+npm audit --audit-level moderate # TODO SNOW-841052 fast-xml-parser has low vulnerability - when new version will be released `moderate` option should be removed
 
 echo "[INFO] Uploading Artifacts"
 ARTIFACTS=($(ls snowflake-sdk*))


### PR DESCRIPTION
### Description
Temporary set `npm audit` level to `moderate` until new version of fast-xml-parser is released and its low vulnerability is fixed 

### Checklist
- [x] Format code according to the existing code style (there is no automatic linter yet)
- [x] Create tests which fail without the change (if possible)
- [x] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [x] Extend the README / documentation and ensure is properly displayed (if necessary)
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message
