### PR TITLE
[SNOW-1230848] Modify the way in which the Moment is created

### DIFF
--- a/lib/connection/result/sf_timestamp.js
+++ b/lib/connection/result/sf_timestamp.js
@@ -61,8 +61,8 @@ function SfTimestamp(epochSeconds, nanoSeconds, scale, timezone, format) {
   this.format = format;
 
   // create a moment object that includes the epoch seconds and the incremental nano seconds
-  // X corresponds to UNIX epoch, SSSSSSSSS corresponds to nano seconds
-  let moment = Moment(`${epochSeconds}.${nanoSeconds}`, 'X.SSSSSSSSS');
+  let moment = Moment(epochSeconds * 1000);
+  moment.nanoSeconds = nanoSeconds;
 
   // set the moment's timezone
   if (Util.isString(timezone)) {


### PR DESCRIPTION
### Description
@sfc-gh-pmotacki mentioned to me that the [fix ](https://github.com/snowflakedb/snowflake-connector-nodejs/pull/799) for SNOW-1230848 has resulted in a degraded performance when fetching rows that include timestamps. This change keeps the same fix but, instead of "parsing" the epoch seconds and nano seconds, it assigns them directly to the Moment.

### Checklist
- [x] Format code according to the existing code style (run `npm run lint:check -- CHANGED_FILES` and fix problems in changed code)
- [x] Create tests which fail without the change (if possible)
- [x] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [x] Extend the README / documentation and ensure is properly displayed (if necessary)
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message
