### PR TITLE
SNOW-1281470 bump axios to 1.6.8 to address CVE-2024-28849

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "agent-base": "^6.0.2",
     "asn1.js-rfc2560": "^5.0.0",
     "asn1.js-rfc5280": "^3.0.0",
-    "axios": "^1.6.5",
+    "axios": "^1.6.8",
     "big-integer": "^1.6.43",
     "bignumber.js": "^9.1.2",
     "binascii": "0.0.2",


### PR DESCRIPTION
The fix for the CVE is already available with `follow-redirects` 1.15.6 which is installed with `axios` 1.6.8 Snyk URL: https://security.snyk.io/vuln/SNYK-JS-FOLLOWREDIRECTS-6444610

Current requirement for `^1.6.5` already allows for `axios` 1.6.8 to be automatically installed upon every (re)installation of `snowflake-sdk` but still better to bump the minimum version
