### PR TITLE
Update to latest winston

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "python-struct": "^1.1.3",
     "simple-lru-cache": "^0.0.2",
     "uuid": "^8.3.2",
-    "winston": "^3.1.0"
+    "winston": "^3.12.0"
   },
   "devDependencies": {
     "@aws-sdk/types": "^3.387.0",


### PR DESCRIPTION
I was still getting the error in https://github.com/snowflakedb/snowflake-connector-nodejs/issues/106.  Turns out that I was pinned to winston 3.1.0 in my project, but that version doesn't support `new winston.createLogger`

### Description
Please explain the changes you made here.

### Checklist
- [ ] Format code according to the existing code style (run `npm run lint:check -- CHANGED_FILES` and fix problems in changed code)
- [ ] Create tests which fail without the change (if possible)
- [ ] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [ ] Extend the README / documentation and ensure is properly displayed (if necessary)
- [ ] Provide JIRA issue id (if possible) or GitHub issue id in commit message
