### PR TITLE
SNOW-891285: Move async to dev dependencies

### DIFF
--- a/ci/container/package.json
+++ b/ci/container/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodejs_driver_test",
-  "version": "1.6.20",
+  "version": "1.7.0",
   "description": "Tests for Snowflake Nodejs Driver",
   "main": "index.js",
   "scripts": {
@@ -10,13 +10,10 @@
   },
   "devDependencies": {
     "async": "^3.2.3",
-    "insert-module-globals": "^7.2.0",
     "mocha": "^5.2.0",
     "mock-require": "^3.0.3",
     "nyc": "^15.1.0",
-    "test-console": "^2.0.0",
-    "vinyl-buffer": "^1.0.1",
-    "vinyl-source-stream": "^1.1.2"
+    "test-console": "^2.0.0"
   },
   "author": "Snowflake, Inc.",
   "license": "ISC"

--- a/lib/connection/statement.js
+++ b/lib/connection/statement.js
@@ -2,7 +2,6 @@
  * Copyright (c) 2015-2019 Snowflake Computing Inc. All rights reserved.
  */
 
-const async = require('async');
 const { v4: uuidv4 } = require('uuid');
 
 var Url = require('url');

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "agent-base": "^6.0.2",
     "asn1.js-rfc2560": "^5.0.0",
     "asn1.js-rfc5280": "^3.0.0",
-    "async": "^3.2.3",
     "aws-sdk": "^2.878.0",
     "axios": "^0.27.2",
     "big-integer": "^1.6.43",
@@ -39,6 +38,7 @@
     "winston": "^3.1.0"
   },
   "devDependencies": {
+    "async": "^3.2.3",
     "eslint": "^8.41.0",
     "mocha": "^10.1.0",
     "mock-require": "^3.0.3",


### PR DESCRIPTION
### Description
- async library is not used in production code, so it can be moved to dev dependencies
- additionally from test package.json some old, unused libraries can be removed and version should be synchronyzed with driver version

### Checklist
- [x] Format code according to the existing code style (run `npm run lint:check -- CHANGED_FILES` and fix problems in changed code)
- [x] Create tests which fail without the change (if possible)
- [x] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [x] Extend the README / documentation and ensure is properly displayed (if necessary)
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message
