### PR TITLE
SNOW-890305: Bump minor urllib and delete vm2 exclusion

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "simple-lru-cache": "^0.0.2",
     "string-similarity": "^4.0.4",
     "tmp": "^0.2.1",
-    "urllib": "^2.38.0",
+    "urllib": "^2.41.0",
     "uuid": "^3.3.2",
     "winston": "^3.1.0"
   },
@@ -49,8 +49,7 @@
     "@azure/storage-blob": {
       "node-fetch": "^3.2.10"
     },
-    "semver": "^7.5.2",
-    "vm2": "../_EXCLUDED_"
+    "semver": "^7.5.2"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Description
- Bump urllib 2.x minor version
- remove vm2 exclusion (since it is not required transitive dependency of urllib@2 anymore)

### Checklist
- [x] Format code according to the existing code style (run `npm run lint:check -- CHANGED_FILES` and fix problems in changed code)
- [x] Create tests which fail without the change (if possible)
- [x] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [x] Extend the README / documentation and ensure is properly displayed (if necessary)
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message
