### PR TITLE
SNOW-926008 observability improvements continued

### DIFF
--- a/lib/services/large_result_set.js
+++ b/lib/services/large_result_set.js
@@ -71,8 +71,9 @@ function LargeResultSetService(connectionConfig, httpClient)
       if (err || isUnsuccessfulResponse(response))
       {
         // if we're running in DEBUG loglevel, probably we want to see the full error too
-        const logErr = err ? JSON.stringify(err, Util.getCircularReplacer()) 
-        : JSON.stringify(response, Util.getCircularReplacer());
+        const logErr = err ? JSON.stringify(err, Util.getCircularReplacer())
+          : `status: ${JSON.stringify(response.status)} ${JSON.stringify(response.statusText)}` 
+            + ` headers: ${JSON.stringify(response.headers)}`;
         Logger.getInstance().debug('Encountered an error when getting data from cloud storage: ' + logErr);
         // if we haven't exceeded the maximum number of retries yet and the
         // server came back with a retryable error code.

--- a/lib/services/large_result_set.js
+++ b/lib/services/large_result_set.js
@@ -70,6 +70,10 @@ function LargeResultSetService(connectionConfig, httpClient)
       // err happens on timeouts and response is passed when server responded
       if (err || isUnsuccessfulResponse(response))
       {
+        // if we're running in DEBUG loglevel, probably we want to see the full error too
+        const logErr = err ? JSON.stringify(err, Util.getCircularReplacer()) 
+        : JSON.stringify(response, Util.getCircularReplacer());
+        Logger.getInstance().debug('Encountered an error when getting data from cloud storage: ' + logErr);
         // if we haven't exceeded the maximum number of retries yet and the
         // server came back with a retryable error code.
         if (numRetries < maxNumRetries && isRetryableError(response, err))
@@ -84,7 +88,7 @@ function LargeResultSetService(connectionConfig, httpClient)
 
           // wait the appropriate amount of time before retrying the request
           const nextSendRequestWaitTimeMs = sleep * 1000;
-          Logger.getInstance().trace("Request will be retried after %d milliseconds", nextSendRequestWaitTimeMs);
+          Logger.getInstance().trace("Request will be retried after %d milliseconds", Math.floor(nextSendRequestWaitTimeMs));
           setTimeout(sendRequest, nextSendRequestWaitTimeMs);
           return
         }


### PR DESCRIPTION
* extra logging for errors and unsuccessful responses in requests when retrieving query result from cloud storage
* '2515 milliseconds' is enough precision in the logs for retries (was: '2515.1356764370476 milliseconds')
