### PR TITLE
SNOW-856233 not to log to the console when easy logging configured to…

### DIFF
--- a/lib/logger/node.js
+++ b/lib/logger/node.js
@@ -80,10 +80,7 @@ function Logger(options)
     {
       const transports = 'STDOUT' == filePath.toUpperCase()
         ? [ new (winston.transports.Console)() ]
-        : [
-          new (winston.transports.Console)(),
-          new (winston.transports.File)({filename: filePath})
-        ];
+        : [ new (winston.transports.File)({filename: filePath}) ];
       winstonLogger = new winston.createLogger(
         {
           transports: transports,

--- a/test/integration/testEasyLoggingOnConnecting.js
+++ b/test/integration/testEasyLoggingOnConnecting.js
@@ -9,9 +9,9 @@ const path = require('path');
 const os = require('os');
 const fsPromises = require('fs/promises');
 const assert = require('assert');
-const logLevelBefore = Logger.getInstance().getLevel();
 const {codes} = require('./../../lib/errors');
 const errorMessages = require('./../../lib/constants/error_messages');
+const {configureLogger} = require("../configureLogger")
 let tempDir = null;
 
 describe('Easy logging tests', function () {
@@ -21,10 +21,7 @@ describe('Easy logging tests', function () {
   });
 
   after(async function () {
-    Logger.getInstance().configure({
-      level: logLevelBefore,
-      filePath: 'snowflake.log'
-    });
+    configureLogger()
     await fsPromises.rm(tempDir, { recursive: true, force: true });
   });
 

--- a/test/unit/logger/easy_logging_starter_test.js
+++ b/test/unit/logger/easy_logging_starter_test.js
@@ -8,9 +8,9 @@ const fsPromises = require('fs/promises');
 const path = require('path');
 const os = require('os');
 const Logger = require('../../../lib/logger');
+const {configureLogger} = require("../../configureLogger")
 require('../../../lib/snowflake'); // import of it sets up node logger
 const defaultConfigName = 'sf_client_config.json';
-const logLevelBefore = Logger.getInstance().getLevel();
 let tempDir = null;
 
 before(async function () {
@@ -18,10 +18,7 @@ before(async function () {
 });
 
 after(async function () {
-  Logger.getInstance().configure({
-    level: logLevelBefore,
-    filePath: 'snowflake.log'
-  });
+  configureLogger();
   await fsPromises.rm(tempDir, { recursive: true, force: true });
 });
 


### PR DESCRIPTION
… log to the file

### Description
Make possible to log to the file without logging to console output.

### Checklist
- [x] Format code according to the existing code style (run `npm run lint:check -- CHANGED_FILES` and fix problems in changed code)
- [x] Create tests which fail without the change (if possible)
- [x] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [x] Extend the README / documentation and ensure is properly displayed (if necessary)
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message
