### PR TITLE
SNOW-1230848: Fix error related to milliseconds precision

### DIFF
--- a/lib/connection/result/sf_timestamp.js
+++ b/lib/connection/result/sf_timestamp.js
@@ -60,8 +60,9 @@ function SfTimestamp(epochSeconds, nanoSeconds, scale, timezone, format) {
   this.timezone = timezone;
   this.format = format;
 
-  // create a moment object that includes the epoch seconds and the incremental nano seconds
-  let moment = Moment((epochSeconds * 1000) + Math.trunc(nanoSeconds / 1000000));
+  // Milliseconds are truncated to avoid rounding issues, and the decimal part is not useful since Moment only supports milliseconds precision
+  const milliseconds = Math.trunc(nanoSeconds / 1000000);
+  let moment = Moment((epochSeconds * 1000) + milliseconds);
 
   // set the moment's timezone
   if (Util.isString(timezone)) {

--- a/lib/connection/result/sf_timestamp.js
+++ b/lib/connection/result/sf_timestamp.js
@@ -61,8 +61,7 @@ function SfTimestamp(epochSeconds, nanoSeconds, scale, timezone, format) {
   this.format = format;
 
   // create a moment object that includes the epoch seconds and the incremental nano seconds
-  let moment = Moment(epochSeconds * 1000);
-  moment.nanoSeconds = nanoSeconds;
+  let moment = Moment((epochSeconds * 1000) + Math.trunc(nanoSeconds / 1000000));
 
   // set the moment's timezone
   if (Util.isString(timezone)) {

--- a/test/unit/connection/result/result_test_timestamp.js
+++ b/test/unit/connection/result/result_test_timestamp.js
@@ -6,6 +6,65 @@ const Util = require('./../../../../lib/util');
 const assert = require('assert');
 const ResultTestCommon = require('./result_test_common');
 
+function checkSingleTimestamp(dateRowset, timestampOutputFormat, scale, expectedJson, done, additionalValidations = undefined) {
+  const response =
+    {
+      'data': {
+        'parameters': [
+          { 'name': 'TIMEZONE', 'value': 'America/Los_Angeles' },
+          { 'name': 'TIMESTAMP_OUTPUT_FORMAT', 'value': timestampOutputFormat },
+          { 'name': 'TIMESTAMP_NTZ_OUTPUT_FORMAT', 'value': '' },
+          { 'name': 'TIMESTAMP_LTZ_OUTPUT_FORMAT', 'value': '' },
+          { 'name': 'TIMESTAMP_TZ_OUTPUT_FORMAT', 'value': '' },
+          { 'name': 'DATE_OUTPUT_FORMAT', 'value': 'YYYY-MM-DD' },
+          { 'name': 'CLIENT_RESULT_PREFETCH_SLOTS', 'value': 2 },
+          { 'name': 'CLIENT_RESULT_PREFETCH_THREADS', 'value': 1 },
+          { 'name': 'CLIENT_HONOR_CLIENT_TZ_FOR_TIMESTAMP_NTZ', 'value': true },
+          { 'name': 'CLIENT_USE_V1_QUERY_API', 'value': true }
+        ],
+        'rowtype': [{
+          'name': 'C1',
+          'byteLength': null,
+          'nullable': false,
+          'precision': 0,
+          'scale': scale,
+          'length': null,
+          'type': 'timestamp_ntz'
+        }],
+        'rowset': [[dateRowset]],
+        'total': 1,
+        'returned': 1,
+        'queryId': 'b603b7fb-48df-48b6-bc90-25a7cb355e1d',
+        'databaseProvider': null,
+        'finalDatabaseName': null,
+        'finalSchemaName': null,
+        'finalWarehouseName': 'NEW_WH',
+        'finalRoleName': 'ACCOUNTADMIN',
+        'numberOfBinds': 0,
+        'statementTypeId': 4096,
+        'version': 0
+      },
+      'message': null,
+      'code': null,
+      'success': true
+    };
+
+  ResultTestCommon.testResult(
+    ResultTestCommon.createResultOptions(response),
+    function (row) {
+      const actualTimestamp = row.getColumnValue('C1');
+      assert.ok(Util.isDate(row.getColumnValue('C1')));
+      assert.strictEqual(actualTimestamp.toJSON(), expectedJson);
+      if (additionalValidations !== undefined) {
+        additionalValidations(actualTimestamp);
+      }
+    },
+    function () {
+      done();
+    }
+  );
+}
+
 describe('Result: test timestamp', function () {
 
   it('select to_timestamp_ltz(\'Thu, 21 Jan 2016 06:32:44 -0800\') as C1, ' +
@@ -85,60 +144,16 @@ describe('Result: test timestamp', function () {
 
   it('select dateadd(ns,-1, to_timestamp_ntz(\'10000-01-01T00:00:00\', \'YYYY-MM-DD"T"HH24:MI:SS\')) AS C1;',
     function (done) {
-      const response =
-        {
-          'data': {
-            'parameters': [
-              { 'name': 'TIMEZONE', 'value': 'America/Los_Angeles' },
-              { 'name': 'TIMESTAMP_OUTPUT_FORMAT', 'value': 'YYYY-MM-DD HH24:MI:SS.FF3' },
-              { 'name': 'TIMESTAMP_NTZ_OUTPUT_FORMAT', 'value': '' },
-              { 'name': 'TIMESTAMP_LTZ_OUTPUT_FORMAT', 'value': '' },
-              { 'name': 'TIMESTAMP_TZ_OUTPUT_FORMAT', 'value': '' },
-              { 'name': 'DATE_OUTPUT_FORMAT', 'value': 'YYYY-MM-DD' },
-              { 'name': 'CLIENT_RESULT_PREFETCH_SLOTS', 'value': 2 },
-              { 'name': 'CLIENT_RESULT_PREFETCH_THREADS', 'value': 1 },
-              { 'name': 'CLIENT_HONOR_CLIENT_TZ_FOR_TIMESTAMP_NTZ', 'value': true },
-              { 'name': 'CLIENT_USE_V1_QUERY_API', 'value': true }
-            ],
-            'rowtype': [{
-              'name': 'C1',
-              'byteLength': null,
-              'nullable': false,
-              'precision': 0,
-              'scale': 9,
-              'length': null,
-              'type': 'timestamp_ntz'
-            }],
-            'rowset': [['253402300799.999999999']],
-            'total': 1,
-            'returned': 1,
-            'queryId': 'b603b7fb-48df-48b6-bc90-25a7cb355e1d',
-            'databaseProvider': null,
-            'finalDatabaseName': null,
-            'finalSchemaName': null,
-            'finalWarehouseName': 'NEW_WH',
-            'finalRoleName': 'ACCOUNTADMIN',
-            'numberOfBinds': 0,
-            'statementTypeId': 4096,
-            'version': 0
-          },
-          'message': null,
-          'code': null,
-          'success': true
-        };
-
-      ResultTestCommon.testResult(
-        ResultTestCommon.createResultOptions(response),
-        function (row) {
-          const actualTimestamp = row.getColumnValue('C1');
-          assert.ok(Util.isDate(row.getColumnValue('C1')));
-          assert.strictEqual(actualTimestamp.toJSON(), '9999-12-31 23:59:59.999');
+      checkSingleTimestamp(
+        '253402300799.999999999',
+        'YYYY-MM-DD HH24:MI:SS.FF3',
+        9,
+        '9999-12-31 23:59:59.999',
+        done,
+        (actualTimestamp) => {
           assert.strictEqual(actualTimestamp.getNanoSeconds(), 999999999);
           assert.strictEqual(actualTimestamp.getEpochSeconds(), 253402300799);
           assert.strictEqual(actualTimestamp.getScale(), 9);
-        },
-        function () {
-          done();
         }
       );
     }
@@ -146,232 +161,48 @@ describe('Result: test timestamp', function () {
 
   it('select dateadd(ms,999, to_timestamp_ntz(\'2024-04-16T14:57:58\', \'YYYY-MM-DD"T"HH24:MI:SS\')) AS C1;',
     function (done) {
-      const response =
-        {
-          'data': {
-            'parameters': [
-              { 'name': 'TIMEZONE', 'value': 'America/Los_Angeles' },
-              { 'name': 'TIMESTAMP_OUTPUT_FORMAT', 'value': 'YYYY-MM-DD HH24:MI:SS.FF3' },
-              { 'name': 'TIMESTAMP_NTZ_OUTPUT_FORMAT', 'value': '' },
-              { 'name': 'TIMESTAMP_LTZ_OUTPUT_FORMAT', 'value': '' },
-              { 'name': 'TIMESTAMP_TZ_OUTPUT_FORMAT', 'value': '' },
-              { 'name': 'DATE_OUTPUT_FORMAT', 'value': 'YYYY-MM-DD' },
-              { 'name': 'CLIENT_RESULT_PREFETCH_SLOTS', 'value': 2 },
-              { 'name': 'CLIENT_RESULT_PREFETCH_THREADS', 'value': 1 },
-              { 'name': 'CLIENT_HONOR_CLIENT_TZ_FOR_TIMESTAMP_NTZ', 'value': true },
-              { 'name': 'CLIENT_USE_V1_QUERY_API', 'value': true }
-            ],
-            'rowtype': [{
-              'name': 'C1',
-              'byteLength': null,
-              'nullable': false,
-              'precision': 0,
-              'scale': 9,
-              'length': null,
-              'type': 'timestamp_ntz'
-            }],
-            'rowset': [['1713279478.999']],
-            'total': 1,
-            'returned': 1,
-            'queryId': 'b603b7fb-48df-48b6-bc90-25a7cb355e1d',
-            'databaseProvider': null,
-            'finalDatabaseName': null,
-            'finalSchemaName': null,
-            'finalWarehouseName': 'NEW_WH',
-            'finalRoleName': 'ACCOUNTADMIN',
-            'numberOfBinds': 0,
-            'statementTypeId': 4096,
-            'version': 0
-          },
-          'message': null,
-          'code': null,
-          'success': true
-        };
-
-      ResultTestCommon.testResult(
-        ResultTestCommon.createResultOptions(response),
-        function (row) {
-          const actualTimestamp = row.getColumnValue('C1');
-          assert.ok(Util.isDate(row.getColumnValue('C1')));
-          assert.strictEqual(actualTimestamp.toJSON(), '2024-04-16 14:57:58.999');
-        },
-        function () {
-          done();
-        }
+      checkSingleTimestamp(
+        '1713279478.999',
+        'YYYY-MM-DD HH24:MI:SS.FF3',
+        3,
+        '2024-04-16 14:57:58.999',
+        done
       );
     }
   );
 
   it('select dateadd(ms,1, to_timestamp_ntz(\'2024-04-16T14:57:58\', \'YYYY-MM-DD"T"HH24:MI:SS\')) AS C1;',
     function (done) {
-      const response =
-        {
-          'data': {
-            'parameters': [
-              { 'name': 'TIMEZONE', 'value': 'America/Los_Angeles' },
-              { 'name': 'TIMESTAMP_OUTPUT_FORMAT', 'value': 'YYYY-MM-DD HH24:MI:SS.FF3' },
-              { 'name': 'TIMESTAMP_NTZ_OUTPUT_FORMAT', 'value': '' },
-              { 'name': 'TIMESTAMP_LTZ_OUTPUT_FORMAT', 'value': '' },
-              { 'name': 'TIMESTAMP_TZ_OUTPUT_FORMAT', 'value': '' },
-              { 'name': 'DATE_OUTPUT_FORMAT', 'value': 'YYYY-MM-DD' },
-              { 'name': 'CLIENT_RESULT_PREFETCH_SLOTS', 'value': 2 },
-              { 'name': 'CLIENT_RESULT_PREFETCH_THREADS', 'value': 1 },
-              { 'name': 'CLIENT_HONOR_CLIENT_TZ_FOR_TIMESTAMP_NTZ', 'value': true },
-              { 'name': 'CLIENT_USE_V1_QUERY_API', 'value': true }
-            ],
-            'rowtype': [{
-              'name': 'C1',
-              'byteLength': null,
-              'nullable': false,
-              'precision': 0,
-              'scale': 9,
-              'length': null,
-              'type': 'timestamp_ntz'
-            }],
-            'rowset': [['1713279478.001']],
-            'total': 1,
-            'returned': 1,
-            'queryId': 'b603b7fb-48df-48b6-bc90-25a7cb355e1d',
-            'databaseProvider': null,
-            'finalDatabaseName': null,
-            'finalSchemaName': null,
-            'finalWarehouseName': 'NEW_WH',
-            'finalRoleName': 'ACCOUNTADMIN',
-            'numberOfBinds': 0,
-            'statementTypeId': 4096,
-            'version': 0
-          },
-          'message': null,
-          'code': null,
-          'success': true
-        };
-
-      ResultTestCommon.testResult(
-        ResultTestCommon.createResultOptions(response),
-        function (row) {
-          const actualTimestamp = row.getColumnValue('C1');
-          assert.ok(Util.isDate(row.getColumnValue('C1')));
-          assert.strictEqual(actualTimestamp.toJSON(), '2024-04-16 14:57:58.001');
-        },
-        function () {
-          done();
-        }
+      checkSingleTimestamp(
+        '1713279478.001',
+        'YYYY-MM-DD HH24:MI:SS.FF3',
+        3,
+        '2024-04-16 14:57:58.001',
+        done
       );
     }
   );
   
   it('select dateadd(ns,999999999, to_timestamp_ntz(\'2024-04-16T14:57:58\', \'YYYY-MM-DD"T"HH24:MI:SS\')) AS C1;',
     function (done) {
-      const response =
-        {
-          'data': {
-            'parameters': [
-              { 'name': 'TIMEZONE', 'value': 'America/Los_Angeles' },
-              { 'name': 'TIMESTAMP_OUTPUT_FORMAT', 'value': 'YYYY-MM-DD HH24:MI:SS.FF9' },
-              { 'name': 'TIMESTAMP_NTZ_OUTPUT_FORMAT', 'value': '' },
-              { 'name': 'TIMESTAMP_LTZ_OUTPUT_FORMAT', 'value': '' },
-              { 'name': 'TIMESTAMP_TZ_OUTPUT_FORMAT', 'value': '' },
-              { 'name': 'DATE_OUTPUT_FORMAT', 'value': 'YYYY-MM-DD' },
-              { 'name': 'CLIENT_RESULT_PREFETCH_SLOTS', 'value': 2 },
-              { 'name': 'CLIENT_RESULT_PREFETCH_THREADS', 'value': 1 },
-              { 'name': 'CLIENT_HONOR_CLIENT_TZ_FOR_TIMESTAMP_NTZ', 'value': true },
-              { 'name': 'CLIENT_USE_V1_QUERY_API', 'value': true }
-            ],
-            'rowtype': [{
-              'name': 'C1',
-              'byteLength': null,
-              'nullable': false,
-              'precision': 0,
-              'scale': 9,
-              'length': null,
-              'type': 'timestamp_ntz'
-            }],
-            'rowset': [['1713279478.999999999']],
-            'total': 1,
-            'returned': 1,
-            'queryId': 'b603b7fb-48df-48b6-bc90-25a7cb355e1d',
-            'databaseProvider': null,
-            'finalDatabaseName': null,
-            'finalSchemaName': null,
-            'finalWarehouseName': 'NEW_WH',
-            'finalRoleName': 'ACCOUNTADMIN',
-            'numberOfBinds': 0,
-            'statementTypeId': 4096,
-            'version': 0
-          },
-          'message': null,
-          'code': null,
-          'success': true
-        };
-
-      ResultTestCommon.testResult(
-        ResultTestCommon.createResultOptions(response),
-        function (row) {
-          const actualTimestamp = row.getColumnValue('C1');
-          assert.ok(Util.isDate(row.getColumnValue('C1')));
-          assert.strictEqual(actualTimestamp.toJSON(), '2024-04-16 14:57:58.999999999');
-        },
-        function () {
-          done();
-        }
+      checkSingleTimestamp(
+        '1713279478.999999999',
+        'YYYY-MM-DD HH24:MI:SS.FF9',
+        9,
+        '2024-04-16 14:57:58.999999999',
+        done
       );
     }
   );
 
   it('select dateadd(ns,1, to_timestamp_ntz(\'2024-04-16T14:57:58\', \'YYYY-MM-DD"T"HH24:MI:SS\')) AS C1;',
     function (done) {
-      const response =
-        {
-          'data': {
-            'parameters': [
-              { 'name': 'TIMEZONE', 'value': 'America/Los_Angeles' },
-              { 'name': 'TIMESTAMP_OUTPUT_FORMAT', 'value': 'YYYY-MM-DD HH24:MI:SS.FF9' },
-              { 'name': 'TIMESTAMP_NTZ_OUTPUT_FORMAT', 'value': '' },
-              { 'name': 'TIMESTAMP_LTZ_OUTPUT_FORMAT', 'value': '' },
-              { 'name': 'TIMESTAMP_TZ_OUTPUT_FORMAT', 'value': '' },
-              { 'name': 'DATE_OUTPUT_FORMAT', 'value': 'YYYY-MM-DD' },
-              { 'name': 'CLIENT_RESULT_PREFETCH_SLOTS', 'value': 2 },
-              { 'name': 'CLIENT_RESULT_PREFETCH_THREADS', 'value': 1 },
-              { 'name': 'CLIENT_HONOR_CLIENT_TZ_FOR_TIMESTAMP_NTZ', 'value': true },
-              { 'name': 'CLIENT_USE_V1_QUERY_API', 'value': true }
-            ],
-            'rowtype': [{
-              'name': 'C1',
-              'byteLength': null,
-              'nullable': false,
-              'precision': 0,
-              'scale': 9,
-              'length': null,
-              'type': 'timestamp_ntz'
-            }],
-            'rowset': [['1713279478.000000001']],
-            'total': 1,
-            'returned': 1,
-            'queryId': 'b603b7fb-48df-48b6-bc90-25a7cb355e1d',
-            'databaseProvider': null,
-            'finalDatabaseName': null,
-            'finalSchemaName': null,
-            'finalWarehouseName': 'NEW_WH',
-            'finalRoleName': 'ACCOUNTADMIN',
-            'numberOfBinds': 0,
-            'statementTypeId': 4096,
-            'version': 0
-          },
-          'message': null,
-          'code': null,
-          'success': true
-        };
-
-      ResultTestCommon.testResult(
-        ResultTestCommon.createResultOptions(response),
-        function (row) {
-          const actualTimestamp = row.getColumnValue('C1');
-          assert.ok(Util.isDate(row.getColumnValue('C1')));
-          assert.strictEqual(actualTimestamp.toJSON(), '2024-04-16 14:57:58.000000001');
-        },
-        function () {
-          done();
-        }
+      checkSingleTimestamp(
+        '1713279478.000000001',
+        'YYYY-MM-DD HH24:MI:SS.FF9',
+        9,
+        '2024-04-16 14:57:58.000000001',
+        done
       );
     }
   );

--- a/test/unit/connection/result/result_test_timestamp.js
+++ b/test/unit/connection/result/result_test_timestamp.js
@@ -7,6 +7,7 @@ const assert = require('assert');
 const ResultTestCommon = require('./result_test_common');
 
 describe('Result: test timestamp', function () {
+
   it('select to_timestamp_ltz(\'Thu, 21 Jan 2016 06:32:44 -0800\') as C1, ' +
     'to_timestamp_tz(\'Thu, 21 Jan 2016 06:32:44 -0800\') as C2, ' +
     'to_timestamp_ntz(\'Thu, 21 Jan 2016 06:32:44 -0800\') as C3;',
@@ -140,5 +141,238 @@ describe('Result: test timestamp', function () {
           done();
         }
       );
-    });
+    }
+  );
+
+  it('select dateadd(ms,999, to_timestamp_ntz(\'2024-04-16T14:57:58\', \'YYYY-MM-DD"T"HH24:MI:SS\')) AS C1;',
+    function (done) {
+      const response =
+        {
+          'data': {
+            'parameters': [
+              { 'name': 'TIMEZONE', 'value': 'America/Los_Angeles' },
+              { 'name': 'TIMESTAMP_OUTPUT_FORMAT', 'value': 'YYYY-MM-DD HH24:MI:SS.FF3' },
+              { 'name': 'TIMESTAMP_NTZ_OUTPUT_FORMAT', 'value': '' },
+              { 'name': 'TIMESTAMP_LTZ_OUTPUT_FORMAT', 'value': '' },
+              { 'name': 'TIMESTAMP_TZ_OUTPUT_FORMAT', 'value': '' },
+              { 'name': 'DATE_OUTPUT_FORMAT', 'value': 'YYYY-MM-DD' },
+              { 'name': 'CLIENT_RESULT_PREFETCH_SLOTS', 'value': 2 },
+              { 'name': 'CLIENT_RESULT_PREFETCH_THREADS', 'value': 1 },
+              { 'name': 'CLIENT_HONOR_CLIENT_TZ_FOR_TIMESTAMP_NTZ', 'value': true },
+              { 'name': 'CLIENT_USE_V1_QUERY_API', 'value': true }
+            ],
+            'rowtype': [{
+              'name': 'C1',
+              'byteLength': null,
+              'nullable': false,
+              'precision': 0,
+              'scale': 9,
+              'length': null,
+              'type': 'timestamp_ntz'
+            }],
+            'rowset': [['1713279478.999']],
+            'total': 1,
+            'returned': 1,
+            'queryId': 'b603b7fb-48df-48b6-bc90-25a7cb355e1d',
+            'databaseProvider': null,
+            'finalDatabaseName': null,
+            'finalSchemaName': null,
+            'finalWarehouseName': 'NEW_WH',
+            'finalRoleName': 'ACCOUNTADMIN',
+            'numberOfBinds': 0,
+            'statementTypeId': 4096,
+            'version': 0
+          },
+          'message': null,
+          'code': null,
+          'success': true
+        };
+
+      ResultTestCommon.testResult(
+        ResultTestCommon.createResultOptions(response),
+        function (row) {
+          const actualTimestamp = row.getColumnValue('C1');
+          assert.ok(Util.isDate(row.getColumnValue('C1')));
+          assert.strictEqual(actualTimestamp.toJSON(), '2024-04-16 14:57:58.999');
+        },
+        function () {
+          done();
+        }
+      );
+    }
+  );
+
+  it('select dateadd(ms,1, to_timestamp_ntz(\'2024-04-16T14:57:58\', \'YYYY-MM-DD"T"HH24:MI:SS\')) AS C1;',
+    function (done) {
+      const response =
+        {
+          'data': {
+            'parameters': [
+              { 'name': 'TIMEZONE', 'value': 'America/Los_Angeles' },
+              { 'name': 'TIMESTAMP_OUTPUT_FORMAT', 'value': 'YYYY-MM-DD HH24:MI:SS.FF3' },
+              { 'name': 'TIMESTAMP_NTZ_OUTPUT_FORMAT', 'value': '' },
+              { 'name': 'TIMESTAMP_LTZ_OUTPUT_FORMAT', 'value': '' },
+              { 'name': 'TIMESTAMP_TZ_OUTPUT_FORMAT', 'value': '' },
+              { 'name': 'DATE_OUTPUT_FORMAT', 'value': 'YYYY-MM-DD' },
+              { 'name': 'CLIENT_RESULT_PREFETCH_SLOTS', 'value': 2 },
+              { 'name': 'CLIENT_RESULT_PREFETCH_THREADS', 'value': 1 },
+              { 'name': 'CLIENT_HONOR_CLIENT_TZ_FOR_TIMESTAMP_NTZ', 'value': true },
+              { 'name': 'CLIENT_USE_V1_QUERY_API', 'value': true }
+            ],
+            'rowtype': [{
+              'name': 'C1',
+              'byteLength': null,
+              'nullable': false,
+              'precision': 0,
+              'scale': 9,
+              'length': null,
+              'type': 'timestamp_ntz'
+            }],
+            'rowset': [['1713279478.001']],
+            'total': 1,
+            'returned': 1,
+            'queryId': 'b603b7fb-48df-48b6-bc90-25a7cb355e1d',
+            'databaseProvider': null,
+            'finalDatabaseName': null,
+            'finalSchemaName': null,
+            'finalWarehouseName': 'NEW_WH',
+            'finalRoleName': 'ACCOUNTADMIN',
+            'numberOfBinds': 0,
+            'statementTypeId': 4096,
+            'version': 0
+          },
+          'message': null,
+          'code': null,
+          'success': true
+        };
+
+      ResultTestCommon.testResult(
+        ResultTestCommon.createResultOptions(response),
+        function (row) {
+          const actualTimestamp = row.getColumnValue('C1');
+          assert.ok(Util.isDate(row.getColumnValue('C1')));
+          assert.strictEqual(actualTimestamp.toJSON(), '2024-04-16 14:57:58.001');
+        },
+        function () {
+          done();
+        }
+      );
+    }
+  );
+  
+  it('select dateadd(ns,999999999, to_timestamp_ntz(\'2024-04-16T14:57:58\', \'YYYY-MM-DD"T"HH24:MI:SS\')) AS C1;',
+    function (done) {
+      const response =
+        {
+          'data': {
+            'parameters': [
+              { 'name': 'TIMEZONE', 'value': 'America/Los_Angeles' },
+              { 'name': 'TIMESTAMP_OUTPUT_FORMAT', 'value': 'YYYY-MM-DD HH24:MI:SS.FF9' },
+              { 'name': 'TIMESTAMP_NTZ_OUTPUT_FORMAT', 'value': '' },
+              { 'name': 'TIMESTAMP_LTZ_OUTPUT_FORMAT', 'value': '' },
+              { 'name': 'TIMESTAMP_TZ_OUTPUT_FORMAT', 'value': '' },
+              { 'name': 'DATE_OUTPUT_FORMAT', 'value': 'YYYY-MM-DD' },
+              { 'name': 'CLIENT_RESULT_PREFETCH_SLOTS', 'value': 2 },
+              { 'name': 'CLIENT_RESULT_PREFETCH_THREADS', 'value': 1 },
+              { 'name': 'CLIENT_HONOR_CLIENT_TZ_FOR_TIMESTAMP_NTZ', 'value': true },
+              { 'name': 'CLIENT_USE_V1_QUERY_API', 'value': true }
+            ],
+            'rowtype': [{
+              'name': 'C1',
+              'byteLength': null,
+              'nullable': false,
+              'precision': 0,
+              'scale': 9,
+              'length': null,
+              'type': 'timestamp_ntz'
+            }],
+            'rowset': [['1713279478.999999999']],
+            'total': 1,
+            'returned': 1,
+            'queryId': 'b603b7fb-48df-48b6-bc90-25a7cb355e1d',
+            'databaseProvider': null,
+            'finalDatabaseName': null,
+            'finalSchemaName': null,
+            'finalWarehouseName': 'NEW_WH',
+            'finalRoleName': 'ACCOUNTADMIN',
+            'numberOfBinds': 0,
+            'statementTypeId': 4096,
+            'version': 0
+          },
+          'message': null,
+          'code': null,
+          'success': true
+        };
+
+      ResultTestCommon.testResult(
+        ResultTestCommon.createResultOptions(response),
+        function (row) {
+          const actualTimestamp = row.getColumnValue('C1');
+          assert.ok(Util.isDate(row.getColumnValue('C1')));
+          assert.strictEqual(actualTimestamp.toJSON(), '2024-04-16 14:57:58.999999999');
+        },
+        function () {
+          done();
+        }
+      );
+    }
+  );
+
+  it('select dateadd(ns,1, to_timestamp_ntz(\'2024-04-16T14:57:58\', \'YYYY-MM-DD"T"HH24:MI:SS\')) AS C1;',
+    function (done) {
+      const response =
+        {
+          'data': {
+            'parameters': [
+              { 'name': 'TIMEZONE', 'value': 'America/Los_Angeles' },
+              { 'name': 'TIMESTAMP_OUTPUT_FORMAT', 'value': 'YYYY-MM-DD HH24:MI:SS.FF9' },
+              { 'name': 'TIMESTAMP_NTZ_OUTPUT_FORMAT', 'value': '' },
+              { 'name': 'TIMESTAMP_LTZ_OUTPUT_FORMAT', 'value': '' },
+              { 'name': 'TIMESTAMP_TZ_OUTPUT_FORMAT', 'value': '' },
+              { 'name': 'DATE_OUTPUT_FORMAT', 'value': 'YYYY-MM-DD' },
+              { 'name': 'CLIENT_RESULT_PREFETCH_SLOTS', 'value': 2 },
+              { 'name': 'CLIENT_RESULT_PREFETCH_THREADS', 'value': 1 },
+              { 'name': 'CLIENT_HONOR_CLIENT_TZ_FOR_TIMESTAMP_NTZ', 'value': true },
+              { 'name': 'CLIENT_USE_V1_QUERY_API', 'value': true }
+            ],
+            'rowtype': [{
+              'name': 'C1',
+              'byteLength': null,
+              'nullable': false,
+              'precision': 0,
+              'scale': 9,
+              'length': null,
+              'type': 'timestamp_ntz'
+            }],
+            'rowset': [['1713279478.000000001']],
+            'total': 1,
+            'returned': 1,
+            'queryId': 'b603b7fb-48df-48b6-bc90-25a7cb355e1d',
+            'databaseProvider': null,
+            'finalDatabaseName': null,
+            'finalSchemaName': null,
+            'finalWarehouseName': 'NEW_WH',
+            'finalRoleName': 'ACCOUNTADMIN',
+            'numberOfBinds': 0,
+            'statementTypeId': 4096,
+            'version': 0
+          },
+          'message': null,
+          'code': null,
+          'success': true
+        };
+
+      ResultTestCommon.testResult(
+        ResultTestCommon.createResultOptions(response),
+        function (row) {
+          const actualTimestamp = row.getColumnValue('C1');
+          assert.ok(Util.isDate(row.getColumnValue('C1')));
+          assert.strictEqual(actualTimestamp.toJSON(), '2024-04-16 14:57:58.000000001');
+        },
+        function () {
+          done();
+        }
+      );
+    }
+  );
 });

--- a/test/unit/connection/result/result_test_timestamp.js
+++ b/test/unit/connection/result/result_test_timestamp.js
@@ -159,18 +159,6 @@ describe('Result: test timestamp', function () {
     }
   );
 
-  it('select dateadd(ms,999, to_timestamp_ntz(\'2024-04-16T14:57:58\', \'YYYY-MM-DD"T"HH24:MI:SS\')) AS C1;',
-    function (done) {
-      checkSingleTimestamp(
-        '1713279478.999',
-        'YYYY-MM-DD HH24:MI:SS.FF3',
-        3,
-        '2024-04-16 14:57:58.999',
-        done
-      );
-    }
-  );
-
   it('select to_timestamp_ntz(\'2024-04-16T14:57:58:999\', \'YYYY-MM-DD"T"HH24:MI:SS:FF3\') AS C1;',
     function (done) {
       checkSingleTimestamp(
@@ -183,7 +171,7 @@ describe('Result: test timestamp', function () {
     }
   );
 
-  it('select dateadd(ms,1, to_timestamp_ntz(\'2024-04-16T14:57:58\', \'YYYY-MM-DD"T"HH24:MI:SS\')) AS C1;',
+  it('select to_timestamp_ntz(\'2024-04-16T14:57:58:001\', \'YYYY-MM-DD"T"HH24:MI:SS:FF3\') AS C1;',
     function (done) {
       checkSingleTimestamp(
         '1713279478.001',
@@ -195,18 +183,6 @@ describe('Result: test timestamp', function () {
     }
   );
   
-  it('select dateadd(ns,999999999, to_timestamp_ntz(\'2024-04-16T14:57:58\', \'YYYY-MM-DD"T"HH24:MI:SS\')) AS C1;',
-    function (done) {
-      checkSingleTimestamp(
-        '1713279478.999999999',
-        'YYYY-MM-DD HH24:MI:SS.FF9',
-        9,
-        '2024-04-16 14:57:58.999999999',
-        done
-      );
-    }
-  );
-
   it('select to_timestamp_ntz(\'2024-04-16T14:57:58:999999999\', \'YYYY-MM-DD"T"HH24:MI:SS:FF9\') AS C1;',
     function (done) {
       checkSingleTimestamp(
@@ -219,7 +195,7 @@ describe('Result: test timestamp', function () {
     }
   );
 
-  it('select dateadd(ns,1, to_timestamp_ntz(\'2024-04-16T14:57:58\', \'YYYY-MM-DD"T"HH24:MI:SS\')) AS C1;',
+  it('select to_timestamp_ntz(\'2024-04-16T14:57:58:000000001\', \'YYYY-MM-DD"T"HH24:MI:SS:FF9\')) AS C1;',
     function (done) {
       checkSingleTimestamp(
         '1713279478.000000001',

--- a/test/unit/connection/result/result_test_timestamp.js
+++ b/test/unit/connection/result/result_test_timestamp.js
@@ -171,6 +171,18 @@ describe('Result: test timestamp', function () {
     }
   );
 
+  it('select to_timestamp_ntz(\'2024-04-16T14:57:58:999\', \'YYYY-MM-DD"T"HH24:MI:SS:FF3\') AS C1;',
+    function (done) {
+      checkSingleTimestamp(
+        '1713279478.999',
+        'YYYY-MM-DD HH24:MI:SS.FF3',
+        3,
+        '2024-04-16 14:57:58.999',
+        done
+      );
+    }
+  );
+
   it('select dateadd(ms,1, to_timestamp_ntz(\'2024-04-16T14:57:58\', \'YYYY-MM-DD"T"HH24:MI:SS\')) AS C1;',
     function (done) {
       checkSingleTimestamp(
@@ -184,6 +196,18 @@ describe('Result: test timestamp', function () {
   );
   
   it('select dateadd(ns,999999999, to_timestamp_ntz(\'2024-04-16T14:57:58\', \'YYYY-MM-DD"T"HH24:MI:SS\')) AS C1;',
+    function (done) {
+      checkSingleTimestamp(
+        '1713279478.999999999',
+        'YYYY-MM-DD HH24:MI:SS.FF9',
+        9,
+        '2024-04-16 14:57:58.999999999',
+        done
+      );
+    }
+  );
+
+  it('select to_timestamp_ntz(\'2024-04-16T14:57:58:999999999\', \'YYYY-MM-DD"T"HH24:MI:SS:FF9\') AS C1;',
     function (done) {
       checkSingleTimestamp(
         '1713279478.999999999',


### PR DESCRIPTION
### Description
Previously, some changes had been done to address the bug SNOW-1230848. However, these changes resulted in a loss of precision in some cases in which milliseconds were used. After thinking more about this, the solution I propose is the following: instead of the original `Moment((epochSeconds * 1000) +(nanoSeconds / 1000000))`, we can use `Moment((epochSeconds * 1000) + Math.trunc(nanoSeconds / 1000000))`. This prevents the bug SNOW-1230848 (which was caused by rounding, and is described in detail [here](https://github.com/snowflakedb/snowflake-connector-nodejs/pull/799), while also preserving milliseconds and nanoseconds precision (some unit tests were added to validate this).

### Checklist
- [x] Format code according to the existing code style (run `npm run lint:check -- CHANGED_FILES` and fix problems in changed code)
- [x] Create tests which fail without the change (if possible)
- [x] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [x] Extend the README / documentation and ensure is properly displayed (if necessary)
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message
