### PR TITLE
Force GCP strange behaviour

### DIFF
--- a/lib/services/large_result_set.js
+++ b/lib/services/large_result_set.js
@@ -67,6 +67,9 @@ function LargeResultSetService(connectionConfig, httpClient)
     // invoked when the request completes
     const callback = function callback(err, response, body)
     {
+      if (response) {
+        Logger.getInstance().trace(`Response: content-type is ${response.getResponseHeader('Content-Type')} and content-encoding is ${response.getResponseHeader('Content-Encoding')}`)
+      }
       // err happens on timeouts and response is passed when server responded
       if (err || isUnsuccessfulResponse(response))
       {

--- a/test/integration/testLargeResultSet.js
+++ b/test/integration/testLargeResultSet.js
@@ -4,10 +4,11 @@
 const assert = require('assert');
 const async = require('async');
 const testUtil = require('./testUtil');
+const { configureLogger } = require('../configureLogger');
 
 const sourceRowCount = 10000;
 
-describe('Large result Set Tests', function ()
+describe.only('Large result Set Tests', function ()
 {
   let connection;
   const selectAllFromOrders = `select randstr(1000,random()) from table(generator(rowcount=>${sourceRowCount}))`;
@@ -16,7 +17,12 @@ describe('Large result Set Tests', function ()
   {
     connection = testUtil.createConnection();
     await testUtil.connectAsync(connection);
+    // setting ROWS_PER_RESULTSET causes invalid, not encoded chunks from GCP
+    await testUtil.executeCmdAsync(connection, 'alter session set ROWS_PER_RESULTSET = 1000000');
   });
+
+  beforeEach(() => configureLogger('TRACE'));
+  afterEach(() => configureLogger('ERROR'));
 
   after(async () =>
   {


### PR DESCRIPTION
### Description
Setting ROWS_PER_RESULTSET on session makes GCP responses strange.

### Checklist
- [ ] Format code according to the existing code style (run `npm run lint:check -- CHANGED_FILES` and fix problems in changed code)
- [ ] Create tests which fail without the change (if possible)
- [ ] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [ ] Extend the README / documentation and ensure is properly displayed (if necessary)
- [ ] Provide JIRA issue id (if possible) or GitHub issue id in commit message
