### PR TITLE
SNOW-856233 easy logging - not fail on directory search error

### DIFF
--- a/lib/configuration/client_configuration.js
+++ b/lib/configuration/client_configuration.js
@@ -5,6 +5,7 @@ const os = require('os');
 const path = require('path');
 const fs = require('fs');
 const {isString} = require('../util');
+const Logger = require('../logger');
 const clientConfigFileName = 'sf_client_config.json';
 
 const Levels = Object.freeze({
@@ -142,9 +143,9 @@ function ConfigurationUtil(fsPromisesModule, processModule) {
   function findConfig (filePathFromConnectionString) {
     return verifyNotEmpty(filePathFromConnectionString)
       .then((filePath) => filePath ?? getFilePathFromEnvironmentVariable())
-      .then((filePath) => filePath ?? searchForConfigInDictionary('.'))
-      .then((filePath) => filePath ?? searchForConfigInDictionary(os.homedir()))
-      .then((filePath) => filePath ?? searchForConfigInDictionary(os.tmpdir()));
+      .then((filePath) => filePath ?? searchForConfigInDictionary(() => '.', 'driver'))
+      .then((filePath) => filePath ?? searchForConfigInDictionary(() => os.homedir(), 'home'))
+      .then((filePath) => filePath ?? searchForConfigInDictionary(() => os.tmpdir(), 'temp'));
   }
 
   async function verifyNotEmpty (filePath) {
@@ -155,9 +156,15 @@ function ConfigurationUtil(fsPromisesModule, processModule) {
     return verifyNotEmpty(process.env.SF_CLIENT_CONFIG_FILE);
   }
 
-  async function searchForConfigInDictionary (dictionary) {
-    const filePath = path.join(dictionary, clientConfigFileName);
-    return onlyIfFileExists(filePath);
+  async function searchForConfigInDictionary (directoryProvider, directoryDescription) {
+    try {
+      const directory = directoryProvider();
+      const filePath = path.join(directory, clientConfigFileName);
+      return onlyIfFileExists(filePath);
+    } catch (e) {
+      Logger.getInstance().error('Error while searching for the client config in %s directory: %s', directoryDescription, e);
+      return null;
+    }
   }
 
   async function onlyIfFileExists (filePath) {


### PR DESCRIPTION
### Description
Prevent to fail if client config file could not be found because of an unexpected error during the phase of searching in predefined directory. It could happen if for example there is no home folder in the operating system.

### Checklist
- [x] Format code according to the existing code style (run `npm run lint:check -- CHANGED_FILES` and fix problems in changed code)
- [x] Create tests which fail without the change (if possible)
- [x] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [x] Extend the README / documentation and ensure is properly displayed (if necessary)
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message
