### PR TITLE
fix:only create tmp directory when compression is on. 

### DIFF
--- a/lib/file_transfer_agent/file_transfer_agent.js
+++ b/lib/file_transfer_agent/file_transfer_agent.js
@@ -353,11 +353,13 @@ function FileTransferAgent(context) {
   */
   async function uploadOneFile(meta) {
     meta['realSrcFilePath'] = meta['srcFilePath'];
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tmp'));
-    meta['tmpDir'] = tmpDir;
+
     try {
       if (meta['requireCompress']) {
-        const result = await SnowflakeFileUtil.compressFileWithGZIP(meta['srcFilePath'], meta['tmpDir']);
+        const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tmp'));
+        const result = await SnowflakeFileUtil.compressFileWithGZIP(meta['srcFilePath'], tmpDir);
+
+        meta['tmpDir'] = tmpDir;
         meta['realSrcFilePath'] = result.name;
       }
       const result = await SnowflakeFileUtil.getDigestAndSizeForFile(meta['realSrcFilePath']);
@@ -378,25 +380,27 @@ function FileTransferAgent(context) {
       meta['errorDetails'] = err.toString();
       meta['errorDetails'] += ` file=${meta['srcFileName']}, real file=${meta['realSrcFilePath']}`;
     } finally {
-      // Remove all files inside tmp folder
-      const matchingFileNames = glob.sync(path.join(meta['tmpDir'], meta['srcFileName'] + '*'));
-      for (const matchingFileName of matchingFileNames) {
-        await new Promise((resolve, reject) => {
-          fs.unlink(matchingFileName, err => {
-            if (err) {
-              reject(err);
-            }
-            resolve();
+      // Remove all files inside tmp folder if compression is set
+      if (meta['requireCompress']) {
+        const matchingFileNames = glob.sync(path.join(meta['tmpDir'], meta['srcFileName'] + '*'));
+        for (const matchingFileName of matchingFileNames) {
+          await new Promise((resolve, reject) => {
+            fs.unlink(matchingFileName, err => {
+              if (err) {
+                reject(err);
+              }
+              resolve();
+            });
           });
+        }
+        // Delete tmp folder
+        fs.rmdir(meta['tmpDir'], (err) => {
+          if (err) {
+            throw (err);
+          }
+
         });
       }
-      // Delete tmp folder
-      fs.rmdir(meta['tmpDir'], (err) => {
-        if (err) {
-          throw (err);
-        }
-
-      });
     }
 
     return meta;
@@ -562,7 +566,7 @@ function FileTransferAgent(context) {
     const quoteIndex = command.substring(startIndex).indexOf('\'');
     let endIndex = spaceIndex;
     if (quoteIndex !== -1 && quoteIndex < spaceIndex) {
-      endIndex = quoteIndex; 
+      endIndex = quoteIndex;
     }
     const filePath = command.substring(startIndex, startIndex + endIndex);
     return filePath;
@@ -757,7 +761,7 @@ function FileTransferAgent(context) {
     if (sourceCompression === 'auto_detect') {
       autoDetect = true;
 
-    } else if (sourceCompression === typeof('undefined')) {
+    } else if (sourceCompression === typeof ('undefined')) {
       autoDetect = false;
     } else {
       userSpecifiedSourceCompression = fileCompressionType.lookupByMimeSubType(sourceCompression);
@@ -838,6 +842,6 @@ function FileTransferAgent(context) {
 }
 
 //TODO SNOW-992387: Create a function to renew expired client
-function renewExpiredClient() {}
+function renewExpiredClient() { }
 
 module.exports = FileTransferAgent;


### PR DESCRIPTION
### Description
Changed file_transfer_agent  uploadOneFile method so that it only creates the tmp files when compression is on. Currently this code fails on the rmdir of the tmp directory because the directory is not empty. We do not utilize the compression feature and there is no need to create this directory. The documentation currently states: The driver uses this temporary directory to create temporary compressed files before uploading those files to Snowflake.

### Checklist
- [ ] Format code according to the existing code style (run `npm run lint:check -- CHANGED_FILES` and fix problems in changed code)
- [ ] Create tests which fail without the change (if possible)
- [ ] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [ ] Extend the README / documentation and ensure is properly displayed (if necessary)
- [ ] Provide JIRA issue id (if possible) or GitHub issue id in commit message
