### PR TITLE
[TypeError]: Fix when constructor is calling new instances

### DIFF
--- a/lib/agent/https_ocsp_agent.js
+++ b/lib/agent/https_ocsp_agent.js
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2015-2019 Snowflake Computing Inc. All rights reserved.
- */
-
 const HttpsAgent = require('https').Agent;
 const SocketUtil = require('./socket_util');
 
@@ -14,7 +10,7 @@ const SocketUtil = require('./socket_util');
  * @constructor
  */
 function HttpsOcspAgent(options) {
-  const agent = HttpsAgent.apply(this, [options]);
+  const agent = new HttpsAgent(options); 
   agent.createConnection = function (port, host, options) {
     // make sure the 'options' variables references the argument that actually
     // contains the options

--- a/lib/agent/https_ocsp_agent.js
+++ b/lib/agent/https_ocsp_agent.js
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2015-2019 Snowflake Computing Inc. All rights reserved.
+ */
+
 const HttpsAgent = require('https').Agent;
 const SocketUtil = require('./socket_util');
 

--- a/lib/http/base.js
+++ b/lib/http/base.js
@@ -6,7 +6,7 @@ const zlib = require('zlib');
 const Util = require('../util');
 const Logger = require('../logger');
 const axios = require('axios');
-const URL = require('node:url').URL;
+const URL = require('url');
 
 const DEFAULT_REQUEST_TIMEOUT = 360000;
 
@@ -202,13 +202,6 @@ function prepareRequestOptions(options) {
 
   const params = options.params;
 
-  let mock;
-  if (this._connectionConfig.agentClass) {
-    mock = {
-      agentClass: this._connectionConfig.agentClass
-    };
-  }
-  const backoffStrategy = this.constructExponentialBackoffStrategy();
   const requestOptions =  {
     method: options.method,
     url: options.url,
@@ -217,15 +210,14 @@ function prepareRequestOptions(options) {
     params: params,
     timeout: timeout,
     requestOCSP: true,
-    retryDelay: backoffStrategy,
     rejectUnauthorized: true,
     // we manually parse jsons or other structures from the server so they need to be text
     responseType: options.responseType || 'text',
   };
 
-  const url = new URL(options.url);
+  const url = new URL.URL(options.url);
   const isHttps = url.protocol === 'https:';
-  const agent = this.getAgent(url, this._connectionConfig.getProxy(), mock);
+  const agent = this.getAgent(url, this._connectionConfig.getProxy());
   if (isHttps) {
     requestOptions.httpsAgent = agent;
   } else {


### PR DESCRIPTION
### Description
Fixes
 ```Unexpected error from calling callback function TypeError: Cannot call a class constructor without |new|\n    at Agent (node:http:361:14)\n    at HttpsOcspAgent```

```Unexpected error from calling callback function TypeError: this.constructExponentialBackoffStrategy is not a function. (In 'this.constructExponentialBackoffStrategy()', 'this.constructExponentialBackoffStrategy' is undefined)\n    at prepareRequestOptions ```
### Checklist
- [x] Format code according to the existing code style (run `npm run lint:check -- CHANGED_FILES` and fix problems in changed code)
- [ ] Create tests which fail without the change (if possible)
- [ ] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [ ] Extend the README / documentation and ensure is properly displayed (if necessary)
- [ ] Provide JIRA issue id (if possible) or GitHub issue id in commit message
