### PR TITLE
SNOW-841052: Don't put nvm in pack during ci build

### DIFF
--- a/ci/container/build_component.sh
+++ b/ci/container/build_component.sh
@@ -14,7 +14,9 @@ rm -f snowflake-sdk*.tgz
 echo "[DEBUG] Version"
 npm version
 echo "[DEBUG] Installing newer node - bundled npm version 6.0.1 does not support setting audit level"
-export NVM_DIR=`pwd`/nvm
+export NVM_PARENT_DIR=`pwd`/ignore
+mkdir -p $NVM_PARENT_DIR
+export NVM_DIR="$NVM_PARENT_DIR/nvm"
 cp -r /usr/local/nvm $NVM_DIR
 source $NVM_DIR/nvm.sh && nvm install 10
 echo "[DEBUG] Packing"


### PR DESCRIPTION
### Description
Unintentionally nvm in build phase was included in npm package for testing. This PR move it to ignored by npm directory (in .npmignore).

### Checklist
- [x] Format code according to the existing code style (run `npm run lint:check -- CHANGED_FILES` and fix problems in changed code)
- [x] Create tests which fail without the change (if possible)
- [x] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [x] Extend the README / documentation and ensure is properly displayed (if necessary)
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message
