### PR TITLE
SNOW-845753 - Add Jenkins user to allow list for cla assistant check

### DIFF
--- a/.github/workflows/cla_bot.yml
+++ b/.github/workflows/cla_bot.yml
@@ -24,7 +24,7 @@ jobs:
           path-to-signatures: 'signatures/version1.json'
           path-to-document: 'https://github.com/snowflakedb/CLA/blob/main/README.md'
           branch: 'main'
-          allowlist: 'dependabot[bot],github-actions'
+          allowlist: 'dependabot[bot],github-actions,Jenkins User,_jenkins'
           remote-organization-name: 'snowflakedb'
           remote-repository-name: 'cla-db'
           


### PR DESCRIPTION
### Description
CLA Assistant check has been failing for release branches. The failure is due the jenkins user used to create the branch and do the commit is not in the allow list in that check.
The fix is to add it.

### Checklist
- [ ] Format code according to the existing code style (run `npm run lint:check -- CHANGED_FILES` and fix problems in changed code)
- [ ] Create tests which fail without the change (if possible)
- [ ] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [ ] Extend the README / documentation and ensure is properly displayed (if necessary)
- [ ] Provide JIRA issue id (if possible) or GitHub issue id in commit message
