### PR TITLE
SNOW-502598: Enable executing queries with `asyncExec: true`

### DIFF
--- a/lib/connection/statement.js
+++ b/lib/connection/statement.js
@@ -198,6 +198,7 @@ exports.createStatementPostExec = function (
   statementContext.complete = complete;
   statementContext.streamResult = statementOptions.streamResult;
   statementContext.fetchAsString = statementOptions.fetchAsString;
+  statementContext.asyncExec = statementOptions.asyncExec;
   statementContext.multiResultIds = statementOptions.multiResultIds;
   statementContext.multiCurId = statementOptions.multiCurId;
 
@@ -361,6 +362,7 @@ function createContextPreExec(
   statementContext.complete = complete;
   statementContext.streamResult = statementOptions.streamResult;
   statementContext.fetchAsString = statementOptions.fetchAsString;
+  statementContext.asyncExec = statementOptions.asyncExec;
   statementContext.multiResultIds = statementOptions.multiResultIds;
   statementContext.multiCurId = statementOptions.multiCurId;
 
@@ -672,6 +674,13 @@ function invokeStatementComplete(statement, context)
   }
   else
   {
+    // if the result is not an instance of Result, then asyncExec was true, and we should just return the result object
+    // with the query ID inside.
+    if (!(context.result instanceof Result))
+    {
+      context.complete(null, statement, context.result);
+      return;
+    }
     process.nextTick(function ()
     {
       // aggregate all the rows into an array and pass this
@@ -768,6 +777,12 @@ function createOnStatementRequestSuccRow(statement, context)
     // if we don't already have a result
     if (!context.result)
     {
+      if (context.asyncExec && body && (body.code === '333333' || body.code === '333334')) {
+        context.result = {
+          queryId: body.data.queryId
+        };
+        return;
+      }
       if (body.data.resultIds != undefined && body.data.resultIds.length > 0)
       {
         //multi statements
@@ -1148,7 +1163,9 @@ function createFnStreamRows(statement, context)
       }
     }
 
-    return new RowStream(statement, context, options);
+    return context.result instanceof Result
+      ? new RowStream(statement, context, options)
+      : context.result;
   };
 }
 
@@ -1305,6 +1322,10 @@ function sendRequestPreExec(statementContext, onResultAvailable)
     json.isInternal = statementContext.internal;
   }
 
+  if (Util.exists(statementContext.asyncExec)) {
+    json.asyncExec = statementContext.asyncExec
+  }
+
   // use the snowflake service to issue the request
   sendSfRequest(statementContext,
     {
@@ -1358,6 +1379,10 @@ this.sendRequest = function (statementContext, onResultAvailable)
   if (Util.exists(statementContext.internal))
   {
     json.isInternal = statementContext.internal;
+  }
+
+  if (Util.exists(statementContext.asyncExec)) {
+    json.asyncExec = statementContext.asyncExec
   }
 
   var options =
@@ -1607,9 +1632,14 @@ function buildResultRequestCallback(
       statementContext.statementId = body.data.queryId;
 
       // if the result is not ready yet, extract the result url from the response
-      // and issue a GET request to try to fetch the result again
+      // and issue a GET request to try to fetch the result again, unless asyncExec is specified.
       if (body && (body.code === '333333' || body.code === '333334'))
       {
+        if (statementContext.asyncExec)
+        {
+          await onResultAvailable.call(null, err, body);
+          return;
+        }
         // extract the result url from the response and try to get the result
         // again
         sendSfRequest(statementContext,

--- a/lib/connection/statement.js
+++ b/lib/connection/statement.js
@@ -676,7 +676,7 @@ function invokeStatementComplete(statement, context)
   {
     // if the result is not an instance of Result, then asyncExec was true, and we should just return the result object
     // with the query ID inside.
-    if (!(context.result instanceof Result))
+    if (context.asyncExec && !(context.result instanceof Result))
     {
       context.complete(null, statement, context.result);
       return;
@@ -1163,7 +1163,7 @@ function createFnStreamRows(statement, context)
       }
     }
 
-    return context.result instanceof Result
+    return !context.asyncExec
       ? new RowStream(statement, context, options)
       : context.result;
   };


### PR DESCRIPTION
### Description

My team is using the JavaScript Snowflake SDK. We need to be able to execute queries without waiting for the result. I see that the JavaScript Snowflake SDK has functionality for polling query results, a Result class, a RowStream class, etc.; however, it would be sufficient for us if we could just issue a request with `asyncExec: true`, get the Snowflake query ID back, and then monitor the query ourselves (for example, using [RESULT_SCAN](https://docs.snowflake.com/en/sql-reference/functions/result_scan)).

With this in mind, I've tried to create a small patch that does just that. This may partially address SNOW-502598 (see #486 and #208). I've also prepared a patch for @types/snowflake-sdk:

```diff
--- a/index.d.ts
+++ b/index.d.ts
@@ -571,7 +571,13 @@ export type Connection = NodeJS.EventEmitter & {
          * - {@link https://docs.snowflake.com/en/user-guide/nodejs-driver-use.html#fetching-data-types-as-strings Fetching Data Types As Strings}
          */
         fetchAsString?: Array<'String' | 'Boolean' | 'Number' | 'Date' | 'JSON' | 'Buffer'> | undefined;
-        complete?: (err: SnowflakeError | undefined, stmt: Statement, rows: any[] | undefined) => void;
+
+        /**
+         * Set to `true` to execute the query asynchronously, and the `complete` callback will receive an object with the query ID.
+         */
+        asyncExec?: boolean
+
+        complete?: (err: SnowflakeError | undefined, stmt: Statement, result: any[] | { queryId: string } | undefined) => void;
     }): Statement;
 
     /**
```

If you use Yarn v2 or later, you can try these changes out by

1. Updating your dependency to `git@github.com:propeldata/snowflake-connector-nodejs.git#head=asyncExec`
2. Using `yarn patch` to apply the @types/snowflake-sdk patch above.

### Warning

**This is definitely a hack,** because the JavaScript Snowflake SDK's `execute` method is supposed to return a Statement object with APIs you can invoke, like `getColumns` and `streamRows`. These are probably not working with this patch; however, my team does not use these APIs anyway. We typically invoke the JavaScript Snowflake SDK as follows:

```ts
const { queryId } = new Promise((resolve, reject) => {
  client.execute({
    sqlText: 'CALL SYSTEM$WAIT(5, \'MINUTES\')',
    asyncExec: true,
    complete (err, _stmt, result) {
      if (err != null) {
        reject(err)
      } else {
        resolve(result)
      }
    }
  })
})
```

I would look to the JavaScript Snowflake SDK team for ideas on how to better integrate this functionality with the Statement object. Perhaps, when `asyncExec: true` is set, we should just synthesize a Result with a RowStream containing a singular row. That singular row could contain a singular column with the query ID. Maybe this would make sense?

### Checklist
- [x] Format code according to the existing code style (run `npm run lint:check -- CHANGED_FILES` and fix problems in changed code)
- [ ] Create tests which fail without the change (if possible)
- [x] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [ ] Extend the README / documentation and ensure is properly displayed (if necessary)
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message
