### PR TITLE
SNOW-926008 supportability/observability enhancement for generic and proxy use-cases

### DIFF
--- a/lib/agent/https_proxy_ocsp_agent.js
+++ b/lib/agent/https_proxy_ocsp_agent.js
@@ -98,7 +98,14 @@ function connect(req, opts, fn)
 {
   var proxy = this.proxy;
   var agent = this;
-  Logger.getInstance().debug("Using proxy=%s for host %s", proxy.host, opts.host);
+
+  // is proxy same as the host it's proxying for? that's a problem
+  // can occur when envvar HTTPS_PROXY is the same as Connection proxyHost
+  if (proxy.host === opts.host) {
+    Logger.getInstance().warn('Looks like the proxy (%s) is the same as the host it is proxying for (%s). '
+        + 'If you have connectivity problems, please check if HTTPS_PROXY and proxyHost:proxyPort '
+        + 'settings are both in effect and if so, try unsetting one of them.', proxy.host, opts.host);
+  };
 
   // create a socket connection to the proxy server
   var socket;

--- a/lib/http/node.js
+++ b/lib/http/node.js
@@ -130,7 +130,6 @@ NodeHttpClient.prototype.getAgent = function (parsedUrl, proxy, mock) {
   } else {
     agent = getFromCacheOrCreate(HttpAgent, agentOptions, parsedUrl);
   }
-
   return agent;
 };
 

--- a/lib/http/node.js
+++ b/lib/http/node.js
@@ -53,6 +53,16 @@ function getFromCacheOrCreate(agentClass, options, parsedUrl) {
     const agent = agentClass(agentOptions);
     httpsAgentCache.set(agentId, agent);
     Logger.getInstance().trace(`Create and add to cache new agent ${agentId}`);
+
+    // detect and log PROXY envvar + agent proxy settings
+    const compareAndLogEnvAndAgentProxies = Util.getCompareAndLogEnvAndAgentProxies(agentOptions);
+    Logger.getInstance().debug(`Proxy settings used in requests:${compareAndLogEnvAndAgentProxies.messages}`);
+    // if there's anything to warn on (e.g. both envvar + agent proxy used, and they are different)
+    // log warnings on them
+    if (compareAndLogEnvAndAgentProxies.warnings) {
+      Logger.getInstance().warn(`${compareAndLogEnvAndAgentProxies.warnings}`);
+    }
+
     return agent;
   }
 
@@ -73,12 +83,6 @@ function prepareProxyAgentOptions(agentOptions, proxy) {
     agentOptions.user = proxy.user;
     agentOptions.password = proxy.password;
   }
-  // log the proxy details used in the agent, for supportability
-  const proxyProtocolHostAndPort = agentOptions.protocol ?
-      ' protocol=' + agentOptions.protocol + ' proxy=' + agentOptions.host + ':' + agentOptions.port
-      : ' proxy=' + agentOptions.host + ':' + agentOptions.port;
-  const proxyUsername = agentOptions.user ? ' user=' + agentOptions.user : '';
-  Logger.getInstance().debug("Using proxy configured in Connection:%s%s", proxyProtocolHostAndPort, proxyUsername);
 }
 
 function isBypassProxy(proxy, url, bypassProxy) {
@@ -127,30 +131,6 @@ NodeHttpClient.prototype.getAgent = function (parsedUrl, proxy, mock) {
     agent = getFromCacheOrCreate(HttpAgent, agentOptions, parsedUrl);
   }
 
-  // try to detect and log PROXY envvar
-  const envProxy = Util.getEnvProxy();
-  // HTTP_PROXY/http_proxy or HTTPS_PROXY/https_proxy is set
-  if (envProxy.httpProxy || envProxy.httpsProxy) {
-    Logger.getInstance().debug('PROXY environment variables used in request: %s %s %s'
-        , envProxy.logHttpProxy, envProxy.logHttpsProxy, envProxy.logNoProxy);
-    // is both PROXY envvar and proxyHost:proxyPort used ? could lead to problems
-    // check if the envvar is different from the agent proxy
-    if (proxy) {
-      const prxHostWithPort = proxy.host + ':' + proxy.port
-      if (envProxy.httpProxy &&
-          Util.removeScheme(envProxy.httpProxy).toLowerCase() != prxHostWithPort.toLowerCase()) {
-        Logger.getInstance().warn('Using both the HTTP_PROXY (%s) and the proxyHost:proxyPort (%s) settings to connect, '
-            + 'but with different values. If you experience connectivity issues, try unsetting one of them.'
-            , envProxy.httpProxy, prxHostWithPort);
-      };
-      if (envProxy.httpsProxy &&
-          Util.removeScheme(envProxy.httpsProxy).toLowerCase() != prxHostWithPort.toLowerCase()) {
-        Logger.getInstance().warn('Using both the HTTPS_PROXY (%s) and the proxyHost:proxyPort (%s) settings to connect, '
-            + 'but with different values. If you experience connectivity issues, try unsetting one of them.'
-            , envProxy.httpsProxy, prxHostWithPort);
-      };
-    };
-  };
   return agent;
 };
 

