### PR TITLE
SNOW-859636 Exclude codecov[bot] from Jira Issue comments

### DIFF
--- a/.github/workflows/jira_comment.yml
+++ b/.github/workflows/jira_comment.yml
@@ -23,7 +23,7 @@ jobs:
           echo ::set-output name=jira::$jira
       - name: Comment on issue
         uses: atlassian/gajira-comment@master
-        if: startsWith(steps.extract.outputs.jira, 'SNOW-')
+        if: startsWith(steps.extract.outputs.jira, 'SNOW-') && github.event.comment.user.login != 'codecov[bot]'
         with:
           issue: "${{ steps.extract.outputs.jira }}"
           comment: "${{ github.event.comment.user.login }} commented:\n\n${{ github.event.comment.body }}\n\n${{ github.event.comment.html_url }}"


### PR DESCRIPTION
### Description
To prevent codecov[bot] spamming on Jira tickets we want to exclude it from comment action.

### Checklist
- [ ] Format code according to the existing code style (run `npm run lint:check -- CHANGED_FILES` and fix problems in changed code)
- [ ] Create tests which fail without the change (if possible)
- [ ] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [ ] Extend the README / documentation and ensure is properly displayed (if necessary)
- [ ] Provide JIRA issue id (if possible) or GitHub issue id in commit message
