### PR TITLE
adding encoding as a devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "winston": "^3.1.0"
   },
   "devDependencies": {
+    "encoding": "^0.1.13",
     "eslint": "^8.41.0",
     "mocha": "^10.1.0",
     "mock-require": "^3.0.3",


### PR DESCRIPTION
should fix https://github.com/snowflakedb/snowflake-connector-nodejs/issues/609

the older versions of `node-fetch` on which some of our dependencies depend, use `encoding` as an optional peerDependency. v3 of `node-fetch` eliminated this dependency and due to [an override](https://github.com/snowflakedb/snowflake-connector-nodejs/pull/346), we are already using it, however some of our dependencies still depend on the older `node-fetch` versions:
```
# npm ls node-fetch
snowflake-sdk@1.7.0 /node/snowflake-connector-nodejs
+-- @azure/storage-blob@12.15.0 overridden
| `-- @azure/core-http@3.0.2
|   `-- node-fetch@3.3.2.  <<< v3
`-- @google-cloud/storage@6.12.0
  +-- gaxios@5.1.3
  | `-- node-fetch@2.6.12.  <<< v2
  `-- teeny-request@8.0.3
    `-- node-fetch@2.6.12.  <<< v2
```

As a result, in certain cases users of `snowflake-sdk` can see a warning message like
```
Module not found: Can't resolve 'encoding' in 'path/node_modules/node-fetch/lib'
```

which is literally nothing but a warning message as everything works correctly, but it would be nice perhaps to get rid of this warning too.

I thought perhaps we could address this issue by bumping the dependencies (e.g. the GCP Storage) but even in their latest versions they seem to depend on `gaxios` which for now depends on v2 of `node-fetch` and looking at issues gaxios#508 and gaxios#445, I'm not sure how realistic is to think it will be moved to `node-fetch` v3 in the near future. Did not look at `teeny-request` therefore.

Users around the world are working around this issue with running `npm i -D encoding` in their projects, see links in the linked issue.

So maybe we can address this in `snowflake-sdk`, by adding `encoding` as an (unused) devDependency.