### PR TITLE
SNOW-886505: Add CodeCov token to github action

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -213,24 +213,16 @@ jobs:
         name: Upload code coverage
         runs-on: ubuntu-latest
         steps:
-          - name: Checkout # it is still recommended to checkout https://about.codecov.io/blog/uploading-code-coverage-in-a-separate-job-on-github-actions/
+          - name: Checkout # it is still recommended to check out https://about.codecov.io/blog/uploading-code-coverage-in-a-separate-job-on-github-actions/
             uses: actions/checkout@v3
           - name: Download code coverage result
             uses: actions/download-artifact@v3
             with:
               name: codeCoverage
               path: coverage
-          # codecov action sometimes fails but retry works - until action provides retry let's retry on our own https://github.com/codecov/codecov-action/issues/926
-          - name: Upload coverage reports to Codecov with GitHub Action (take 1)
-            id: uploadToCodeCovTake1
-            uses: codecov/codecov-action@v3
-            continue-on-error: true
-            with:
-              fail_ci_if_error: true
-          - name: Upload coverage reports to Codecov with GitHub Action (take 2)
-            id: uploadToCodeCovTake2
-            # only run when take 1 failed
-            if: steps.uploadToCodeCovTake1.outcome == 'failure'
+          - name: Upload coverage reports to Codecov
             uses: codecov/codecov-action@v3
             with:
+              # without the token code cov may fail because of Github limits https://github.com/codecov/codecov-action/issues/557
+              token: ${{ secrets.CODE_COV_UPLOAD_TOKEN }}
               fail_ci_if_error: true


### PR DESCRIPTION
### Description
CodeCov github action should be more stable with token and don't fail on Github limits

### Checklist
- [x] Format code according to the existing code style (run `npm run lint:check -- CHANGED_FILES` and fix problems in changed code)
- [x] Create tests which fail without the change (if possible)
- [x] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [x] Extend the README / documentation and ensure is properly displayed (if necessary)
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message