--- a/lib/http/node.js
+++ b/lib/http/node.js
@@ -73,6 +73,12 @@ function prepareProxyAgentOptions(agentOptions, proxy) {
     agentOptions.user = proxy.user;
     agentOptions.password = proxy.password;
   }
+  // log the proxy details used in the agent, for supportability
+  const proxyProtocolHostAndPort = agentOptions.protocol ?
+      ' protocol=' + agentOptions.protocol + ' proxy=' + agentOptions.host + ':' + agentOptions.port
+      : ' proxy=' + agentOptions.host + ':' + agentOptions.port;
+  const proxyUsername = agentOptions.user ? ' user=' + agentOptions.user : '';
+  Logger.getInstance().debug("Using proxy configured in Connection:%s%s", proxyProtocolHostAndPort, proxyUsername);
 }
 
 function isBypassProxy(proxy, url, bypassProxy) {
@@ -120,6 +126,31 @@ NodeHttpClient.prototype.getAgent = function (parsedUrl, proxy, mock) {
   } else {
     agent = getFromCacheOrCreate(HttpAgent, agentOptions, parsedUrl);
   }
+
+  // try to detect and log PROXY envvar
+  const envProxy = Util.getEnvProxy();
+  // HTTP_PROXY/http_proxy or HTTPS_PROXY/https_proxy is set
+  if (envProxy.httpProxy || envProxy.httpsProxy) {
+    Logger.getInstance().debug('PROXY environment variables used in request: %s %s %s'
+        , envProxy.logHttpProxy, envProxy.logHttpsProxy, envProxy.logNoProxy);
+    // is both PROXY envvar and proxyHost:proxyPort used ? could lead to problems
+    // check if the envvar is different from the agent proxy
+    if (proxy) {
+      const prxHostWithPort = proxy.host + ':' + proxy.port
+      if (envProxy.httpProxy &&
+          Util.removeScheme(envProxy.httpProxy).toLowerCase() != prxHostWithPort.toLowerCase()) {
+        Logger.getInstance().warn('Using both the HTTP_PROXY (%s) and the proxyHost:proxyPort (%s) settings to connect, '
+            + 'but with different values. If you experience connectivity issues, try unsetting one of them.'
+            , envProxy.httpProxy, prxHostWithPort);
+      };
+      if (envProxy.httpsProxy &&
+          Util.removeScheme(envProxy.httpsProxy).toLowerCase() != prxHostWithPort.toLowerCase()) {
+        Logger.getInstance().warn('Using both the HTTPS_PROXY (%s) and the proxyHost:proxyPort (%s) settings to connect, '
+            + 'but with different values. If you experience connectivity issues, try unsetting one of them.'
+            , envProxy.httpsProxy, prxHostWithPort);
+      };
+    };
+  };
   return agent;
 };
 

--- a/lib/services/sf.js
+++ b/lib/services/sf.js
@@ -615,6 +615,10 @@ function StateAbstract(options)
           // if we got an error, wrap it into a network error
           if (err)
           {
+            // if we're running in DEBUG loglevel, probably we want to see the full error instead
+            Logger.getInstance().debug('Encountered an error when sending the request. Details: '
+                + JSON.stringify(err, Util.getCircularReplacer()));
+
             err = Errors.createNetworkError(
               ErrorCodes.ERR_SF_NETWORK_COULD_NOT_CONNECT, err);
           }

--- a/lib/util.js
+++ b/lib/util.js
@@ -638,3 +638,34 @@ exports.isCorrectSubdomain = function (value) {
   const subdomainRegex = RegExp(/^\w[\w.-]+\w$/i);
   return subdomainRegex.test(value);
 };
