### PR TITLE
SNOW-1031704 bump `@google-cloud/storage` to v7

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@aws-sdk/client-s3": "^3.388.0",
     "@aws-sdk/node-http-handler": "^3.374.0",
     "@azure/storage-blob": "^12.11.0",
-    "@google-cloud/storage": "^6.9.3",
+    "@google-cloud/storage": "^7.7.0",
     "@techteamer/ocsp": "1.0.1",
     "agent-base": "^6.0.2",
     "asn1.js-rfc2560": "^5.0.0",


### PR DESCRIPTION
 SNOW-1031704 - checked first as a Draft and all test seem to pass. So converting to a regular one.

Besides upgrading to the newer version of the dependency, this PR also aims to address the concern caused by v6 of the dependency, leading to issues in Next.js 
```
./node_modules/@google-cloud/storage/node_modules/retry-request/index.js
Module not found: Can't resolve 'request' in '/path/to/node_modules/@google-cloud/storage/node_modules/retry-request'
```

see https://github.com/snowflakedb/snowflake-connector-nodejs/issues/759

