### PR TITLE
Result calling issue

### DIFF
--- a/lib/connection/result/result.js
+++ b/lib/connection/result/result.js
@@ -53,6 +53,7 @@ function Result(options) {
   this._returnedRows = data.returned;
   this._totalRows = data.total;
   this._statementTypeId = data.statementTypeId;
+  Logger.getInstance().trace("The result.js is called. QueryId is:", this._queryId);
 
   // if no chunk headers were specified, but a query-result-master-key (qrmk)
   // was specified, build the chunk headers from the qrmk

--- a/test/unit/result_test.js
+++ b/test/unit/result_test.js
@@ -27,21 +27,11 @@ describe.only("test and log how many result.js called for each execution",functi
         sqlText: "select 1",
         complete: function (err, stmt)
         {
-          testUtil.checkError(err);
-          var stream = stmt.streamRows();
-          var rowCount = 0;
-          stream.on('data', function ()
-          {
-            rowCount++;
-          });
-          stream.on('error', function (err)
-          {
-            testUtil.checkError(err);
-          });
-          stream.on('end', function ()
-          {
+          if(err){
+            console.log(err.message);
+          }else{
             done();
-          });
+          }
         }
       });
     });

--- a/test/unit/result_test.js
+++ b/test/unit/result_test.js
@@ -1,0 +1,49 @@
+const connOption = require("../integration/connectionOptions");
+const snowflake = require('snowflake-sdk');
+const assert = require('assert');
+const testUtil = require("../integration/testUtil");
+
+snowflake.configure({logLevel:"TRACE"});
+
+describe.only("test and log how many result.js called for each execution",function (){
+     let connection = snowflake.createConnection(connOption.valid);
+      connection.connect(
+        function (err, conn)
+        {
+          if (err)
+          {
+            console.error('Unable to connect: ' + err.message);
+          }
+          else
+          {
+            console.log('Successfully connected to Snowflake');
+          }
+        }
+      )
+    
+    it('Run Select 1 query', function (done)
+    {
+      connection.execute({
+        sqlText: "select 1",
+        complete: function (err, stmt)
+        {
+          testUtil.checkError(err);
+          var stream = stmt.streamRows();
+          var rowCount = 0;
+          stream.on('data', function ()
+          {
+            rowCount++;
+          });
+          stream.on('error', function (err)
+          {
+            testUtil.checkError(err);
+          });
+          stream.on('end', function ()
+          {
+            done();
+          });
+        }
+      });
+    });
+})
+  


### PR DESCRIPTION
### Description
This is a PR to investigate the issue that the result.js called twice per execution.
How to Test: Run SNOWFLAKE_TEST_USER="<USER>" SNOWFLAKE_TEST_PASSWORD="<PASSWORD>!" SNOWFLAKE_TEST_ACCOUNT="<Account>" SNOWFLAKE_TEST_WAREHOUSE="<WareHouse>" SNOWFLAKE_TEST_DATABASE="<DB>" SNOWFLAKE_TEST_SCHEMA="<Schema>" npm test

Here is my trace level logs: [snowflake.log](https://github.com/snowflakedb/snowflake-connector-nodejs/files/12669718/snowflake.log)

### ChecklistC:\Users\JYun\workspaces\snowflake-connector-nodejs\testing.js
- [ ] Format code according to the existing code style (run `npm run lint:check -- CHANGED_FILES` and fix problems in changed code)
- [ ] Create tests which fail without the change (if possible)
- [ ] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [ ] Extend the README / documentation and ensure is properly displayed (if necessary)
- [ ] Provide JIRA issue id (if possible) or GitHub issue id in commit message