+
+/**
+ * Try to get the PROXY environmental variables
+ * On Windows, envvar name is case-insensitive, but on *nix, it's case-sensitive
+ *
+ * @returns {object}
+ */
+exports.getEnvProxy = function() {
+  const envProxy = {};
+  envProxy.httpProxy = process.env.HTTP_PROXY || process.env.http_proxy;
+  envProxy.httpsProxy = process.env.HTTPS_PROXY || process.env.https_proxy;
+  envProxy.noProxy = process.env.NO_PROXY || process.env.no_proxy;
+
+  envProxy.logHttpProxy = envProxy.httpProxy ?
+      'HTTP_PROXY: ' + envProxy.httpProxy : 'HTTP_PROXY: <unset>';
+  envProxy.logHttpsProxy = envProxy.httpsProxy ?
+      'HTTPS_PROXY: ' + envProxy.httpsProxy : 'HTTPS_PROXY: <unset>';
+  envProxy.logNoProxy = envProxy.noProxy ?
+      'NO_PROXY: ' + envProxy.noProxy : 'NO_PROXY: <unset>';
+
+  return envProxy;
+};
+
+/**
+* remove http:// or https:// from the input, e.g. used with proxy URL
+* @param input
+* @returns {string}
+*/
+exports.removeScheme = function (input) {
+  return input.toString().replace(/(^\w+:|^)\/\//, '');
+};

--- a/lib/util.js
+++ b/lib/util.js
@@ -643,10 +643,16 @@ exports.isCorrectSubdomain = function (value) {
  * Try to get the PROXY environmental variables
  * On Windows, envvar name is case-insensitive, but on *nix, it's case-sensitive
  *
+ * Compare them with the proxy specified on the Connection, if any
+ * Return with the log constructed from the components detection and comparison
+ * If there's something to warn the user about, return that too
+ *
+ * @param the agentOptions object from agent creation
  * @returns {object}
  */
-exports.getEnvProxy = function() {
+exports.getCompareAndLogEnvAndAgentProxies = function(agentOptions) {
   const envProxy = {};
+  let logMessages = {'messages': '', 'warnings': ''};
   envProxy.httpProxy = process.env.HTTP_PROXY || process.env.http_proxy;
   envProxy.httpsProxy = process.env.HTTPS_PROXY || process.env.https_proxy;
   envProxy.noProxy = process.env.NO_PROXY || process.env.no_proxy;
@@ -658,7 +664,39 @@ exports.getEnvProxy = function() {
   envProxy.logNoProxy = envProxy.noProxy ?
       'NO_PROXY: ' + envProxy.noProxy : 'NO_PROXY: <unset>';
 
-  return envProxy;
+  // log PROXY envvars
+  if (envProxy.httpProxy || envProxy.httpsProxy) {
+      logMessages.messages = logMessages.messages + ` // PROXY environment variables: `
+      + `${envProxy.logHttpProxy} ${envProxy.logHttpsProxy} ${envProxy.logNoProxy}.`;
+  }
+
+  // log proxy config on Connection, if any set
+  if (agentOptions.host) {
+      const proxyHostAndPort = agentOptions.host + ':' + agentOptions.port
+      const proxyProtocolHostAndPort = agentOptions.protocol ?
+          ' protocol=' + agentOptions.protocol + ' proxy=' + proxyHostAndPort
+          : ' proxy=' + proxyHostAndPort;
+      const proxyUsername = agentOptions.user ? ' user=' + agentOptions.user : ''
+      logMessages.messages = logMessages.messages + ` // Proxy configured in Connection:${proxyProtocolHostAndPort}${proxyUsername}`;
+
+      // check if both the PROXY envvars and Connection proxy config is set
+      // generate warnings if they are, and are also different
+      if (envProxy.httpProxy &&
+          this.removeScheme(envProxy.httpProxy).toLowerCase() != this.removeScheme(proxyHostAndPort).toLowerCase()) {
+          logMessages.warnings = logMessages.warnings + ` Using both the HTTP_PROXY (${envProxy.httpProxy})`
+          +` and the proxyHost:proxyPort (${proxyHostAndPort}) settings to connect, but with different values.`
+          +` If you experience connectivity issues, try unsetting one of them.`
+      };
+      if (envProxy.httpsProxy &&
+          this.removeScheme(envProxy.httpsProxy).toLowerCase() != this.removeScheme(proxyHostAndPort).toLowerCase()) {
+          logMessages.warnings = logMessages.warnings + ` Using both the HTTPS_PROXY (${envProxy.httpsProxy})`
+          +` and the proxyHost:proxyPort (${proxyHostAndPort}) settings to connect, but with different values.`
+          +` If you experience connectivity issues, try unsetting one of them.`
+      };
+  }
+  logMessages.messages = logMessages.messages ? logMessages.messages : ' none.'
+
+  return logMessages;
 };
 
 /**


### PR DESCRIPTION
- generic observability: instead of swallowing the underlying error upon connectivity issue and emit a hard-to-debug generic error message, log that underlying error stack on DEBUG loglevel

- proxy: detecting if HTTP_PROXY/HTTPS_PROXY environmental variable is set, log them on DEBUG loglevel
- proxy: added logging for Connection's proxyPort and proxyUser (if set), had only proxyHost. 
-- this bit of logging now moved to generic agent
- proxy: if both HTTPS_PROXY and proxyHost is set, can lead to not-so-trivial-to-debug situations ; log this on WARN loglevel for more intuitive troubleshooting
