### PR TITLE
SNOW-872497: Fix windows + azure problem when getting files from stage

### DIFF
--- a/lib/file_transfer_agent/azure_util.js
+++ b/lib/file_transfer_agent/azure_util.js
@@ -250,8 +250,7 @@ function azure_util(azure, filestream) {
           writer.write(data);
         });
         readableStream.on('end', () => {
-          writer.end();
-          resolve();
+          writer.end(resolve);
         });
         readableStream.on('error', reject);
       });

--- a/test/integration/testPutGet.js
+++ b/test/integration/testPutGet.js
@@ -647,8 +647,6 @@ describe('PUT GET test with GCS_USE_DOWNSCOPED_CREDENTIAL', function () {
 });
 
 describe('PUT GET test with multiple files', function () {
-  this.retries(3); // this test suit are considered as flaky test
-
   let connection;
   let tmpDir;
   const stage = `@${DATABASE_NAME}.${SCHEMA_NAME}.%${TEMP_TABLE_NAME}`;


### PR DESCRIPTION
### Description
`resolve` should be called as callback when finishing reading file from Azure Blob Storage. Without that received stream was often empty and we receive error:
```
1) PUT GET test multiple files
       testUploadMultifiles:
     Uncaught Error: error:0606506D:digital envelope routines:EVP_DecryptFinal_ex:wrong final block length
      at Decipheriv.final (internal/crypto/cipher.js:172:29)
      at ReadStream.<anonymous> (D:\a\snowflake-connector-nodejs\snowflake-connector-nodejs\lib\file_transfer_agent\encrypt_util.js:272:32)
      at ReadStream.emit (events.js:314:20)
      at ReadStream.EventEmitter.emit (domain.js:483:12)
      at internal/fs/streams.js:247:14
      at FSReqCallback.oncomplete (fs.js:156:23)
```

### Checklist
- [x] Format code according to the existing code style (run `npm run lint:check -- CHANGED_FILES` and fix problems in changed code)
- [x] Create tests which fail without the change (if possible)
- [x] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [x] Extend the README / documentation and ensure is properly displayed (if necessary)
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message
