### PR TITLE
revert word-wrap upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "@azure/storage-blob": {
       "node-fetch": "^3.2.10"
     },
-    "word-wrap" : "npm:@aashutoshrathi/word-wrap@1.2.6",
     "semver": "^7.5.2"
   },
   "repository": {


### PR DESCRIPTION
Latest word-wrap is released and is automatically downloaded by urllib. we no longer needs to override it.