### PR TITLE
SNOW-1278568: Fix externalbrowser auth for Chrome browser

### DIFF
--- a/lib/authentication/auth_web.js
+++ b/lib/authentication/auth_web.js
@@ -102,11 +102,11 @@ function AuthWeb(connectionConfig, httpClient, webbrowser) {
     open(loginUrl);
 
     // Step 4: get SAML token
-    const tokenData = await withBrowserActionTimeout(browserActionTimeout, receiveData).catch((rejected) => {
+    const tokenGetHttpLine = await withBrowserActionTimeout(browserActionTimeout, receiveData).catch((rejected) => {
       server.close();
       throw new Error(util.format('Error while getting SAML token: %s', rejected));
     });
-    processGet(tokenData);
+    processGet(tokenGetHttpLine);
   };
   
   this.generateProofKey = function () {
@@ -138,7 +138,7 @@ function AuthWeb(connectionConfig, httpClient, webbrowser) {
         // Receive the data and split by line
         const data = chunk.toString().split('\r\n');
 
-        // Stop accepting connections and close
+        // Destroy the socket
         socket.destroy();
 
         // Do not close the server until GET request is received
@@ -147,7 +147,7 @@ function AuthWeb(connectionConfig, httpClient, webbrowser) {
         }
 
         server.close();
-        resolve(data);
+        resolve(data[0]);
       });
       socket.on('error', (socketErr) => {
         if (socketErr['code'] === 'ECONNRESET') {
@@ -164,27 +164,16 @@ function AuthWeb(connectionConfig, httpClient, webbrowser) {
   /**
    * Parse the GET request and get token parameter value.
    *
-   * @param {String[]} data
+   * @param {String} tokenHttpGetLine
    *    
    * @returns {null}
    */
-  function processGet(data) {
-    let targetLine;
-
-    for (const line of data) {
-      if (line.startsWith('GET ')) {
-        targetLine = line;
-        break;
-      } else {
-        return;
-      }
-    }
-
+  function processGet(tokenHttpGetLine) {
     // Split the GET request line
-    targetLine = targetLine.split(' ');
+    const data = tokenHttpGetLine.split(' ');
 
     // Get value of the "token" query parameter
-    token = querystring.parse(targetLine[1])['/?token'];
+    token = querystring.parse(data[1])['/?token'];
   }
 
   const withBrowserActionTimeout = (millis, promise) => {

--- a/lib/authentication/auth_web.js
+++ b/lib/authentication/auth_web.js
@@ -138,7 +138,6 @@ function AuthWeb(connectionConfig, httpClient, webbrowser) {
         // Receive the data and split by line
         const data = chunk.toString().split('\r\n');
 
-        // Destroy the socket
         socket.destroy();
 
         // Do not close the server until GET request is received

--- a/lib/authentication/auth_web.js
+++ b/lib/authentication/auth_web.js
@@ -135,6 +135,11 @@ function AuthWeb(connectionConfig, httpClient, webbrowser) {
         // Receive the data and split by line
         const data = chunk.toString().split('\r\n');
 
+        // Make sure that we do not close the socket on other types of requests like OPTIONS or favicon
+        if (!data[0].startsWith('GET /?token=')) {
+          return;
+        }
+
         // Stop accepting connections and close
         socket.destroy();
         server.close();

--- a/lib/authentication/auth_web.js
+++ b/lib/authentication/auth_web.js
@@ -102,7 +102,9 @@ function AuthWeb(connectionConfig, httpClient, webbrowser) {
     open(loginUrl);
 
     // Step 4: get SAML token
-    const tokenData = await withBrowserActionTimeout(browserActionTimeout, receiveData);
+    const tokenData = await withBrowserActionTimeout(browserActionTimeout, receiveData).catch((rejected) => {
+      throw new Error(util.format('Error while getting SAML token: %s', rejected));
+    });
     processGet(tokenData);
   };
   
@@ -135,15 +137,15 @@ function AuthWeb(connectionConfig, httpClient, webbrowser) {
         // Receive the data and split by line
         const data = chunk.toString().split('\r\n');
 
-        // Make sure that we do not close the socket on other types of requests like OPTIONS or favicon
+        // Stop accepting connections and close
+        socket.destroy();
+
+        // Do not close the server until GET request is received
         if (!data[0].startsWith('GET /?token=')) {
           return;
         }
 
-        // Stop accepting connections and close
-        socket.destroy();
         server.close();
-
         resolve(data);
       });
       socket.on('error', (socketErr) => {

--- a/lib/authentication/auth_web.js
+++ b/lib/authentication/auth_web.js
@@ -103,6 +103,7 @@ function AuthWeb(connectionConfig, httpClient, webbrowser) {
 
     // Step 4: get SAML token
     const tokenData = await withBrowserActionTimeout(browserActionTimeout, receiveData).catch((rejected) => {
+      server.close();
       throw new Error(util.format('Error while getting SAML token: %s', rejected));
     });
     processGet(tokenData);

--- a/test/unit/authentication/authentication_test.js
+++ b/test/unit/authentication/authentication_test.js
@@ -155,7 +155,16 @@ describe('external browser authentication', function () {
     webbrowser = require('webbrowser');
     httpclient = require('httpclient');
 
-    const auth = new AuthWeb(connectionConfig, httpclient, webbrowser.open);
+    const fastFailConnectionConfig = {
+      getBrowserActionTimeout: () => 10,
+      getProxy: () => {},
+      getAuthenticator: () => credentials.authenticator,
+      getServiceName: () => '',
+      getDisableConsoleLogin: () => true,
+      host: 'fakehost'
+    };
+
+    const auth = new AuthWeb(fastFailConnectionConfig, httpclient, webbrowser.open);
     await assert.rejects(async () => {
       await auth.authenticate(credentials.authenticator, '', credentials.account, credentials.username);
     }, {

--- a/test/unit/authentication/authentication_test.js
+++ b/test/unit/authentication/authentication_test.js
@@ -110,14 +110,14 @@ describe('external browser authentication', function () {
   it('external browser - authenticate method is thenable', done => {
     const auth = new AuthWeb(connectionConfig, httpclient, webbrowser.open);
 
-    auth.authenticate(credentials.authenticator, '', credentials.account, credentials.username, credentials.host)
+    auth.authenticate(credentials.authenticator, '', credentials.account, credentials.username)
       .then(done)
       .catch(done);
   });
 
   it('external browser - get success', async function () {
     const auth = new AuthWeb(connectionConfig, httpclient, webbrowser.open);
-    await auth.authenticate(credentials.authenticator, '', credentials.account, credentials.username, credentials.host);
+    await auth.authenticate(credentials.authenticator, '', credentials.account, credentials.username);
 
     const body = { data: {} };
     auth.updateBody(body);
@@ -156,13 +156,11 @@ describe('external browser authentication', function () {
     httpclient = require('httpclient');
 
     const auth = new AuthWeb(connectionConfig, httpclient, webbrowser.open);
-    await auth.authenticate(credentials.authenticator, '', credentials.account, credentials.username, credentials.host);
-
-    const body = { data: {} };
-    auth.updateBody(body);
-
-    assert.strictEqual(typeof body['data']['TOKEN'], 'undefined');
-    assert.strictEqual(typeof body['data']['PROOF_KEY'], 'undefined');
+    await assert.rejects(async () => {
+      await auth.authenticate(credentials.authenticator, '', credentials.account, credentials.username);
+    }, {
+      message: /Error while getting SAML token:/
+    });
   });
 
   it('external browser - check authenticator', function () {


### PR DESCRIPTION
### Description
Starting with Chrome v123 the browser sends the `OPTIONS` request first, instead of `GET` thus the `externalbrowser` auth was failing.

### Checklist
- [x] Format code according to the existing code style (run `npm run lint:check -- CHANGED_FILES` and fix problems in changed code)
- [x] Create tests which fail without the change (if possible)
- [x] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [x] Extend the README / documentation and ensure is properly displayed (if necessary)
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message
