### PR TITLE
Isolate from global environment.

### DIFF
--- a/lib/http/base.js
+++ b/lib/http/base.js
@@ -36,6 +36,7 @@ HttpClient.prototype.getConnectionConfig = function ()
  * @returns {Object} an object representing the request that was issued.
  */
 HttpClient.prototype.request = function (options) {
+  let request;
   const requestOptions = prepareRequestOptions.call(this, options);
   let sendRequest = async function sendRequest() {
     request = axios.request(requestOptions).then(response => {


### PR DESCRIPTION
Define local `request` variable, so that the one in the global space is not overwritten.

### Description
A global variable named `request` was used, which can potentially conflict with the clients of this library.

Related to the following bug: https://github.com/snowflakedb/snowflake-connector-nodejs/issues/712

### Checklist
- [ ] Format code according to the existing code style (run `npm run lint:check -- CHANGED_FILES` and fix problems in changed code)
- [ ] Create tests which fail without the change (if possible)
- [ ] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [ ] Extend the README / documentation and ensure is properly displayed (if necessary)
- [ ] Provide JIRA issue id (if possible) or GitHub issue id in commit message
