### PR TITLE
SNOW-749232: Upgrade to aws-sdk v3

### DIFF
--- a/lib/file_transfer_agent/file_transfer_agent.js
+++ b/lib/file_transfer_agent/file_transfer_agent.js
@@ -574,7 +574,6 @@ function file_transfer_agent(context)
       var s3location = SnowflakeS3Util.extractBucketNameAndPath(stageInfo['location']);
 
       await client.getBucketAccelerateConfiguration({ Bucket: s3location.bucketName })
-        .promise()
         .then(function (data)
         {
           useAccelerateEndpoint = data['Status'] == 'Enabled';

--- a/lib/file_transfer_agent/s3_util.js
+++ b/lib/file_transfer_agent/s3_util.js
@@ -4,16 +4,15 @@
 
 const EncryptionMetadata = require('./encrypt_util').EncryptionMetadata;
 const FileHeader = require('./file_util').FileHeader;
-
 const expandTilde = require('expand-tilde');
 
-const AMZ_IV = "x-amz-iv";
-const AMZ_KEY = "x-amz-key";
-const AMZ_MATDESC = "x-amz-matdesc";
+const AMZ_IV = 'x-amz-iv';
+const AMZ_KEY = 'x-amz-key';
+const AMZ_MATDESC = 'x-amz-matdesc';
 const SFC_DIGEST = 'sfc-digest';
 
 const EXPIRED_TOKEN = 'ExpiredToken';
-const NO_SUCH_KEY= 'NoSuchKey';
+const NO_SUCH_KEY = 'NoSuchKey';
 
 const ERRORNO_WSAECONNABORTED = 10053;  // network connection was aborted
 
@@ -22,147 +21,125 @@ const resultStatus = require('./file_util').resultStatus;
 const HTTP_HEADER_VALUE_OCTET_STREAM = 'application/octet-stream';
 
 // S3 Location: S3 bucket name + path
-function S3Location(bucketName, s3path)
-{
+function S3Location (bucketName, s3path) {
   return {
-    "bucketName": bucketName, // S3 bucket name
-    "s3path": s3path // S3 path name
-  }
+    'bucketName': bucketName, // S3 bucket name
+    's3path': s3path // S3 path name
+  };
 }
 
 /**
  * Creates an S3 utility object.
- * 
+ *
  * @param {module} s3
  * @param {module} filestream
- * 
+ *
  * @returns {Object}
  * @constructor
  */
-function s3_util(s3, filestream)
-{
-  const AWS = typeof s3 !== "undefined" ? s3 : require('aws-sdk');
-  const fs = typeof filestream !== "undefined" ? filestream : require('fs');
+function s3_util (s3, filestream) {
+  const AWS = typeof s3 !== 'undefined' ? s3 : require('@aws-sdk/client-s3');
+  const fs = typeof filestream !== 'undefined' ? filestream : require('fs');
 
   // magic number, given from  error message.
   this.DATA_SIZE_THRESHOLD = 67108864;
 
   /**
-  * Create an AWS S3 client using an AWS token.
-  *
-  * @param {Object} stageInfo
-  *
-  * @returns {String}
-  */
-  this.createClient = function (stageInfo, useAccelerateEndpoint)
-  {
-    var stageCredentials = stageInfo['creds'];
-    var securityToken = stageCredentials['AWS_TOKEN'];
+   * Create an AWS S3 client using an AWS token.
+   *
+   * @param {Object} stageInfo
+   *
+   * @returns {AWS.S3}
+   */
+  this.createClient = function (stageInfo, useAccelerateEndpoint) {
+    const stageCredentials = stageInfo['creds'];
+    const securityToken = stageCredentials['AWS_TOKEN'];
 
     // if GS sends us an endpoint, it's likely for FIPS. Use it.
-    var endPoint = null;
-    if (stageInfo['endPoint'])
-    {
+    let endPoint = null;
+    if (stageInfo['endPoint']) {
       endPoint = 'https://' + stageInfo['endPoint'];
     }
 
-    var config = {
+    const config = {
       apiVersion: '2006-03-01',
-      signatureVersion: 'v4',
       region: stageInfo['region'],
-      accessKeyId: stageCredentials['AWS_KEY_ID'],
-      secretAccessKey: stageCredentials['AWS_SECRET_KEY'],
-      sessionToken: securityToken,
+      credentials: {
+        accessKeyId: stageCredentials['AWS_KEY_ID'],
+        secretAccessKey: stageCredentials['AWS_SECRET_KEY'],
+        sessionToken: securityToken,
+      },
       endpoint: endPoint,
-      useAccelerateEndpoint: useAccelerateEndpoint
+      useAccelerateEndpoint: useAccelerateEndpoint,
     };
 
-    var s3 = new AWS.S3(config);
-
-    return s3;
-  }
+    return new AWS.S3(config);
+  };
 
   /**
-  * Extract the bucket name and path from the metadata's stage location.
-  *
-  * @param {String} stageLocation
-  *
-  * @returns {Object}
-  */
-  this.extractBucketNameAndPath = function (stageLocation)
-  {
+   * Extract the bucket name and path from the metadata's stage location.
+   *
+   * @param {String} stageLocation
+   *
+   * @returns {Object}
+   */
+  this.extractBucketNameAndPath = function (stageLocation) {
     // expand '~' and '~user' expressions
-    if (process.platform !== "win32")
-    {
+    if (process.platform !== 'win32') {
       stageLocation = expandTilde(stageLocation);
     }
 
-    var bucketName = stageLocation;
-    var s3path;
+    let bucketName = stageLocation;
+    let s3path;
 
     // split stage location as bucket name and path
-    if (stageLocation.includes('/'))
-    {
+    if (stageLocation.includes('/')) {
       bucketName = stageLocation.substring(0, stageLocation.indexOf('/'));
 
       s3path = stageLocation.substring(stageLocation.indexOf('/') + 1, stageLocation.length);
-      if (s3path && !s3path.endsWith('/'))
-      {
+      if (s3path && !s3path.endsWith('/')) {
         s3path += '/';
       }
     }
     return S3Location(bucketName, s3path);
-  }
+  };
 
   /**
-  * Create file header based on file being uploaded or not.
-  *
-  * @param {Object} meta
-  * @param {String} filename
-  *
-  * @returns {Object}
-  */
-  this.getFileHeader = async function (meta, filename)
-  {
-    var stageInfo = meta['stageInfo'];
-    var client = this.createClient(stageInfo);
-    var s3location = this.extractBucketNameAndPath(stageInfo['location']);
+   * Get file header based on file being uploaded or not.
+   *
+   * @param {Object} meta
+   * @param {String} filename
+   *
+   * @returns {Object}
+   */
+  this.getFileHeader = async function (meta, filename) {
+    const stageInfo = meta['stageInfo'];
+    const client = this.createClient(stageInfo);
+    const s3location = this.extractBucketNameAndPath(stageInfo['location']);
 
-    var params = {
+    const params = {
       Bucket: s3location.bucketName,
       Key: s3location.s3path + filename
     };
 
-    var akey;
+    let akey;
 
-    try
-    {
+    try {
       await client.getObject(params)
-        .promise()
-        .then(function (data)
-        {
+        .then(function (data) {
           akey = data;
-        })
-    }
-    catch (err)
-    {
-      if (err['code'] == EXPIRED_TOKEN)
-      {
+        });
+    } catch (err) {
+      if (err['Code'] == EXPIRED_TOKEN) {
         meta['resultStatus'] = resultStatus.RENEW_TOKEN;
         return null;
-      }
-      else if (err['code'] == NO_SUCH_KEY)
-      {
+      } else if (err['Code'] == NO_SUCH_KEY) {
         meta['resultStatus'] = resultStatus.NOT_FOUND_FILE;
         return FileHeader(null, null, null);
-      }
-      else if (err['code'] == '400')
-      {
+      } else if (err['Code'] == '400') {
         meta['resultStatus'] = resultStatus.RENEW_TOKEN;
         return null;
-      }
-      else
-      {
+      } else {
         meta['resultStatus'] = resultStatus.ERROR;
         return null;
       }
@@ -170,9 +147,8 @@ function s3_util(s3, filestream)
 
     meta['resultStatus'] = resultStatus.UPLOADED;
 
-    var encryptionMetadata;
-    if (akey && akey.Metadata[AMZ_KEY])
-    {
+    let encryptionMetadata;
+    if (akey && akey.Metadata[AMZ_KEY]) {
       encryptionMetadata = EncryptionMetadata(
         akey.Metadata[AMZ_KEY],
         akey.Metadata[AMZ_IV],
@@ -185,54 +161,45 @@ function s3_util(s3, filestream)
       akey.ContentLength,
       encryptionMetadata
     );
-  }
+  };
 
- /**
-  * Create the file metadata then upload the file.
-  *
-  * @param {String} dataFile
-  * @param {Object} meta
-  * @param {Object} encryptionMetadata
-  * @param {Number} maxConcurrency
-  *
-  * @returns {null}
-  */
-  this.uploadFile = async function (dataFile, meta, encryptionMetadata, maxConcurrency)
-  {
-    var fileStream = fs.readFileSync(dataFile);
-    await this.uploadFileStream(fileStream, meta, encryptionMetadata, maxConcurrency);
-  }
-    
   /**
-  * Create the file metadata then upload the file stream.
-  *
-  * @param {String} fileStream
-  * @param {Object} meta
-  * @param {Object} encryptionMetadata
-  * @param {Number} maxConcurrency
-  *
-  * @returns {null}
-  */
-  this.uploadFileStream = async function (fileStream, meta, encryptionMetadata, maxConcurrency)
-  {
-    var s3Metadata = {
+   * Create the file metadata then upload the file.
+   *
+   * @param {String} dataFile
+   * @param {Object} meta
+   * @param {Object} encryptionMetadata
+   */
+  this.uploadFile = async function (dataFile, meta, encryptionMetadata) {
+    const fileStream = fs.readFileSync(dataFile);
+    await this.uploadFileStream(fileStream, meta, encryptionMetadata);
+  };
+
+  /**
+   * Create the file metadata then upload the file stream.
+   *
+   * @param {String} fileStream
+   * @param {Object} meta
+   * @param {Object} encryptionMetadata
+   */
+  this.uploadFileStream = async function (fileStream, meta, encryptionMetadata) {
+    const s3Metadata = {
       HTTP_HEADER_CONTENT_TYPE: HTTP_HEADER_VALUE_OCTET_STREAM,
       SFC_DIGEST: meta['SHA256_DIGEST']
     };
 
-    if (encryptionMetadata)
-    {
+    if (encryptionMetadata) {
       s3Metadata[AMZ_IV] = encryptionMetadata.iv;
       s3Metadata[AMZ_KEY] = encryptionMetadata.key;
       s3Metadata[AMZ_MATDESC] = encryptionMetadata.matDesc;
     }
 
-    var stageInfo = meta['stageInfo'];
-    var client = this.createClient(stageInfo);
+    const stageInfo = meta['stageInfo'];
+    const client = this.createClient(stageInfo);
 
-    var s3location = this.extractBucketNameAndPath(meta['stageInfo']['location']);
+    const s3location = this.extractBucketNameAndPath(meta['stageInfo']['location']);
 
-    var params = {
+    const params = {
       Bucket: s3location.bucketName,
       Body: fileStream,
       Key: s3location.s3path + meta['dstFileName'],
@@ -240,26 +207,16 @@ function s3_util(s3, filestream)
     };
 
     // call S3 to upload file to specified bucket
-    try
-    {
-      await client.upload(params)
-        .promise();
-    }
-    catch (err)
-    {
-      if (err['code'] == EXPIRED_TOKEN)
-      {
+    try {
+      await client.putObject(params);
+    } catch (err) {
+      if (err['Code'] == EXPIRED_TOKEN) {
         meta['resultStatus'] = resultStatus.RENEW_TOKEN;
-      }
-      else
-      {
+      } else {
         meta['lastError'] = err;
-        if (err['code'] == ERRORNO_WSAECONNABORTED)
-        {
+        if (err['Code'] == ERRORNO_WSAECONNABORTED) {
           meta['resultStatus'] = resultStatus.NEED_RETRY_WITH_LOWER_CONCURRENCY;
-        }
-        else
-        {
+        } else {
           meta['resultStatus'] = resultStatus.NEED_RETRY;
         }
       }
@@ -268,7 +225,7 @@ function s3_util(s3, filestream)
 
     meta['dstFileSize'] = meta['uploadSize'];
     meta['resultStatus'] = resultStatus.UPLOADED;
-  }
+  };
 
   /**
    * Download the file.
@@ -276,61 +233,47 @@ function s3_util(s3, filestream)
    * @param {String} dataFile
    * @param {Object} meta
    * @param {Object} encryptionMetadata
-   * @param {Number} maxConcurrency
-   *
-   * @returns {null}
    */
-  this.nativeDownloadFile = async function (meta, fullDstPath, maxConcurrency)
-  {
-    var stageInfo = meta['stageInfo'];
-    var client = this.createClient(stageInfo);
+  this.nativeDownloadFile = async function (meta, fullDstPath) {
+    const stageInfo = meta['stageInfo'];
+    const client = this.createClient(stageInfo);
 
-    var s3location = this.extractBucketNameAndPath(meta['stageInfo']['location']);
+    const s3location = this.extractBucketNameAndPath(meta['stageInfo']['location']);
 
-    var params = {
+    const params = {
       Bucket: s3location.bucketName,
       Key: s3location.s3path + meta['dstFileName'],
     };
 
     // call S3 to download file to specified bucket
-    try
-    {
+    try {
       await client.getObject(params)
-        .promise()
-        .then((data) =>
-        {
-          return new Promise((resolve, reject) =>
-          {
-            fs.writeFile(fullDstPath, data.Body, 'binary', (err) =>
-            {
-              if (err) reject(err);
+        .then(data => data.Body.transformToByteArray())
+        .then((data) => {
+          return new Promise((resolve, reject) => {
+            fs.writeFile(fullDstPath, data, 'binary', (err) => {
+              if (err) {
+                reject(err);
+              }
               resolve();
             });
           });
         });
-    }
-    catch (err)
-    {
-      if (err['code'] == EXPIRED_TOKEN)
-      {
+    } catch (err) {
+      if (err['Code'] == EXPIRED_TOKEN) {
         meta['resultStatus'] = resultStatus.RENEW_TOKEN;
-      }
-      else
-      {
+      } else {
         meta['lastError'] = err;
-        if (err['code'] == ERRORNO_WSAECONNABORTED)
-        {
+        if (err['Code'] == ERRORNO_WSAECONNABORTED) {
           meta['resultStatus'] = resultStatus.NEED_RETRY_WITH_LOWER_CONCURRENCY;
-        }
-        else
-        {
+        } else {
           meta['resultStatus'] = resultStatus.NEED_RETRY;
         }
       }
       return;
     }
     meta['resultStatus'] = resultStatus.DOWNLOADED;
-  }
+  };
 }
 
 module.exports = s3_util;

--- a/package.json
+++ b/package.json
@@ -3,13 +3,13 @@
   "version": "1.8.0",
   "description": "Node.js driver for Snowflake",
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.388.0",
     "@azure/storage-blob": "^12.11.0",
     "@google-cloud/storage": "^6.9.3",
     "@techteamer/ocsp": "1.0.0",
     "agent-base": "^6.0.2",
     "asn1.js-rfc2560": "^5.0.0",
     "asn1.js-rfc5280": "^3.0.0",
-    "aws-sdk": "^2.878.0",
     "axios": "^1.5.0",
     "big-integer": "^1.6.43",
     "bignumber.js": "^2.4.0",
@@ -37,6 +37,7 @@
     "winston": "^3.1.0"
   },
   "devDependencies": {
+    "@aws-sdk/types": "^3.387.0",
     "async": "^3.2.3",
     "eslint": "^8.41.0",
     "mocha": "^10.1.0",


### PR DESCRIPTION
### Description
aws-sdk v2 causes warning message:

```
(node:39752) NOTE: We are formalizing our plans to enter AWS SDK for JavaScript (v2) into maintenance mode in 2023.

Please migrate your code to use AWS SDK for JavaScript (v3).
For more information, check the migration guide at https://a.co/7PzMCcy
(Use `node --trace-warnings ...` to show where the warning was created)
```

and we should switch to AWS SDK in version 3.

**AWS SDK v3 needs Node version `>=14`**

### Checklist
- [x] Format code according to the existing code style (run `npm run lint:check -- CHANGED_FILES` and fix problems in changed code)
- [x] Create tests which fail without the change (if possible)
- [x] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [x] Extend the README / documentation and ensure is properly displayed (if necessary)
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message
