### PR TITLE
SNOW-831683: Retry and cleanup testPutGet and testArrayBindCustomerTable

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,7 +17,7 @@ module.exports = {
     'indent': ['warn', 2],
     'linebreak-style': ['warn', 'unix'],
     'no-async-promise-executor': ['warn'],
-    'no-console': ['warn'],
+    'no-console': ['warn', { 'allow': ['warn', 'error'] }],
     'no-empty': ['warn'],
     'no-ex-assign': ['warn'],
     'no-extra-semi': ['warn'],

--- a/test/integration/testArrayBindCustomerTable.js
+++ b/test/integration/testArrayBindCustomerTable.js
@@ -1,12 +1,13 @@
 /*
  * Copyright (c) 2015-2019 Snowflake Computing Inc. All rights reserved.
  */
-var assert = require('assert');
-var testUtil = require('./testUtil');
+const assert = require('assert');
+const testUtil = require('./testUtil');
 
-describe('Test Stage Binding with Customer Table', function ()
-{
+describe('Test Stage Binding with Customer Table', function () {
   this.timeout(300000);
+  this.retries(3); // this test suit are considered as flaky test
+
   let connection;
   const tableName = 'EVENTS_TEMP';
   const createTable = `create or replace TABLE ${tableName} (ORGANIZATION_ID VARCHAR(16777216),` +
@@ -20,25 +21,21 @@ describe('Test Stage Binding with Customer Table', function ()
     'SHOP_MYSHOPIFYDOMAIN VARCHAR(16777216),SHOP_NAME VARCHAR(16777216),APP_APIKEY VARCHAR(16777216))';
   const insertWithQmark = `insert into ${tableName} values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`;
 
-  before(async () =>
-  {
+  before(async () => {
     connection = testUtil.createConnection();
     await testUtil.connectAsync(connection);
     await testUtil.executeCmdAsync(connection, createTable);
   });
 
-  after(async () =>
-  {
-    await testUtil.executeCmdAsync(connection, `DROP TABLE IF EXISTS ${tableName};`);
+  after(async () => {
+    await testUtil.dropTablesIgnoringErrorsAsync(connection, [tableName]);
     await testUtil.destroyConnectionAsync(connection);
   });
 
-  it('testArrayBindCustomerTable', function (done)
-  {
+  it('testArrayBindCustomerTable', function (done) {
     const arrBind = [];
     const rowsToInsert = 10000; // 100000 rows causes "Statement exhausted compilation resources and was canceled. Please contact support." in regression environment
-    for (let i = 0; i < rowsToInsert; i++)
-    {
+    for (let i = 0; i < rowsToInsert; i++) {
       arrBind.push(['string' + i, 'appid', 'occuredat', 'shopid', 'type', 'id', 10.9, 'charge amount currency code',
         'chargeid', 'chargename', 'chargetest', 'chargebillingon', 'reason', 'description', 99.99, 'appcredit amount currency code',
         'appcreditid', 'appcreditname', 'appcredittest', 'appname', 'shopmyshopifyoumin', 'shopname', 'appapikey']);
@@ -46,11 +43,17 @@ describe('Test Stage Binding with Customer Table', function ()
     connection.execute({
       sqlText: insertWithQmark,
       binds: arrBind,
-      complete: function (err, stmt)
-      {
-        testUtil.checkError(err);
-        assert.strictEqual(stmt.getNumUpdatedRows(), rowsToInsert);
-        done();
+      complete: function (err, stmt) {
+        if (err) {
+          done(err);
+        } else {
+          try {
+            assert.strictEqual(stmt.getNumUpdatedRows(), rowsToInsert);
+            done();
+          } catch (e) {
+            done(e);
+          }
+        }
       }
     });
   });

--- a/test/integration/testPutGet.js
+++ b/test/integration/testPutGet.js
@@ -17,9 +17,9 @@ const DATABASE_NAME = connOption.valid.database;
 const SCHEMA_NAME = connOption.valid.schema;
 const TEMP_TABLE_NAME = 'TEMP_TABLE';
 
-const SKIPPED = "SKIPPED";
-const UPLOADED = "UPLOADED";
-const DOWNLOADED = "DOWNLOADED";
+const SKIPPED = 'SKIPPED';
+const UPLOADED = 'UPLOADED';
+const DOWNLOADED = 'DOWNLOADED';
 
 const COL1 = 'C1';
 const COL2 = 'C2';
@@ -28,80 +28,80 @@ const COL1_DATA = 'FIRST';
 const COL2_DATA = 'SECOND';
 const COL3_DATA = 'THIRD';
 const ROW_DATA =
-  COL1_DATA + "," + COL2_DATA + "," + COL3_DATA + "\n" +
-  COL1_DATA + "," + COL2_DATA + "," + COL3_DATA + "\n" +
-  COL1_DATA + "," + COL2_DATA + "," + COL3_DATA + "\n" +
-  COL1_DATA + "," + COL2_DATA + "," + COL3_DATA + "\n";
+  COL1_DATA + ',' + COL2_DATA + ',' + COL3_DATA + '\n' +
+  COL1_DATA + ',' + COL2_DATA + ',' + COL3_DATA + '\n' +
+  COL1_DATA + ',' + COL2_DATA + ',' + COL3_DATA + '\n' +
+  COL1_DATA + ',' + COL2_DATA + ',' + COL3_DATA + '\n';
 const ROW_DATA_SIZE = 76;
 
-const ROW_DATA_OVERWRITE = COL3_DATA + "," + COL1_DATA + "," + COL2_DATA + "\n";
+const ROW_DATA_OVERWRITE = COL3_DATA + ',' + COL1_DATA + ',' + COL2_DATA + '\n';
 const ROW_DATA_OVERWRITE_SIZE = 19;
 
-function getPlatformTmpPath(tmpPath){
-  var path = `file://${tmpPath}`;
+function getPlatformTmpPath (tmpPath) {
+  let path = `file://${tmpPath}`;
   // Windows user contains a '~' in the path which causes an error
-  if (process.platform == "win32")
-  {
-    var fileName = tmpPath.substring(tmpPath.lastIndexOf('\\'));
+  if (process.platform == 'win32') {
+    const fileName = tmpPath.substring(tmpPath.lastIndexOf('\\'));
     path = `file://${process.env.USERPROFILE}\\AppData\\Local\\Temp\\${fileName}`;
   }
   return path;
 }
 
-function executePutCmd(connection, putQuery, callback, results){
+function executePutCmd (connection, putQuery, callback, results) {
   // Upload file
-  var statement = connection.execute({
+  connection.execute({
     sqlText: putQuery,
-    complete: function (err, stmt, rows)
-    {
-      var stream = statement.streamRows();
-      stream.on('error', function (err)
-      {
+    complete: function (err, stmt) {
+      const stream = stmt.streamRows();
+      stream.on('error', function (err) {
         callback(err);
       });
-      stream.on('data', function (row)
-      {
+      stream.on('data', function (row) {
         results.fileSize = row.targetSize;
         // Check the file is correctly uploaded
         assert.strictEqual(row['status'], UPLOADED);
         // Check the target encoding is correct
         assert.strictEqual(row['targetCompression'], 'GZIP');
       });
-      stream.on('end', function (row)
-      {
+      stream.on('end', function () {
         callback();
       });
     }
   });
 }
 
-describe('PUT GET test', function ()
-{
-  var connection;
-  var tmpFile;
-  var createTable = `create or replace table ${TEMP_TABLE_NAME} (${COL1} STRING, ${COL2} STRING, ${COL3} STRING)`;
-  var copyInto = `COPY INTO ${TEMP_TABLE_NAME}`;
-  var removeFile = `REMOVE @${DATABASE_NAME}.${SCHEMA_NAME}.%${TEMP_TABLE_NAME}`;
-  var dropTable = `DROP TABLE IF EXISTS ${TEMP_TABLE_NAME}`;
+describe('PUT GET test', function () {
+  this.retries(3); // this test suit are considered as flaky test
 
-  before(function (done)
-  {
+  let connection;
+  let tmpFile;
+  const createTable = `create or replace table ${TEMP_TABLE_NAME} (${COL1} STRING, ${COL2} STRING, ${COL3} STRING)`;
+  const truncateTable = `truncate table if exists ${TEMP_TABLE_NAME}`;
+  const copyInto = `COPY INTO ${TEMP_TABLE_NAME}`;
+  const removeFile = `REMOVE @${DATABASE_NAME}.${SCHEMA_NAME}.%${TEMP_TABLE_NAME}`;
+  const dropTable = `DROP TABLE IF EXISTS ${TEMP_TABLE_NAME}`;
+
+  before(async () => {
     connection = testUtil.createConnection();
-    testUtil.connect(connection, done);
+    await testUtil.connectAsync(connection);
+    await testUtil.executeCmdAsync(connection, createTable);
   });
 
-  after(function (done)
-  {
-    testUtil.destroyConnection(connection, done);
+  beforeEach(async () => {
+    await testUtil.executeCmdAsync(connection, truncateTable);
   });
 
-  afterEach(function ()
-  {
-    fs.closeSync(tmpFile.fd);
-    fs.unlinkSync(tmpFile.name);
+  afterEach(async () => {
+    testUtil.deleteFileSyncIgnoringErrors(tmpFile);
+    await testUtil.executeCmdAsync(connection, removeFile);
   });
 
-  var testCases =
+  after(async () => {
+    await testUtil.executeCmdAsync(connection, dropTable);
+    await testUtil.destroyConnectionAsync(connection);
+  });
+
+  const testCases =
     [
       {
         name: 'gzip',
@@ -129,382 +129,337 @@ describe('PUT GET test', function ()
       }
     ];
 
-  var createItCallback = function (testCase)
-  {
-    return function (done)
-    {
+  const createItCallback = function (testCase) {
+    return function (done) {
       {
         // Create a temp file with specified file extension
         tmpFile = tmp.fileSync({ postfix: testCase.encoding['file_extension'] });
         // Write row data to temp file
         fs.writeFileSync(tmpFile.name, ROW_DATA);
 
-        var putQuery = `PUT file://${tmpFile.name} @${DATABASE_NAME}.${SCHEMA_NAME}.%${TEMP_TABLE_NAME}`;
+        let putQuery = `PUT file://${tmpFile.name} @${DATABASE_NAME}.${SCHEMA_NAME}.%${TEMP_TABLE_NAME}`;
         // Windows user contains a '~' in the path which causes an error
-        if (process.platform == "win32")
-        {
-          var fileName = tmpFile.name.substring(tmpFile.name.lastIndexOf('\\'));
+        if (process.platform == 'win32') {
+          const fileName = tmpFile.name.substring(tmpFile.name.lastIndexOf('\\'));
           putQuery = `PUT file://${process.env.USERPROFILE}\\AppData\\Local\\Temp\\${fileName} @${DATABASE_NAME}.${SCHEMA_NAME}.%${TEMP_TABLE_NAME}`;
         }
 
         // Create a tmp folder for downloaded files
-        var tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'get'));
-        var fileSize;
+        const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'get'));
+        let fileSize;
 
-        var getQuery = `GET @${DATABASE_NAME}.${SCHEMA_NAME}.%${TEMP_TABLE_NAME} file://${tmpDir}`;
+        let getQuery = `GET @${DATABASE_NAME}.${SCHEMA_NAME}.%${TEMP_TABLE_NAME} file://${tmpDir}`;
         // Windows user contains a '~' in the path which causes an error
-        if (process.platform == "win32")
-        {
-          var dirName = tmpDir.substring(tmpDir.lastIndexOf('\\') + 1);
+        if (process.platform == 'win32') {
+          const dirName = tmpDir.substring(tmpDir.lastIndexOf('\\') + 1);
           getQuery = `GET @${DATABASE_NAME}.${SCHEMA_NAME}.%${TEMP_TABLE_NAME} file://${process.env.USERPROFILE}\\AppData\\Local\\Temp\\${dirName}`;
         }
 
         async.series(
           [
-            function (callback)
-            {
-              // Create temp table
-              testUtil.executeCmd(connection, createTable, callback);
-            },
-            function (callback)
-            {
+            function (callback) {
               // Upload file
-              var statement = connection.execute({
+              connection.execute({
                 sqlText: putQuery,
-                complete: function (err, stmt, rows)
-                {
-                  var stream = statement.streamRows();
-                  stream.on('error', function (err)
-                  {
-                    done(err);
-                  });
-                  stream.on('data', function (row)
-                  {
-                    fileSize = row.targetSize;
-                    // Check the file is correctly uploaded
-                    assert.strictEqual(row['status'], UPLOADED);
-                    // Check the target encoding is correct
-                    assert.strictEqual(row['targetCompression'], testCase.encoding['name']);
-                  });
-                  stream.on('end', function (row)
-                  {
-                    callback();
-                  });
+                complete: function (err, _, rows) {
+                  if (err) {
+                    callback(err);
+                  } else {
+                    // example expected rows:
+                    // [{"source":"tmp-69066-85e8r477L32w-.gz","target":"tmp-69066-85e8r477L32w-.gz","sourceSize":76,
+                    //   "targetSize":76,"sourceCompression":null,"targetCompression":"GZIP","status":"UPLOADED"}]
+                    const row = rows[0];
+                    try {
+                      fileSize = row['targetSize'];
+                      // Check the file is correctly uploaded
+                      assert.strictEqual(row['status'], UPLOADED);
+                      // Check the target encoding is correct
+                      assert.strictEqual(row['targetCompression'], testCase.encoding['name']);
+                      callback();
+                    } catch (e) {
+                      callback(e);
+                    }
+                  }
                 }
               });
             },
-            function (callback)
-            {
+            function (callback) {
               // Copy into temp table
               testUtil.executeCmd(connection, copyInto, callback);
             },
-            function (callback)
-            {
+            function (callback) {
               // Check the contents are correct
-              var statement = connection.execute({
+              connection.execute({
                 sqlText: `SELECT * FROM ${TEMP_TABLE_NAME}`,
-                complete: function (err, stmt, rows)
-                {
-                  var stream = statement.streamRows();
-                  stream.on('error', function (err)
-                  {
-                    done(err);
-                  });
-                  stream.on('data', function (row)
-                  {
-                    // Check the row data is correct
-                    assert.strictEqual(row[COL1], COL1_DATA);
-                    assert.strictEqual(row[COL2], COL2_DATA);
-                    assert.strictEqual(row[COL3], COL3_DATA);
-                  });
-                  stream.on('end', function (row)
-                  {
-                    callback()
-                  });
+                complete: function (err, stmt) {
+                  if(err){
+                    callback(err);
+                  } else {
+                    const stream = stmt.streamRows();
+                    stream.on('error', function (err) {
+                      callback(err);
+                    });
+                    stream.on('data', function (row) {
+                      // Check the row data is correct
+                      assert.strictEqual(row[COL1], COL1_DATA);
+                      assert.strictEqual(row[COL2], COL2_DATA);
+                      assert.strictEqual(row[COL3], COL3_DATA);
+                    });
+                    stream.on('end', function () {
+                      callback();
+                    });
+                  }
                 }
               });
             },
-            function (callback)
-            {
+            function (callback) {
               // Check the row count is correct
-              var statement = connection.execute({
+              connection.execute({
                 sqlText: `SELECT COUNT(*) FROM ${TEMP_TABLE_NAME}`,
-                complete: function (err, stmt, rows)
-                {
-                  var stream = statement.streamRows();
-                  stream.on('error', function (err)
-                  {
-                    done(err);
-                  });
-                  stream.on('data', function (row)
-                  {
-                    // Check the row count is correct
-                    assert.strictEqual(row['COUNT(*)'], 4);
-                  });
-                  stream.on('end', function (row)
-                  {
-                    callback();
-                  });
+                complete: function (err, stmt) {
+                  if(err){
+                    callback(err);
+                  }else {
+                    const stream = stmt.streamRows();
+                    stream.on('error', function (err) {
+                      callback(err);
+                    });
+                    stream.on('data', function (row) {
+                      // Check the row count is correct
+                      assert.strictEqual(row['COUNT(*)'], 4);
+                    });
+                    stream.on('end', function () {
+                      callback();
+                    });
+                  }
                 }
               });
             },
-            function (callback)
-            {
+            function (callback) {
               // Run GET command
-              var statement = connection.execute({
+              connection.execute({
                 sqlText: getQuery,
-                complete: function (err, stmt, rows)
-                {
-                  var stream = statement.streamRows();
-                  stream.on('error', function (err)
-                  {
-                    done(err);
-                  });
-                  stream.on('data', function (row)
-                  {
-                    assert.strictEqual(row.status, DOWNLOADED);
-                    assert.strictEqual(row.size, fileSize);
-                    // Delete the downloaded file
-                    fs.unlink(path.join(tmpDir, row.file), (err) =>
-                    {
-                      if (err) throw (err);
-                      // Delete the temporary folder
-                      fs.rmdir(tmpDir, (err) =>
-                      {
-                        if (err) throw (err);
+                complete: function (err, stmt) {
+                  if(err){
+                    callback(err);
+                  }else {
+                    const stream = stmt.streamRows();
+                    stream.on('error', function (err) {
+                      callback(err);
+                    });
+                    stream.on('data', function (row) {
+                      assert.strictEqual(row.status, DOWNLOADED);
+                      assert.strictEqual(row.size, fileSize);
+                      // Delete the downloaded file
+                      fs.unlink(path.join(tmpDir, row.file), (err) => {
+                        if (err) {
+                          throw (err);
+                        }
+                        // Delete the temporary folder
+                        fs.rmdir(tmpDir, (err) => {
+                          if (err) {
+                            throw (err);
+                          }
+                        });
                       });
                     });
-                  });
-                  stream.on('end', function (row)
-                  {
-                    callback();
-                  });
+                    stream.on('end', function () {
+                      callback();
+                    });
+                  }
                 }
               });
-            },
-            function (callback)
-            {
-              // Remove files from staging
-              testUtil.executeCmd(connection, removeFile, callback);
-            },
-            function (callback)
-            {
-              // Drop temp table
-              testUtil.executeCmd(connection, dropTable, callback);
             }
           ],
           done
         );
-      };
+      }
+
     };
   };
 
-  for (var index = 0; index < testCases.length; index++)
-  {
-    var testCase = testCases[index];
+  for (let index = 0; index < testCases.length; index++) {
+    const testCase = testCases[index];
     it(testCase.name, createItCallback(testCase));
   }
 });
 
-describe('PUT GET overwrite test', function ()
-{
-  var connection;
-  var tmpFile;
-  var createTable = `create or replace table ${TEMP_TABLE_NAME} (${COL1} STRING, ${COL2} STRING, ${COL3} STRING)`;
-  var removeFile = `REMOVE @${DATABASE_NAME}.${SCHEMA_NAME}.%${TEMP_TABLE_NAME}`;
-  var dropTable = `DROP TABLE IF EXISTS ${TEMP_TABLE_NAME}`;
+describe('PUT GET overwrite test', function () {
+  this.retries(3); // this test suit are considered as flaky test
 
-  // Create a temp file with specified file extension
-  var tmpFile = tmp.fileSync();
+  let connection;
+  const createTable = `create or replace table ${TEMP_TABLE_NAME} (${COL1} STRING, ${COL2} STRING, ${COL3} STRING)`;
+  const removeFile = `REMOVE @${DATABASE_NAME}.${SCHEMA_NAME}.%${TEMP_TABLE_NAME}`;
+  const dropTable = `DROP TABLE IF EXISTS ${TEMP_TABLE_NAME}`;
+
+  // Create a temp file without specified file extension
+  const tmpFile = tmp.fileSync();
   // Write row data to temp file
   fs.writeFileSync(tmpFile.name, ROW_DATA);
 
-  before(function (done)
-  {
+  before(async () => {
     connection = testUtil.createConnection();
-    testUtil.connect(connection, done);
+    await testUtil.connectAsync(connection);
+    await testUtil.executeCmdAsync(connection, createTable);
   });
 
-  after(function (done)
-  {
-    testUtil.destroyConnection(connection, done);
+  after(async () => {
+    testUtil.deleteFileSyncIgnoringErrors(tmpFile);
+
+    await testUtil.executeCmdAsync(connection, removeFile);
+    await testUtil.executeCmdAsync(connection, dropTable);
+    await testUtil.destroyConnectionAsync(connection);
   });
 
-  var putQuery = `
+  let putQuery = `
     PUT file://${tmpFile.name} @${DATABASE_NAME}.${SCHEMA_NAME}.%${TEMP_TABLE_NAME} AUTO_COMPRESS=FALSE`;
   // Windows user contains a '~' in the path which causes an error
-  if (process.platform == "win32")
-  {
-    var fileName = tmpFile.name.substring(tmpFile.name.lastIndexOf('\\'));
+  if (process.platform == 'win32') {
+    const fileName = tmpFile.name.substring(tmpFile.name.lastIndexOf('\\'));
     putQuery = `
       PUT file://${process.env.USERPROFILE}\\AppData\\Local\\Temp\\${fileName} @${DATABASE_NAME}.${SCHEMA_NAME}.%${TEMP_TABLE_NAME} AUTO_COMPRESS=FALSE`;
   }
 
-  var testCases =
+  const testCases =
     [
       {
         name: 'overwrite'
       },
     ];
 
-  var createItCallback = function (testCase)
-  {
-    return function (done)
-    {
+  const createItCallback = function () {
+    return function (done) {
       {
         async.series(
           [
-            function (callback)
-            {
-              // Create temp table
-              testUtil.executeCmd(connection, createTable, callback);
-            },
-            function (callback)
-            {
-              var statement = connection.execute({
+            function (callback) {
+              connection.execute({
                 sqlText: putQuery,
-                complete: function (err, stmt, rows)
-                {
-                  var stream = statement.streamRows();
-                  stream.on('error', function (err)
-                  {
-                    done(err);
-                  });
-                  stream.on('data', function (row)
-                  {
-                    // Check the file is correctly uploaded
-                    assert.strictEqual(row['status'], UPLOADED);
-                    assert.strictEqual(row.targetSize, ROW_DATA_SIZE);
-                  });
-                  stream.on('end', function (row)
-                  {
-                    callback();
-                  });
-                }
-              });
-            },
-            function (callback)
-            {
-              var statement = connection.execute({
-                sqlText: putQuery,
-                complete: function (err, stmt, rows)
-                {
-                  var stream = statement.streamRows();
-                  stream.on('error', function (err)
-                  {
-                    done(err);
-                  });
-                  stream.on('data', function (row)
-                  {
-                    if (!connOption.account.includes("gcp"))
-                    {
+                complete: function (err, stmt) {
+                  if(err){
+                    callback(err);
+                  }else {
+                    const stream = stmt.streamRows();
+                    stream.on('error', function (err) {
+                      callback(err);
+                    });
+                    stream.on('data', function (row) {
                       // Check the file is correctly uploaded
-                      assert.strictEqual(row['status'], SKIPPED);
-                    }
-                  });
-                  stream.on('end', function (row)
-                  {
-                    callback();
-                  });
+                      assert.strictEqual(row['status'], UPLOADED);
+                      assert.strictEqual(row.targetSize, ROW_DATA_SIZE);
+                    });
+                    stream.on('end', function () {
+                      callback();
+                    });
+                  }
                 }
               });
             },
-            function (callback)
-            {
-              fs.writeFileSync(tmpFile.name, ROW_DATA_OVERWRITE);
-              putQuery += " OVERWRITE=TRUE";
-
-              var statement = connection.execute({
+            function (callback) {
+              connection.execute({
                 sqlText: putQuery,
-                complete: function (err, stmt, rows)
-                {
-                  var stream = statement.streamRows();
-                  stream.on('error', function (err)
-                  {
-                    done(err);
-                  });
-                  stream.on('data', function (row)
-                  {
-                    // Check the file is correctly uploaded
-                    assert.strictEqual(row['status'], UPLOADED);
-                    assert.strictEqual(row.targetSize, ROW_DATA_OVERWRITE_SIZE);
-                  });
-                  stream.on('end', function (row)
-                  {
-                    callback();
-                  });
+                complete: function (err, stmt) {
+                  if(err){
+                    callback(err);
+                  }else {
+                    const stream = stmt.streamRows();
+                    stream.on('error', function (err) {
+                      callback(err);
+                    });
+                    stream.on('data', function (row) {
+                      if (!connOption.account.includes('gcp')) {
+                        // Check the file is correctly uploaded
+                        assert.strictEqual(row['status'], SKIPPED);
+                      }
+                    });
+                    stream.on('end', function () {
+                      callback();
+                    });
+                  }
                 }
               });
             },
-            function (callback)
-            {
-              fs.closeSync(tmpFile.fd);
-              fs.unlinkSync(tmpFile.name);
+            function (callback) {
+              fs.writeFileSync(tmpFile.name, ROW_DATA_OVERWRITE);
+              putQuery += ' OVERWRITE=TRUE';
 
-              // Remove files from staging
-              testUtil.executeCmd(connection, removeFile, callback);
-            },
-            function (callback)
-            {
-              // Drop temp table
-              testUtil.executeCmd(connection, dropTable, callback);
+              connection.execute({
+                sqlText: putQuery,
+                complete: function (err, stmt) {
+                  if(err){
+                    callback(err);
+                  }else {
+                    const stream = stmt.streamRows();
+                    stream.on('error', function (err) {
+                      callback(err);
+                    });
+                    stream.on('data', function (row) {
+                      // Check the file is correctly uploaded
+                      assert.strictEqual(row['status'], UPLOADED);
+                      assert.strictEqual(row.targetSize, ROW_DATA_OVERWRITE_SIZE);
+                    });
+                    stream.on('end', function () {
+                      callback();
+                    });
+                  }
+                }
+              });
             }
           ],
           done
         );
-      };
+      }
+
     };
   };
 
-  for (var index = 0; index < testCases.length; index++)
-  {
-    var testCase = testCases[index];
-    it(testCase.name, createItCallback(testCase));
+  for (let index = 0; index < testCases.length; index++) {
+    const testCase = testCases[index];
+    it(testCase.name, createItCallback());
   }
 });
 
-describe('PUT GET test with GCS_USE_DOWNSCOPED_CREDENTIAL', function ()
-{
-  var connection;
+describe('PUT GET test with GCS_USE_DOWNSCOPED_CREDENTIAL select large query', function () {
+  this.retries(3); // this test suit are considered as flaky test
 
-  before(function (done)
-  {
-    connection = testUtil.createConnection();
-    connection.gcsUseDownscopedCredential = true;
-    testUtil.connect(connection, done);
+  let connection;
+
+  before(async () => {
+    connection = testUtil.createConnection({
+      gcsUseDownscopedCredential: true
+    });
+    await testUtil.connectAsync(connection);
   });
 
-  after(function (done)
-  {
-    testUtil.destroyConnection(connection, done);
+  after(async () => {
+    await testUtil.destroyConnectionAsync(connection);
   });
 
-  it('testSelectLargeQuery', function (done)
-  {
+  it('testSelectLargeQuery', function (done) {
     async.series(
       [
-        function (callback)
-        {
-          var rowCount = 100000;
+        function (callback) {
+          const rowCount = 100000;
           // Check the row count is correct
-          var statement = connection.execute({
-            sqlText: `SELECT COUNT(*) FROM (select seq4() from table(generator(rowcount => ${rowCount})))`,
-            complete: function (err, stmt, rows)
-            {
-              var stream = statement.streamRows();
-              stream.on('error', function (err)
-              {
-                done(err);
-              });
-              stream.on('data', function (row)
-              {
-                // Check the row count is correct
-                assert.strictEqual(row['COUNT(*)'], rowCount);
-              });
-              stream.on('end', function (row)
-              {
-                callback();
-              });
+          connection.execute({
+            sqlText: `SELECT COUNT(*)
+                      FROM (select seq4() from table (generator(rowcount => ${rowCount})))`,
+            complete: function (err, stmt) {
+              if (err) {
+                callback(err);
+              } else {
+                const stream = stmt.streamRows();
+                stream.on('error', function (err) {
+                  callback(err);
+                });
+                stream.on('data', function (row) {
+                  // Check the row count is correct
+                  assert.strictEqual(row['COUNT(*)'], rowCount);
+                });
+                stream.on('end', function () {
+                  callback();
+                });
+              }
             }
           });
         }
@@ -512,178 +467,174 @@ describe('PUT GET test with GCS_USE_DOWNSCOPED_CREDENTIAL', function ()
       done
     );
   });
+});
 
-  it('testUploadDownload', function (done)
-  {
-    var tmpFile;
-    var createTable = `create or replace table ${TEMP_TABLE_NAME} (${COL1} STRING, ${COL2} STRING, ${COL3} STRING)`;
-    var copyInto = `COPY INTO ${TEMP_TABLE_NAME}`;
-    var removeFile = `REMOVE @${DATABASE_NAME}.${SCHEMA_NAME}.%${TEMP_TABLE_NAME}`;
-    var dropTable = `DROP TABLE IF EXISTS ${TEMP_TABLE_NAME}`;
+describe('PUT GET test with GCS_USE_DOWNSCOPED_CREDENTIAL', function () {
+  this.retries(3); // this test suit are considered as flaky test
+
+  let connection;
+
+  let tmpFile;
+  const createTable = `create or replace table ${TEMP_TABLE_NAME} (${COL1} STRING, ${COL2} STRING, ${COL3} STRING)`;
+  const copyInto = `COPY INTO ${TEMP_TABLE_NAME}`;
+  const removeFile = `REMOVE @${DATABASE_NAME}.${SCHEMA_NAME}.%${TEMP_TABLE_NAME}`;
+  const dropTable = `DROP TABLE IF EXISTS ${TEMP_TABLE_NAME}`;
+
+  before(async () => {
+    connection = testUtil.createConnection({
+      gcsUseDownscopedCredential: true
+    });
+    await testUtil.connectAsync(connection);
+    await testUtil.executeCmdAsync(connection, createTable);
+  });
+
+  after(async () => {
+    testUtil.deleteFileSyncIgnoringErrors(tmpFile);
+
+    await testUtil.executeCmdAsync(connection, removeFile);
+    await testUtil.executeCmdAsync(connection, dropTable);
+    await testUtil.destroyConnectionAsync(connection);
+  });
+
+  it('testUploadDownload', function (done) {
 
     // Create a temp file with specified file extension
     tmpFile = tmp.fileSync({ postfix: 'gz' });
     // Write row data to temp file
     fs.writeFileSync(tmpFile.name, ROW_DATA);
 
-    var putQuery = `PUT file://${tmpFile.name} @${DATABASE_NAME}.${SCHEMA_NAME}.%${TEMP_TABLE_NAME}`;
+    let putQuery = `PUT file://${tmpFile.name} @${DATABASE_NAME}.${SCHEMA_NAME}.%${TEMP_TABLE_NAME}`;
     // Windows user contains a '~' in the path which causes an error
-    if (process.platform == "win32")
-    {
-      var fileName = tmpFile.name.substring(tmpFile.name.lastIndexOf('\\'));
+    if (process.platform == 'win32') {
+      const fileName = tmpFile.name.substring(tmpFile.name.lastIndexOf('\\'));
       putQuery = `PUT file://${process.env.USERPROFILE}\\AppData\\Local\\Temp\\${fileName} @${DATABASE_NAME}.${SCHEMA_NAME}.%${TEMP_TABLE_NAME}`;
     }
 
     // Create a tmp folder for downloaded files
-    var tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'get'));
-    var fileSize;
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'get'));
+    let fileSize;
 
-    var getQuery = `GET @${DATABASE_NAME}.${SCHEMA_NAME}.%${TEMP_TABLE_NAME} file://${tmpDir}`;
+    let getQuery = `GET @${DATABASE_NAME}.${SCHEMA_NAME}.%${TEMP_TABLE_NAME} file://${tmpDir}`;
     // Windows user contains a '~' in the path which causes an error
-    if (process.platform == "win32")
-    {
-      var dirName = tmpDir.substring(tmpDir.lastIndexOf('\\') + 1);
+    if (process.platform == 'win32') {
+      const dirName = tmpDir.substring(tmpDir.lastIndexOf('\\') + 1);
       getQuery = `GET @${DATABASE_NAME}.${SCHEMA_NAME}.%${TEMP_TABLE_NAME} file://${process.env.USERPROFILE}\\AppData\\Local\\Temp\\${dirName}`;
     }
 
     async.series(
       [
-        function (callback)
-        {
-          // Create temp table
-          testUtil.executeCmd(connection, createTable, callback);
-        },
-        function (callback)
-        {
+        function (callback) {
           // Upload file
-          var statement = connection.execute({
+          connection.execute({
             sqlText: putQuery,
-            complete: function (err, stmt, rows)
-            {
-              var stream = statement.streamRows();
-              stream.on('error', function (err)
-              {
-                done(err);
-              });
-              stream.on('data', function (row)
-              {
-                fileSize = row.targetSize;
-                // Check the file is correctly uploaded
-                assert.strictEqual(row['status'], UPLOADED);
-                // Check the target encoding is correct
-                assert.strictEqual(row['targetCompression'], 'GZIP');
-              });
-              stream.on('end', function (row)
-              {
-                callback();
-              });
+            complete: function (err, stmt) {
+              if (err) {
+                callback(err);
+              } else {
+                const stream = stmt.streamRows();
+                stream.on('error', function (err) {
+                  callback(err);
+                });
+                stream.on('data', function (row) {
+                  fileSize = row.targetSize;
+                  // Check the file is correctly uploaded
+                  assert.strictEqual(row['status'], UPLOADED);
+                  // Check the target encoding is correct
+                  assert.strictEqual(row['targetCompression'], 'GZIP');
+                });
+                stream.on('end', function () {
+                  callback();
+                });
+              }
             }
           });
         },
-        function (callback)
-        {
+        function (callback) {
           // Copy into temp table
           testUtil.executeCmd(connection, copyInto, callback);
         },
-        function (callback)
-        {
+        function (callback) {
           // Check the contents are correct
-          var statement = connection.execute({
+          connection.execute({
             sqlText: `SELECT * FROM ${TEMP_TABLE_NAME}`,
-            complete: function (err, stmt, rows)
-            {
-              var stream = statement.streamRows();
-              stream.on('error', function (err)
-              {
-                done(err);
-              });
-              stream.on('data', function (row)
-              {
-                // Check the row data is correct
-                assert.strictEqual(row[COL1], COL1_DATA);
-                assert.strictEqual(row[COL2], COL2_DATA);
-                assert.strictEqual(row[COL3], COL3_DATA);
-              });
-              stream.on('end', function (row)
-              {
-                callback()
-              });
+            complete: function (err, stmt) {
+              if(err){
+                callback(err);
+              }else {
+                const stream = stmt.streamRows();
+                stream.on('error', function (err) {
+                  callback(err);
+                });
+                stream.on('data', function (row) {
+                  // Check the row data is correct
+                  assert.strictEqual(row[COL1], COL1_DATA);
+                  assert.strictEqual(row[COL2], COL2_DATA);
+                  assert.strictEqual(row[COL3], COL3_DATA);
+                });
+                stream.on('end', function () {
+                  callback();
+                });
+              }
             }
           });
         },
-        function (callback)
-        {
+        function (callback) {
           // Check the row count is correct
-          var statement = connection.execute({
+          connection.execute({
             sqlText: `SELECT COUNT(*) FROM ${TEMP_TABLE_NAME}`,
-            complete: function (err, stmt, rows)
-            {
-              var stream = statement.streamRows();
-              stream.on('error', function (err)
-              {
-                done(err);
-              });
-              stream.on('data', function (row)
-              {
-                // Check the row count is correct
-                assert.strictEqual(row['COUNT(*)'], 4);
-              });
-              stream.on('end', function (row)
-              {
-                callback();
-              });
+            complete: function (err, stmt) {
+              if(err){
+                callback(err);
+              }else {
+                const stream = stmt.streamRows();
+                stream.on('error', function (err) {
+                  callback(err);
+                });
+                stream.on('data', function (row) {
+                  // Check the row count is correct
+                  assert.strictEqual(row['COUNT(*)'], 4);
+                });
+                stream.on('end', function () {
+                  callback();
+                });
+              }
             }
           });
         },
-        function (callback)
-        {
+        function (callback) {
           // Run GET command
-          var statement = connection.execute({
+          connection.execute({
             sqlText: getQuery,
-            complete: function (err, stmt, rows)
-            {
-              var stream = statement.streamRows();
-              stream.on('error', function (err)
-              {
-                done(err);
-              });
-              stream.on('data', function (row)
-              {
-                assert.strictEqual(row.status, DOWNLOADED);
-                assert.strictEqual(row.size, fileSize);
-                // Delete the downloaded file
-                fs.unlink(path.join(tmpDir, row.file), (err) =>
-                {
-                  if (err) throw (err);
-                  // Delete the temporary folder
-                  fs.rmdir(tmpDir, (err) =>
-                  {
-                    if (err) throw (err);
+            complete: function (err, stmt) {
+              if(err){
+                callback(err); 
+              }else {
+                const stream = stmt.streamRows();
+                stream.on('error', function (err) {
+                  callback(err);
+                });
+                stream.on('data', function (row) {
+                  assert.strictEqual(row.status, DOWNLOADED);
+                  assert.strictEqual(row.size, fileSize);
+                  // Delete the downloaded file
+                  fs.unlink(path.join(tmpDir, row.file), (err) => {
+                    if (err) {
+                      throw (err);
+                    }
+                    // Delete the temporary folder
+                    fs.rmdir(tmpDir, (err) => {
+                      if (err) {
+                        throw (err);
+                      }
+                    });
                   });
                 });
-              });
-              stream.on('end', function (row)
-              {
-                callback();
-              });
+                stream.on('end', function () {
+                  callback();
+                });
+              }
             }
           });
-        },
-        function (callback)
-        {
-          // Remove files from staging
-          testUtil.executeCmd(connection, removeFile, callback);
-        },
-        function (callback)
-        {
-          // Drop temp table
-          testUtil.executeCmd(connection, dropTable, callback);
-        },
-        function (callback)
-        {
-          fs.closeSync(tmpFile.fd);
-          fs.unlinkSync(tmpFile.name);
-          callback();
         }
       ],
       done
@@ -691,240 +642,216 @@ describe('PUT GET test with GCS_USE_DOWNSCOPED_CREDENTIAL', function ()
   });
 });
 
-describe('PUT GET test multiple files', function ()
-{
-  var connection;
-  var stage = `@${DATABASE_NAME}.${SCHEMA_NAME}.%${TEMP_TABLE_NAME}`;
-  var removeFile = `REMOVE ${stage}`;
+describe('PUT GET test multiple files', function () {
+  this.retries(3); // this test suit are considered as flaky test
 
-  before(function (done)
-  {
-    connection = testUtil.createConnection();
-    connection.gcsUseDownscopedCredential = true;
-    async.series(
-      [
-        function (callback)
-        {
-          testUtil.connect(connection, callback);
-        },
-        function (callback)
-        {
-          var createTable = `create or replace table ${TEMP_TABLE_NAME} (${COL1} STRING, ${COL2} STRING, ${COL3} STRING)`;
-          // Create temp table
-          testUtil.executeCmd(connection, createTable, callback);
-        }
-      ],
-      done
-    );
+  let connection;
+  let tmpDir;
+  const stage = `@${DATABASE_NAME}.${SCHEMA_NAME}.%${TEMP_TABLE_NAME}`;
+  const removeFile = `REMOVE ${stage}`;
+  let tmpFiles; // FileSyncObject[]
+
+  before(async () => {
+    connection = testUtil.createConnection({
+      gcsUseDownscopedCredential: true,
+    });
+    await testUtil.connectAsync(connection);
+    const createTable = `create or replace table ${TEMP_TABLE_NAME} (${COL1} STRING, ${COL2} STRING, ${COL3} STRING)`;
+    await testUtil.executeCmdAsync(connection, createTable);
   });
 
-  after(function (done)
-  { 
-    async.series(
-      [
-        function (callback)
-        {
-          var dropTable = `DROP TABLE IF EXISTS ${TEMP_TABLE_NAME}`;
-          // Drop temp table
-          testUtil.executeCmd(connection, dropTable, callback);
-        },
-        function (callback)
-        {
-          testUtil.destroyConnection(connection, callback);
-        }
-      ],
-      done
-    );
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'get'));
+    tmpFiles = [];
   });
 
-  it('testDownloadMultifiles', function (done)
-  {
-    var tmpFile1, tmpFile2;
+  afterEach(async () => {
+    tmpFiles.forEach(file => {
+      testUtil.deleteFileSyncIgnoringErrors(file);
+    });
+    testUtil.deleteFolderSyncIgnoringErrors(tmpDir);
 
+    await testUtil.executeCmdAsync(connection, removeFile);
+    await testUtil.executeCmdAsync(connection, `truncate table if exists ${TEMP_TABLE_NAME}`);
+  });
+
+  after(async () => {
+    await testUtil.dropTablesIgnoringErrorsAsync(connection, [TEMP_TABLE_NAME]);
+    await testUtil.destroyConnectionAsync(connection);
+  });
+
+  it('testDownloadMultifiles', function (done) {
     // Create two temp file with specified file extension
-    tmpFile1 = tmp.fileSync({ postfix: 'gz' });
-    tmpFile2 = tmp.fileSync({ postfix: 'gz' });
+    const tmpFile1 = tmp.fileSync({ postfix: 'gz' });
+    const tmpFile2 = tmp.fileSync({ postfix: 'gz' });
+    tmpFiles = [tmpFile1, tmpFile2];
+
     // Write row data to temp file
     fs.writeFileSync(tmpFile1.name, ROW_DATA);
     fs.writeFileSync(tmpFile2.name, ROW_DATA);
 
-    var tmpfilePath1 = getPlatformTmpPath(tmpFile1.name);
-    var tmpfilePath2 = getPlatformTmpPath(tmpFile2.name);
+    const tmpfilePath1 = getPlatformTmpPath(tmpFile1.name);
+    const tmpfilePath2 = getPlatformTmpPath(tmpFile2.name);
 
-    var putQuery1 = `PUT ${tmpfilePath1} ${stage}`;
-    var putQuery2 = `PUT ${tmpfilePath2} ${stage}`;
+    const putQuery1 = `PUT ${tmpfilePath1} ${stage}`;
+    const putQuery2 = `PUT ${tmpfilePath2} ${stage}`;
 
-    // Create a tmp folder for downloaded files
-    var tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'get'));
-    var results = {};
- 
-    var tmpdirPath = getPlatformTmpPath(tmpDir);
-    var getQuery = `GET ${stage} ${tmpdirPath}`;
+    const results = {};
+
+    const tmpdirPath = getPlatformTmpPath(tmpDir);
+    const getQuery = `GET ${stage} ${tmpdirPath}`;
+
+    const testResult = [];
 
     async.series(
       [
-        function (callback)
-        {
-          fileSize = executePutCmd(connection, putQuery1, callback, results);
+        function (callback) {
+          executePutCmd(connection, putQuery1, callback, results);
         },
-        function (callback)
-        {
-          fileSize = executePutCmd(connection, putQuery2, callback, results);
+        function (callback) {
+          executePutCmd(connection, putQuery2, callback, results);
         },
-        function (callback)
-        {
+        function (callback) {
           // Run GET command
-          var statement = connection.execute({
+          connection.execute({
             sqlText: getQuery,
-            complete: function (err, stmt, rows)
-            {
-              var stream = statement.streamRows();
-              stream.on('error', function (err)
-              {
+            complete: function (err, stmt) {
+              if (err) {
                 callback(err);
-              });
-              stream.on('data', function (row)
-              {
-                assert.strictEqual(row.status, DOWNLOADED);
-                assert.strictEqual(row.size, results.fileSize);
+              } else {
+                const stream = stmt.streamRows();
+                stream.on('error', function (err) {
+                  callback(err);
+                });
+                stream.on('data', function (row) {
+                  assert.strictEqual(row.status, DOWNLOADED);
+                  assert.strictEqual(row.size, results.fileSize);
 
-                // Decompress the downloaded file
-                var compressedFile = path.join(tmpDir,row.file);
-                var decompressedFile = path.join(tmpDir,'de-'+row.file);
-                const fileContents = fs.createReadStream(compressedFile);
-                const writeStream = fs.createWriteStream(decompressedFile);
-                const unzip = zlib.createGunzip();
+                  // Decompress the downloaded file
+                  const compressedFile = path.join(tmpDir, row.file);
+                  const decompressedFile = path.join(tmpDir, 'de-' + row.file);
+                  const fileContents = fs.createReadStream(compressedFile);
+                  const writeStream = fs.createWriteStream(decompressedFile);
+                  const unzip = zlib.createGunzip();
 
-                fileContents.pipe(unzip).pipe(writeStream).on('finish', function() {
-                  // Verify the data of the downloaded file
-                  var data = fs.readFileSync(decompressedFile).toString();
-                  assert.strictEqual(data, ROW_DATA);
-                  fs.unlinkSync(compressedFile);
-                  fs.unlinkSync(decompressedFile);
-                })
-              });
-              stream.on('end', function (row)
-              {
-                callback();
-              });
+                  fileContents.pipe(unzip).pipe(writeStream).on('finish', function () {
+                    // Verify the data of the downloaded file
+                    // this callback is called asynchronously so we gather results and in stream end we check if all files are correct
+                    const data = fs.readFileSync(decompressedFile).toString();
+                    try {
+                      assert.strictEqual(data, ROW_DATA);
+                      testResult.push(true);
+                    } catch (e) {
+                      testResult.push(e);
+                    }
+                  });
+                });
+                stream.on('end', function () {
+                  expectArrayToBeFinallyFilledWithTrue(2, testResult, callback);
+                });
+              }
             }
           });
         },
-        function (callback)
-        {
-          // Remove files from staging
-          testUtil.executeCmd(connection, removeFile, callback);
-        },
-        function (callback)
-        {       
-          fs.closeSync(tmpFile1.fd);
-          fs.unlinkSync(tmpFile1.name);
-          fs.closeSync(tmpFile2.fd);
-          fs.unlinkSync(tmpFile2.name);
-
-          // Delete the temporary folder
-          fs.rmdir(tmpDir, (err) =>
-          {
-            if (err) throw (err);
-          });
-          callback();
-        }
       ],
       done
     );
   });
 
-  it('testUploadMultifiles', function (done)
-  {
+  it('testUploadMultifiles', function (done) {
     const count = 5;
-    var tmpFiles = [];
-
-    // Create a tmp folder for downloaded files
-    var tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'get'));
-    var results = {};
-
-    var tmpdirPath = getPlatformTmpPath(tmpDir);
-    var getQuery = `GET ${stage} ${tmpdirPath}`;
+    const results = {};
+    const tmpdirPath = getPlatformTmpPath(tmpDir);
+    const getQuery = `GET ${stage} ${tmpdirPath}`;
 
     // Create temp files with specified prefix
+    tmpFiles = [];
     for (let i = 0; i < count; i++) {
-      var tmpFile = tmp.fileSync({ prefix: 'testUploadDownloadMultifiles'});
+      const tmpFile = tmp.fileSync({ prefix: 'testUploadDownloadMultifiles' });
       fs.writeFileSync(tmpFile.name, ROW_DATA);
       tmpFiles.push(tmpFile);
     }
 
-    var putQuery = `PUT file://${os.tmpdir()}/testUploadDownloadMultifiles* ${stage}`;
+    let putQuery = `PUT file://${os.tmpdir()}/testUploadDownloadMultifiles* ${stage}`;
     // Windows user contains a '~' in the path which causes an error
-    if (process.platform == "win32")
-    {
+    if (process.platform == 'win32') {
       putQuery = `PUT file://${process.env.USERPROFILE}\\AppData\\Local\\Temp\\testUploadDownloadMultifiles* ${stage}`;
     }
 
+    const testResult = [];
+
     async.series(
       [
-        function (callback)
-        {
-          fileSize = executePutCmd(connection, putQuery, callback, results);
+        function (callback) {
+          executePutCmd(connection, putQuery, callback, results);
         },
-        function (callback)
-        {
+        function (callback) {
           // Run GET command
-          var statement = connection.execute({
+          connection.execute({
             sqlText: getQuery,
-            complete: function (err, stmt, rows)
-            {
-              var stream = statement.streamRows();
-              stream.on('error', function (err)
-              {
+            complete: function (err, stmt) {
+              if (err) {
                 callback(err);
-              });
-              stream.on('data', function (row)
-              {
-                assert.strictEqual(row.status, DOWNLOADED);
-                assert.strictEqual(row.size, results.fileSize);
+              } else {
+                const stream = stmt.streamRows();
+                stream.on('error', function (err) {
+                  callback(err);
+                });
+                stream.on('data', function (row) {
+                  assert.strictEqual(row.status, DOWNLOADED);
+                  assert.strictEqual(row.size, results.fileSize);
 
-                // Decompress the downloaded file
-                var compressedFile = path.join(tmpDir,row.file);
-                var decompressedFile = path.join(tmpDir,'de-'+row.file);
-                const fileContents = fs.createReadStream(compressedFile);
-                const writeStream = fs.createWriteStream(decompressedFile);
-                const unzip = zlib.createGunzip();
+                  // Decompress the downloaded file
+                  const compressedFile = path.join(tmpDir, row.file);
+                  const decompressedFile = path.join(tmpDir, 'de-' + row.file);
+                  const fileContents = fs.createReadStream(compressedFile);
+                  const writeStream = fs.createWriteStream(decompressedFile);
+                  const unzip = zlib.createGunzip();
 
-                fileContents.pipe(unzip).pipe(writeStream).on('finish', function() {
-                  // Verify the data of the downloaded file
-                  var data = fs.readFileSync(decompressedFile).toString();
-                  assert.strictEqual(data, ROW_DATA);
-                  fs.unlinkSync(compressedFile);
-                  fs.unlinkSync(decompressedFile);
-                }) 
-              });
-              stream.on('end', function (row)
-              {
-                callback();
-              });
+                  fileContents.pipe(unzip).pipe(writeStream).on('finish', function () {
+                    // Verify the data of the downloaded file
+                    // this callback is called asynchronously so we gather results and in stream end we check if all files are correct
+                    const data = fs.readFileSync(decompressedFile).toString();
+                    try {
+                      assert.strictEqual(data, ROW_DATA);
+                      testResult.push(true);
+                    } catch (e) {
+                      testResult.push(e);
+                    }
+                  });
+                });
+                stream.on('end', function () {
+                  expectArrayToBeFinallyFilledWithTrue(count, testResult, callback);
+                });
+              }
             }
           });
         },
-        function (callback)
-        {
-          // Remove files from staging
-          testUtil.executeCmd(connection, removeFile, callback);
-        },
-        function (callback)
-        {
-          for (let i = 0; i < count; i++) {
-            fs.closeSync(tmpFiles[i].fd);
-            fs.unlinkSync(tmpFiles[i].name);
-          }
-          // Delete the temporary folder
-          fs.rmdir(tmpDir, (err) =>
-          {
-            if (err) throw (err);
-          });
-          callback();
-        }
       ],
       done
     );
   });
+
+  /**
+   * @param expectedResultSize `number` expected result size
+   * @param testResult `any[]` array with gathered results
+   * @param callback `(err|undefined) => void` done or async series callback function
+   */
+  function expectArrayToBeFinallyFilledWithTrue(expectedResultSize, testResult, callback){
+    const expectedResult = new Array(expectedResultSize).fill(true);
+    function checkResult() {
+      if(testResult.length >= expectedResultSize) {
+        try {
+          assert.deepEqual(testResult, expectedResult);
+          callback();
+        } catch (e){
+          callback(e);
+        }
+      } else {
+        setTimeout(checkResult, 100);
+      }
+    }
+
+    setTimeout(checkResult, 100);
+  }
 });


### PR DESCRIPTION
### Description
In `testArrayBindCustomerTable` and `testPutGet`:
- retry flaky tests with `mocha` built-in retry mechanism
- format files with `eslint`
- don't call `done` in `async.series` explicitly - use callback instead
- move common setup and teardown operations to before and after to ensure that for errors resources are correctly cleaned up

### Checklist
- [x] Format code according to the existing code style (run `npm run lint:check -- CHANGED_FILES` and fix problems in changed code)
- [x] Create tests which fail without the change (if possible)
- [x] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [x] Extend the README / documentation and ensure is properly displayed (if necessary)
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message
