### PR TITLE
SNOW-922989 Replace deprecated bignumber.js floor function

### DIFF
--- a/lib/connection/result/column.js
+++ b/lib/connection/result/column.js
@@ -456,7 +456,7 @@ function convertRawTimestampTz(rawColumnValue, column, context)
 
     // extract everything but the lowest 14 bits to get the fractional seconds
     valFracSecsBig =
-      valFracSecsWithTzBig.dividedBy(16384).floor();
+      valFracSecsWithTzBig.dividedBy(16384).integerValue(BigNumber.ROUND_FLOOR);
 
     // extract the lowest 14 bits to get the timezone
     if (valFracSecsWithTzBig.greaterThanOrEqualTo(0))
@@ -521,7 +521,7 @@ function convertRawTimestampHelper(
   // split the value into epoch seconds + nanoseconds; for example,
   // 1365148923.123456789 will be split into 1365148923 (epoch seconds)
   // and 123456789 (nano seconds)
-  var valSecBig = epochFracSecsBig.dividedBy(scaleFactor).floor();
+  var valSecBig = epochFracSecsBig.dividedBy(scaleFactor).integerValue(BigNumber.ROUND_FLOOR);
   var fractionsBig = epochFracSecsBig.minus(valSecBig.times(scaleFactor));
   var valSecNanoBig = fractionsBig.times(Math.pow(10, 9 - scale));
 

--- a/lib/connection/result/column.js
+++ b/lib/connection/result/column.js
@@ -459,7 +459,7 @@ function convertRawTimestampTz(rawColumnValue, column, context)
       valFracSecsWithTzBig.dividedBy(16384).integerValue(BigNumber.ROUND_FLOOR);
 
     // extract the lowest 14 bits to get the timezone
-    if (valFracSecsWithTzBig.greaterThanOrEqualTo(0))
+    if (valFracSecsWithTzBig.isGreaterThanOrEqualTo(0))
     {
       timezoneBig = valFracSecsWithTzBig.modulo(16384);
     }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "asn1.js-rfc5280": "^3.0.0",
     "axios": "^1.5.1",
     "big-integer": "^1.6.43",
-    "bignumber.js": "^6.0.0",
+    "bignumber.js": ">=6.0.0",
     "binascii": "0.0.2",
     "bn.js": "^5.2.1",
     "browser-request": "^0.3.3",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "asn1.js-rfc5280": "^3.0.0",
     "axios": "^1.5.1",
     "big-integer": "^1.6.43",
-    "bignumber.js": ">=6.0.0",
+    "bignumber.js": "^9.1.2",
     "binascii": "0.0.2",
     "bn.js": "^5.2.1",
     "browser-request": "^0.3.3",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "asn1.js-rfc5280": "^3.0.0",
     "axios": "^1.5.1",
     "big-integer": "^1.6.43",
-    "bignumber.js": "^2.4.0",
+    "bignumber.js": "^6.0.0",
     "binascii": "0.0.2",
     "bn.js": "^5.2.1",
     "browser-request": "^0.3.3",


### PR DESCRIPTION
### Description
Replaced the deprecated `floor` function in new versions of bignumber.js (>= 6.0) with the updated solution of calling `.integerValue(BigNumber.ROUND_FLOOR)`

### Checklist
- [X] Format code according to the existing code style (run `npm run lint:check -- CHANGED_FILES` and fix problems in changed code) - I ran this, and there are a lot of warnings in the existing column.js file.
- [ ] Create tests which fail without the change (if possible)
- [X] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`) - Ran unit tests, no new failures
- [ ] Extend the README / documentation and ensure is properly displayed (if necessary)
- [ ] Provide JIRA issue id (if possible) or GitHub issue id in commit message
