### PR TITLE
SNOW-926029: Check for renewing/connecting state when validating a connection

### DIFF
--- a/lib/services/sf.js
+++ b/lib/services/sf.js
@@ -486,7 +486,9 @@ function SnowflakeService(connectionConfig, httpClient, config)
   };
 
   this.isConnected = function () {
-    return currentState === stateConnected || currentState === stateRenewing;
+    return currentState === stateConnected ||
+      currentState === stateConnecting ||
+      currentState === stateRenewing;
   };
 
   this.getServiceName = function ()

--- a/lib/services/sf.js
+++ b/lib/services/sf.js
@@ -485,8 +485,7 @@ function SnowflakeService(connectionConfig, httpClient, config)
     operationQueue.length = 0;
   };
 
-  this.isConnected = function ()
-  {
+  this.isConnected = function () {
     return currentState === stateConnected || currentState === stateRenewing;
   };
 

--- a/lib/services/sf.js
+++ b/lib/services/sf.js
@@ -487,7 +487,7 @@ function SnowflakeService(connectionConfig, httpClient, config)
 
   this.isConnected = function ()
   {
-    return currentState === stateConnected;
+    return currentState === stateConnected || currentState === stateRenewing;
   };
 
   this.getServiceName = function ()


### PR DESCRIPTION
### Description
Regarding issue 678

The PR checks if a connection is renewing/connecting to determine if it is valid. This can prevent an `Already connected` error or `Connection already in progress` error which happens when a user calls the `isUp` or `isValidAsync` function and it returns false and the user then tries to connect manually while the connection is already renewing/connecting

### Checklist
- [x] Format code according to the existing code style (run `npm run lint:check -- CHANGED_FILES` and fix problems in changed code)
- [ ] Create tests which fail without the change (if possible)
- [x] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [ ] Extend the README / documentation and ensure is properly displayed (if necessary)
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message
