### PR TITLE
Fix cannot set sendRequest on undefined in Next.js apps

### DIFF
--- a/lib/connection/statement.js
+++ b/lib/connection/statement.js
@@ -1255,7 +1255,7 @@ function sendRequestPreExec(statementContext, onResultAvailable) {
     true);
 }
 
-this.sendRequest = function (statementContext, onResultAvailable) {
+const sendRequest = function (statementContext, onResultAvailable) {
   // get the request headers
   const headers = statementContext.resultRequestHeaders;
 


### PR DESCRIPTION
### Description

It seems like that `this.sendRequest` was being used to set `sendRequest` as a global function. But `this` is undefined when using it in Next.js bundled server-side routes.

This change makes it so that the function can be used in the statement.js file without referencing `this`.

### Checklist
- [ ] Format code according to the existing code style (run `npm run lint:check -- CHANGED_FILES` and fix problems in changed code)
- [ ] Create tests which fail without the change (if possible)
- [ ] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [ ] Extend the README / documentation and ensure is properly displayed (if necessary)
- [ ] Provide JIRA issue id (if possible) or GitHub issue id in commit message
