### PR TITLE
fix process crash on put file command

### DIFF
--- a/lib/file_transfer_agent/file_util.js
+++ b/lib/file_transfer_agent/file_util.js
@@ -116,25 +116,19 @@ function file_util ()
     var fileInfo = fs.statSync(fileName);
     var bufferSize = fileInfo.size;
 
-    var buffer = [];
-    await new Promise(function (resolve, reject)
+    var hash = await new Promise(function (resolve, reject)
     {
+      var _hash = crypto.createHash('sha256');
+      _hash.setEncoding('base64');
       // Create reader stream and set maximum chunk size
       var infile = fs.createReadStream(fileName, { highWaterMark: chunkSize });
-      infile.on('data', function (chunk)
-      {
-        buffer.push(chunk);
-      });
       infile.on('close', function ()
       {
-        buffer = Buffer.concat(buffer);
-        resolve();
+        _hash.end();
+        resolve(_hash.read());
       });
+      infile.pipe(_hash);
     });
-
-    var hash = crypto.createHash('sha256')
-      .update(buffer)
-      .digest('base64');
 
     return {
       digest: hash,


### PR DESCRIPTION
put command uses getDigestAndSizeForFile() to generate hash for a file - this function read all file contents to buffer
and only after passed for hash generation. Issue is more critical if disable AUTO_COMPRESS and try to upload file. Current change uses stream instead to prevent crashes on a bigger files