### PR TITLE
SNOW-1001672 bump `axios` to 1.6.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "agent-base": "^6.0.2",
     "asn1.js-rfc2560": "^5.0.0",
     "asn1.js-rfc5280": "^3.0.0",
-    "axios": "^1.6.0",
+    "axios": "^1.6.4",
     "big-integer": "^1.6.43",
     "bignumber.js": "^9.1.2",
     "binascii": "0.0.2",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "agent-base": "^6.0.2",
     "asn1.js-rfc2560": "^5.0.0",
     "asn1.js-rfc5280": "^3.0.0",
-    "axios": "^1.6.4",
+    "axios": "^1.6.5",
     "big-integer": "^1.6.43",
     "bignumber.js": "^9.1.2",
     "binascii": "0.0.2",


### PR DESCRIPTION
bump `axios` to 1.6.5

to address High (7.5) severity vulnerability with prototype pollution which is fixed in `axios` 1.6.4
https://security.snyk.io/vuln/SNYK-JS-AXIOS-6144788