### PR TITLE
SNOW-1230848 Fix timestamp discrepancy related to rounding issue in sf_timestamp

### DIFF
--- a/lib/connection/result/sf_timestamp.js
+++ b/lib/connection/result/sf_timestamp.js
@@ -60,8 +60,9 @@ function SfTimestamp(epochSeconds, nanoSeconds, scale, timezone, format) {
   this.timezone = timezone;
   this.format = format;
 
-  // compute the epoch milliseconds and create a moment object from them
-  let moment = Moment((epochSeconds * 1000) + (nanoSeconds / 1000000));
+  // create a moment object that includes the epoch seconds and the incremental nano seconds
+  // X corresponds to UNIX epoch, SSSSSSSSS corresponds to nano seconds
+  let moment = Moment(`${epochSeconds}.${nanoSeconds}`, 'X.SSSSSSSSS');
 
   // set the moment's timezone
   if (Util.isString(timezone)) {

--- a/test/unit/connection/result/result_test_timestamp.js
+++ b/test/unit/connection/result/result_test_timestamp.js
@@ -134,6 +134,7 @@ describe('Result: test timestamp', function () {
           assert.strictEqual(actualTimestamp.toJSON(), '9999-12-31 23:59:59.999');
           assert.strictEqual(actualTimestamp.getNanoSeconds(), 999999999);
           assert.strictEqual(actualTimestamp.getEpochSeconds(), 253402300799);
+          assert.strictEqual(actualTimestamp.getScale(), 9);
         },
         function () {
           done();

--- a/test/unit/connection/result/result_test_timestamp.js
+++ b/test/unit/connection/result/result_test_timestamp.js
@@ -82,16 +82,16 @@ describe('Result: test timestamp', function () {
     );
   });
 
-  it('select dateadd(ns,-1, to_timestamp_ntz(\'10000-01-01T00:00:00\', \'YYYY-MM-DD\"T\"HH24:MI:SS\')) AS C1;',
-  function (done) {
-    const response =
+  it('select dateadd(ns,-1, to_timestamp_ntz(\'10000-01-01T00:00:00\', \'YYYY-MM-DD"T"HH24:MI:SS\')) AS C1;',
+    function (done) {
+      const response =
         {
           'data': {
             'parameters': [
               { 'name': 'TIMEZONE', 'value': 'America/Los_Angeles' },
               { 'name': 'TIMESTAMP_OUTPUT_FORMAT', 'value': 'YYYY-MM-DD HH24:MI:SS.FF3' },
               { 'name': 'TIMESTAMP_NTZ_OUTPUT_FORMAT', 'value': '' },
-              { 'name': 'TIMESTAMP_LTZ_OUTPUT_FORMAT', 'value': ''},
+              { 'name': 'TIMESTAMP_LTZ_OUTPUT_FORMAT', 'value': '' },
               { 'name': 'TIMESTAMP_TZ_OUTPUT_FORMAT', 'value': '' },
               { 'name': 'DATE_OUTPUT_FORMAT', 'value': 'YYYY-MM-DD' },
               { 'name': 'CLIENT_RESULT_PREFETCH_SLOTS', 'value': 2 },
@@ -126,17 +126,17 @@ describe('Result: test timestamp', function () {
           'success': true
         };
 
-    ResultTestCommon.testResult(
-      ResultTestCommon.createResultOptions(response),
-      function (row) {
-        assert.ok(Util.isDate(row.getColumnValue('C1')));
-        assert.strictEqual(
-          row.getColumnValue('C1').toJSON(),
-          '9999-12-31 23:59:59.999');
-      },
-      function () {
-        done();
-      }
-    );
-  });
+      ResultTestCommon.testResult(
+        ResultTestCommon.createResultOptions(response),
+        function (row) {
+          assert.ok(Util.isDate(row.getColumnValue('C1')));
+          assert.strictEqual(
+            row.getColumnValue('C1').toJSON(),
+            '9999-12-31 23:59:59.999');
+        },
+        function () {
+          done();
+        }
+      );
+    });
 });

--- a/test/unit/connection/result/result_test_timestamp.js
+++ b/test/unit/connection/result/result_test_timestamp.js
@@ -81,4 +81,62 @@ describe('Result: test timestamp', function () {
       }
     );
   });
+
+  it('select dateadd(ns,-1, to_timestamp_ntz(\'10000-01-01T00:00:00\', \'YYYY-MM-DD\"T\"HH24:MI:SS\')) AS C1;',
+  function (done) {
+    const response =
+        {
+          'data': {
+            'parameters': [
+              { 'name': 'TIMEZONE', 'value': 'America/Los_Angeles' },
+              { 'name': 'TIMESTAMP_OUTPUT_FORMAT', 'value': 'YYYY-MM-DD HH24:MI:SS.FF3' },
+              { 'name': 'TIMESTAMP_NTZ_OUTPUT_FORMAT', 'value': '' },
+              { 'name': 'TIMESTAMP_LTZ_OUTPUT_FORMAT', 'value': ''},
+              { 'name': 'TIMESTAMP_TZ_OUTPUT_FORMAT', 'value': '' },
+              { 'name': 'DATE_OUTPUT_FORMAT', 'value': 'YYYY-MM-DD' },
+              { 'name': 'CLIENT_RESULT_PREFETCH_SLOTS', 'value': 2 },
+              { 'name': 'CLIENT_RESULT_PREFETCH_THREADS', 'value': 1 },
+              { 'name': 'CLIENT_HONOR_CLIENT_TZ_FOR_TIMESTAMP_NTZ', 'value': true },
+              { 'name': 'CLIENT_USE_V1_QUERY_API', 'value': true }
+            ],
+            'rowtype': [{
+              'name': 'C1',
+              'byteLength': null,
+              'nullable': false,
+              'precision': 0,
+              'scale': 9,
+              'length': null,
+              'type': 'timestamp_ntz'
+            }],
+            'rowset': [['253402300799.999999999']],
+            'total': 1,
+            'returned': 1,
+            'queryId': 'b603b7fb-48df-48b6-bc90-25a7cb355e1d',
+            'databaseProvider': null,
+            'finalDatabaseName': null,
+            'finalSchemaName': null,
+            'finalWarehouseName': 'NEW_WH',
+            'finalRoleName': 'ACCOUNTADMIN',
+            'numberOfBinds': 0,
+            'statementTypeId': 4096,
+            'version': 0
+          },
+          'message': null,
+          'code': null,
+          'success': true
+        };
+
+    ResultTestCommon.testResult(
+      ResultTestCommon.createResultOptions(response),
+      function (row) {
+        assert.ok(Util.isDate(row.getColumnValue('C1')));
+        assert.strictEqual(
+          row.getColumnValue('C1').toJSON(),
+          '9999-12-31 23:59:59.999');
+      },
+      function () {
+        done();
+      }
+    );
+  });
 });

--- a/test/unit/connection/result/result_test_timestamp.js
+++ b/test/unit/connection/result/result_test_timestamp.js
@@ -129,10 +129,11 @@ describe('Result: test timestamp', function () {
       ResultTestCommon.testResult(
         ResultTestCommon.createResultOptions(response),
         function (row) {
+          const actualTimestamp = row.getColumnValue('C1');
           assert.ok(Util.isDate(row.getColumnValue('C1')));
-          assert.strictEqual(
-            row.getColumnValue('C1').toJSON(),
-            '9999-12-31 23:59:59.999');
+          assert.strictEqual(actualTimestamp.toJSON(), '9999-12-31 23:59:59.999');
+          assert.strictEqual(actualTimestamp.getNanoSeconds(), 999999999);
+          assert.strictEqual(actualTimestamp.getEpochSeconds(), 253402300799);
         },
         function () {
           done();


### PR DESCRIPTION
### Description


#### What was the issue?
There were specific timestamps that were displayed incorrectly.
In Snowsight (the data is correct):
<img width="892" alt="image" src="https://github.com/snowflakedb/snowflake-connector-nodejs/assets/127364992/8d50ab02-7eba-4525-b75a-459c38b0171a">

Using the Node Connector (look specifically at the "TO JSON" log):
![image](https://github.com/snowflakedb/snowflake-connector-nodejs/assets/127364992/e9f2d0c1-cd49-4682-85b5-8eb12e7795ed)

#### What caused the issue?
When a SfTimestamp is created, it receives a number of epochSeconds and a number of incremental nanoSeconds. The SfTimestamp object has a property for the nanoseconds and a **moment** property.
The number of milliseconds was sometimes rounded up (from 253402300799999.999999 to 253402300800000, for example), but the property nanoseconds was not changed accordingly to reflect this rounding. This meant that, if we had 253402300799999.999999 epoch milliseconds, that would create a SfTimestamp with a moment that represents 253402300800000 epoch milliseconds, and with a nanosecond property of 999999999. That is actually 253402300800 epoch seconds and 999999999 nanoseconds (an additional second). When converting the SfTimestamp to a Date, and then converting the Date to a string, the moment and the nanosecond properties were both used, which resulted in this specific timestamp being printed as 10000-01-01 00:00:00.999 instead of 9999-12-31 23:59:59.999.
 
#### How was the issue fixed?

The fix avoids using rounding when creating the moment object. Instead of creating the moment from a number of milliseconds, it creates it using the epoch seconds and the nanoseconds, in a way that is similar to what is proposed here: https://github.com/moment/moment/issues/2022#issuecomment-114319265.

A unit test was added in order to check that this issue is fixed with the change in `sf_timestamp`

### Checklist
- [x] Format code according to the existing code style (run `npm run lint:check -- CHANGED_FILES` and fix problems in changed code)
- [x] Create tests which fail without the change (if possible)
- [x] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [x] Extend the README / documentation and ensure is properly displayed (if necessary)
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message
