### PR TITLE
SNOW-852382: Run Windows CI build on azure and gcp

### DIFF
--- a/ci/scripts/set_git_info.sh
+++ b/ci/scripts/set_git_info.sh
@@ -11,12 +11,15 @@ if [[ -z "$GITHUB_ACTIONS" ]]; then
     export client_git_commit=${client_git_commit:-$(git log --pretty=oneline | head -1 | awk '{print $1}')}
 else
     if [[ "$CLOUD_PROVIDER" == "AZURE" ]]; then
-        gpg --quiet --batch --yes --decrypt --passphrase="$PARAMETERS_SECRET" --output $THIS_DIR/../parameters.json $THIS_DIR/../.github/workflows/parameters_azure.json.gpg
+        ENCODED_PARAMETERS_FILE="$THIS_DIR/../.github/workflows/parameters_azure.json.gpg"
     elif [[ "$CLOUD_PROVIDER" == "GCP" ]]; then
-        gpg --quiet --batch --yes --decrypt --passphrase="$PARAMETERS_SECRET" --output $THIS_DIR/../parameters.json $THIS_DIR/../.github/workflows/parameters_gcp.json.gpg
+        ENCODED_PARAMETERS_FILE="$THIS_DIR/../.github/workflows/parameters_gcp.json.gpg"
+    elif [[ "$CLOUD_PROVIDER" == "AWS" ]]; then
+        ENCODED_PARAMETERS_FILE="$THIS_DIR/../.github/workflows/parameters_aws.json.gpg"
     else
-        gpg --quiet --batch --yes --decrypt --passphrase="$PARAMETERS_SECRET" --output $THIS_DIR/../parameters.json $THIS_DIR/../.github/workflows/parameters_aws.json.gpg
+        echo "[ERROR] unknown cloud provider"
     fi
+    gpg --quiet --batch --yes --decrypt --passphrase="$PARAMETERS_SECRET" --output $THIS_DIR/../parameters.json $ENCODED_PARAMETERS_FILE
     export client_git_url=https://github.com/${GITHUB_REPOSITORY}.git
     export client_git_branch=origin/$(basename ${GITHUB_REF})
     export client_git_commit=${GITHUB_SHA}

--- a/ci/test_windows.bat
+++ b/ci/test_windows.bat
@@ -8,7 +8,16 @@ call venv\scripts\activate
 pip install -U snowflake-connector-python
 
 cd %GITHUB_WORKSPACE%
-gpg --quiet --batch --yes --decrypt --passphrase=%PARAMETERS_SECRET% --output parameters.json .github/workflows/parameters_aws.json.gpg
+
+if "%CLOUD_PROVIDER%"=="AZURE" (
+  set ENCODED_PARAMETERS_FILE=.github/workflows/parameters_azure.json.gpg
+) else if "%CLOUD_PROVIDER%"=="GCP" (
+  set ENCODED_PARAMETERS_FILE=.github/workflows/parameters_gcp.json.gpg
+) else (
+  set ENCODED_PARAMETERS_FILE=.github/workflows/parameters_aws.json.gpg
+)
+
+gpg --quiet --batch --yes --decrypt --passphrase=%PARAMETERS_SECRET% --output parameters.json %ENCODED_PARAMETERS_FILE%
 
 REM DON'T FORGET TO include @echo off here or the password may be leaked!
 echo @echo off>parameters.bat

--- a/ci/test_windows.bat
+++ b/ci/test_windows.bat
@@ -13,8 +13,11 @@ if "%CLOUD_PROVIDER%"=="AZURE" (
   set ENCODED_PARAMETERS_FILE=.github/workflows/parameters_azure.json.gpg
 ) else if "%CLOUD_PROVIDER%"=="GCP" (
   set ENCODED_PARAMETERS_FILE=.github/workflows/parameters_gcp.json.gpg
-) else (
+) else if "%CLOUD_PROVIDER%"=="AWS" (
   set ENCODED_PARAMETERS_FILE=.github/workflows/parameters_aws.json.gpg
+) else (
+  echo === unknown cloud provider
+  exit /b 1
 )
 
 gpg --quiet --batch --yes --decrypt --passphrase=%PARAMETERS_SECRET% --output parameters.json %ENCODED_PARAMETERS_FILE%


### PR DESCRIPTION
### Description
Let's Windows CI test scripts do not ignore CLOUD_PROVIDER env variable

### Checklist
- [x] Format code according to the existing code style (run `npm run lint:check -- CHANGED_FILES` and fix problems in changed code)
- [x] Create tests which fail without the change (if possible)
- [x] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [x] Extend the README / documentation and ensure is properly displayed (if necessary)
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message
