### PR TITLE
fix millisec logging

### DIFF
--- a/lib/logger/core.js
+++ b/lib/logger/core.js
@@ -315,7 +315,7 @@ exports.createLogger = function (options, logMessage)
       if (includeTimestamp)
       {
         message = Util.format(
-          '[%s]: %s', moment().format('h:mm:ss.ms A'), message);
+          '[%s]: %s', moment().format('h:mm:ss.SSS A'), message);
       }
 
       // mask secrets


### PR DESCRIPTION
This is a long-standing behaviour which always bothered me :) How [moment's formatting is used for the logging](https://momentjs.com/docs/#/parsing/string-format/), is currently concatenating the minute+seconds in the millisecond position, instead of actually logging the millisecond. Probably a typo which was unfixed for such a long time.

The impact however is making the various issues a bit harder to debug, not having access to the sub-second timings.

Before the fix:
```
{"level":"DEBUG","message":"[7:58:49.5849 AM]: Reading OCSP cache file. /root/.cache/snowflake/ocsp_response_cache.json"}
{"level":"TRACE","message":"[7:58:49.5849 AM]: Returning OCSP status for certificate 05877196EF01E4B545435944CEEC71CD from cache"}
{"level":"TRACE","message":"[7:58:49.5849 AM]: Returning OCSP status for certificate 06D8D904D5584346F68A2FA754227EC4 from cache"}
```
Observe how only the minute+second is logged in place of the milliseconds. 

After the fix:
```
{"level":"DEBUG","message":"[7:59:54.292 AM]: Reading OCSP cache file. /root/.cache/snowflake/ocsp_response_cache.json"}
{"level":"TRACE","message":"[7:59:54.365 AM]: Returning OCSP status for certificate 05877196EF01E4B545435944CEEC71CD from cache"}
{"level":"TRACE","message":"[7:59:54.370 AM]: Returning OCSP status for certificate 06D8D904D5584346F68A2FA754227EC4 from cache"}

```

Observe now how we have access to the milliseconds too.