### PR TITLE
fix options when host is set

### DIFF
--- a/lib/connection/connection_config.js
+++ b/lib/connection/connection_config.js
@@ -81,7 +81,9 @@ function consolidateHostAndAccount(options) {
     if (options.region === 'us-west-2') {
       options.region = '';
     }
-    if (dotPos < 0 && Util.isString(options.region) && options.region.length > 0) {
+    if (Util.exists(options.host)) {
+      options.accessUrl = Util.format('https://%s', options.host);
+    } else if (dotPos < 0 && Util.isString(options.region) && options.region.length > 0) {
       options.accessUrl = Util.format('https://%s.%s.snowflakecomputing.com', options.account, options.region);
     } else {
       options.accessUrl = Util.format('https://%s.snowflakecomputing.com', options.account);


### PR DESCRIPTION
### Description
The host configuration which is in the list of options is not used to construct the accessUrl when it should be.

### Checklist
- [x] Format code according to the existing code style (run `npm run lint:check -- CHANGED_FILES` and fix problems in changed code)
- [x] Create tests which fail without the change (if possible)
- [x] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [x] Extend the README / documentation and ensure is properly displayed (if necessary)
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message
