### PR TITLE
SNOW-1016523 fix driver directory determination in Easy Logging

### DIFF
--- a/lib/configuration/client_configuration.js
+++ b/lib/configuration/client_configuration.js
@@ -30,7 +30,7 @@ function getDefaultDirectories() {
         dir: driverDirectory,
         dirDescription: 'driver'
       }
-    )
+    );
   } else {
     Logger.getInstance().warn('Driver directory is not defined');
   }

--- a/lib/configuration/client_configuration.js
+++ b/lib/configuration/client_configuration.js
@@ -4,7 +4,7 @@
 const os = require('os');
 const path = require('path');
 const fs = require('fs');
-const { isString, exists, isFileNotWritableByGroupOrOthers } = require('../util');
+const { isString, exists, isFileNotWritableByGroupOrOthers, getDriverDirectory } = require('../util');
 const Logger = require('../logger');
 const clientConfigFileName = 'sf_client_config.json';
 
@@ -20,12 +20,20 @@ const Levels = Object.freeze({
 const defaultDirectories = getDefaultDirectories();
 
 function getDefaultDirectories() {
-  const directories = [
-    {
-      dir: '.',
-      dirDescription: 'driver'
-    }
-  ];
+  const directories = [];
+
+  const driverDirectory = getDriverDirectory();
+
+  if (driverDirectory) {
+    directories.push(
+      {
+        dir: driverDirectory,
+        dirDescription: 'driver'
+      }
+    )
+  } else {
+    Logger.getInstance().warn('Driver directory is not defined');
+  }
 
   const homedir = os.homedir();
 

--- a/lib/configuration/client_configuration.js
+++ b/lib/configuration/client_configuration.js
@@ -235,7 +235,7 @@ function ConfigurationUtil(fsPromisesModule, processModule) {
   async function searchForConfigInDictionary(directory, directoryDescription) {
     try {
       const filePath = path.join(directory, clientConfigFileName);
-      return onlyIfFileExists(filePath);
+      return await onlyIfFileExists(filePath);
     } catch (e) {
       Logger.getInstance().error('Error while searching for the client config in %s directory: %s', directoryDescription, e);
       return null;

--- a/lib/logger/easy_logging_starter.js
+++ b/lib/logger/easy_logging_starter.js
@@ -96,16 +96,16 @@ async function getLogPath(config) {
   }
   const pathWithNodeJsSubdirectory = path.join(logPath, 'nodejs');
   await fsPromises.access(pathWithNodeJsSubdirectory, fs.constants.F_OK)
-    .then(() => {
-      if (!isFileModeCorrect(pathWithNodeJsSubdirectory, 0o700, fsPromises)) {
+    .then(async () => {
+      if (!(await isFileModeCorrect(pathWithNodeJsSubdirectory, 0o700, fsPromises))) {
         Logger.getInstance().warn('Log directory: %s could potentially be accessed by others', pathWithNodeJsSubdirectory);
       }
     })
-    .catch(() => {
+    .catch(async () => {
       try {
-        return fsPromises.mkdir(pathWithNodeJsSubdirectory, { recursive: true, mode: 0o700 });
+        await fsPromises.mkdir(pathWithNodeJsSubdirectory, { recursive: true, mode: 0o700 });
       } catch (err) {
-        throw new EasyLoggingError('Failed to create the directory for logs: %s', pathWithNodeJsSubdirectory);
+        throw new EasyLoggingError(`Failed to create the directory for logs: ${pathWithNodeJsSubdirectory}`);
       }
     });
   return pathWithNodeJsSubdirectory;

--- a/lib/util.js
+++ b/lib/util.js
@@ -701,4 +701,4 @@ exports.shouldRetryOktaAuth = function ({ maxRetryTimeout, maxRetryCount, numRet
 
 exports.getDriverDirectory = function () {
   return __dirname;
-}
+};

--- a/lib/util.js
+++ b/lib/util.js
@@ -698,3 +698,7 @@ exports.isFileNotWritableByGroupOrOthers = async function (configFilePath, fsPro
 exports.shouldRetryOktaAuth = function ({ maxRetryTimeout, maxRetryCount, numRetries, startTime, remainingTimeout }) {
   return  (maxRetryTimeout === 0 || Date.now() < startTime + remainingTimeout) && numRetries <= maxRetryCount;
 };
+
+exports.getDriverDirectory = function () {
+  return __dirname;
+}

--- a/test/unit/configuration/configuration_finding_test.js
+++ b/test/unit/configuration/configuration_finding_test.js
@@ -33,7 +33,7 @@ describe('Configuration finding tests', function () {
 
   after(() => {
     if (!driverDirectory) {
-      assert.fail("driver directory not set");
+      assert.fail('driver directory not set');
     }
     mock.stop('fs/promises');
     mock.stop('process');

--- a/test/unit/configuration/configuration_finding_test.js
+++ b/test/unit/configuration/configuration_finding_test.js
@@ -6,9 +6,11 @@ const path = require('path');
 const assert = require('assert');
 const mock = require('mock-require');
 const { Levels, ConfigurationUtil } = require('./../../../lib/configuration/client_configuration');
+const { getDriverDirectory } = require('./../../../lib/util');
 const defaultConfigName = 'sf_client_config.json';
 const badPermissionsConfig = 'bad_perm_config.json';
-const configInDriverDirectory = path.join('.', defaultConfigName);
+const driverDirectory = getDriverDirectory();
+const configInDriverDirectory = path.join(driverDirectory, defaultConfigName);
 const configInHomeDirectory = path.join(os.homedir(), defaultConfigName);
 const configFromEnvVariable = 'env_config.json';
 const configFromConnectionString = 'conn_config.json';
@@ -30,6 +32,9 @@ const clientConfig = {
 describe('Configuration finding tests', function () {
 
   after(() => {
+    if (!driverDirectory) {
+      assert.fail("driver directory not set");
+    }
     mock.stop('fs/promises');
     mock.stop('process');
   });
@@ -85,7 +90,7 @@ describe('Configuration finding tests', function () {
     const fsPromises = require('fs/promises');
     const process = require('process');
     const configUtil = new ConfigurationUtil(fsPromises, process);
-    clientConfig.configPath = 'sf_client_config.json';
+    clientConfig.configPath = configInDriverDirectory;
 
     // when
     const configFound = await configUtil.getClientConfig(null);

--- a/test/unit/logger/easy_logging_starter_test.js
+++ b/test/unit/logger/easy_logging_starter_test.js
@@ -119,7 +119,7 @@ describe('Easy logging starter tests', function () {
       (err) => {
         assert.strictEqual(err.name, 'EasyLoggingError');
         assert.strictEqual(err.message, 'Failed to initialize easy logging');
-        assert.match(err.cause.message, /no such file or directory|permission denied/);
+        assert.match(err.cause.message, /Failed to create the directory for logs/);
         return true;
       });
   });


### PR DESCRIPTION
### Description
Fix driver directory determination in Easy Logging

### Checklist
- [x] Format code according to the existing code style (run `npm run lint:check -- CHANGED_FILES` and fix problems in changed code)
- [x] Create tests which fail without the change (if possible)
- [x] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [x] Extend the README / documentation and ensure is properly displayed (if necessary)
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message
