### PR TITLE
SNOW-847264: Always run tests on node v12 and drop centos6 test builds

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -107,7 +107,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                image: [ 'nodejs-centos6-default', 'nodejs-centos7-node12' ]
+                image: [ 'nodejs-centos7-node12' ]
                 cloud: [ 'AWS' ]
         steps:
             - uses: actions/checkout@v1
@@ -191,7 +191,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                image: [ 'nodejs-centos6-default', 'nodejs-centos7-node12' ]
+                image: [ 'nodejs-centos7-node12' ]
                 #REMOVE AZURE for now
                 #cloud: [ 'AZURE', 'GCP' ]
                 cloud: [ 'GCP' ]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,7 @@ timestamps {
       string(name: 'branch', value: 'main'),
       string(name: 'client_git_commit', value: scmInfo.GIT_COMMIT),
       string(name: 'client_git_branch', value: scmInfo.GIT_BRANCH),
-      string(name: 'TARGET_DOCKER_TEST_IMAGE', value: 'nodejs-centos6-default'),
+      string(name: 'TARGET_DOCKER_TEST_IMAGE', value: 'nodejs-centos7-node12'),
       string(name: 'parent_job', value: env.JOB_NAME),
       string(name: 'parent_build_number', value: env.BUILD_NUMBER)
     ]

--- a/ci/container/test_component.sh
+++ b/ci/container/test_component.sh
@@ -28,22 +28,17 @@ fi
 echo "[INFO] Build is using node versions"
 npm version
 
-set +e
-npm version | grep "node: '12"
-usingNode12=$?
-set -e
-if [ $usingNode12 -eq 0 ]
-then
-  echo "[DEBUG] We are using node v12"
-else
+usingNode12=$(npm version | grep "node: '12" || true)
+if [[ -z ${usingNode12} ]]; then
   echo "[DEBUG] Installing newer node 12"
   export NVM_DIR=`pwd`/nvm
   cp -r /usr/local/nvm $NVM_DIR
   source $NVM_DIR/nvm.sh
   nvm install 12
-
   echo "[INFO] Build is using node versions"
   npm version
+else
+  echo "[DEBUG] We are using node v12"
 fi
 
 echo "[INFO] Installing"

--- a/ci/container/test_component.sh
+++ b/ci/container/test_component.sh
@@ -24,6 +24,29 @@ if [[ "$LOCAL_USER_NAME" == "jenkins" ]]; then
 else
     export PATH=$WORKSPACE/node_modules/mocha/bin:$PATH
 fi
+
+echo "[INFO] Build is using node versions"
+npm version
+
+set +e
+npm version | grep "node: '12"
+usingNode12=$?
+set -e
+if [ $usingNode12 -eq 0 ]
+then
+  echo "[DEBUG] We are using node v12"
+else
+  echo "[DEBUG] Installing newer node 12"
+  export NVM_DIR=`pwd`/nvm
+  cp -r /usr/local/nvm $NVM_DIR
+  source $NVM_DIR/nvm.sh
+  nvm install 12
+
+  echo "[INFO] Build is using node versions"
+  npm version
+fi
+
+echo "[INFO] Installing"
 cp $SOURCE_ROOT/ci/container/package.json .
 npm install
 


### PR DESCRIPTION
### Description
- Ensure that builds run on lowest supported major node version (v12)
- Don't run tests on centos 6

### Checklist
- [x] Format code according to the existing code style (run `npm run lint:check -- CHANGED_FILES` and fix problems in changed code)
- [x] Create tests which fail without the change (if possible)
- [x] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [x] Extend the README / documentation and ensure is properly displayed (if necessary)
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message
