### PR TITLE
SNOW-841052: Bump fast-xml-parser and set audit level to high

### DIFF
--- a/ci/container/build_component.sh
+++ b/ci/container/build_component.sh
@@ -14,6 +14,7 @@ rm -f snowflake-sdk*.tgz
 echo "[DEBUG] Version"
 npm version
 echo "[DEBUG] Installing newer node - bundled npm version 6.0.1 does not support setting audit level"
+# TODO SNOW-847264: Don't install node manually when proper build image will be used
 export NVM_PARENT_DIR=`pwd`/ignore
 mkdir -p $NVM_PARENT_DIR
 export NVM_DIR="$NVM_PARENT_DIR/nvm"
@@ -25,7 +26,7 @@ echo "[DEBUG] Installing"
 npm install
 rm -f ~/.npmrc
 echo "[DEBUG] Auditing"
-npm audit --audit-level moderate # TODO SNOW-841052 fast-xml-parser has low vulnerability - when new version will be released `moderate` option should be removed
+npm audit --audit-level high # TODO SNOW-841052: semver (indirect dep of urllib) has moderate vulnerability - when fix will be available `high` option should be removed
 
 echo "[INFO] Uploading Artifacts"
 ARTIFACTS=($(ls snowflake-sdk*))

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "debug": "^3.2.6",
     "expand-tilde": "^2.0.2",
     "extend": "^3.0.2",
-    "fast-xml-parser": "^4.1.3",
+    "fast-xml-parser": "^4.2.5",
     "generic-pool": "^3.8.2",
     "glob": "^7.1.6",
     "https-proxy-agent": "^5.0.1",


### PR DESCRIPTION
### Description
- bump fast-xml-parser to minimal version 4.2.5 which contains fix for low vulnerability
- set npm audit level to high to fix CI build - semver installed via urllib has 2 moderate vulnerabilities

### Checklist
- [x] Format code according to the existing code style (run `npm run lint:check -- CHANGED_FILES` and fix problems in changed code)
- [x] Create tests which fail without the change (if possible)
- [x] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [x] Extend the README / documentation and ensure is properly displayed (if necessary)
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message
