### PR TITLE
Fix errors that happen on Windows when using PUT command

### DIFF
--- a/lib/file_transfer_agent/file_transfer_agent.js
+++ b/lib/file_transfer_agent/file_transfer_agent.js
@@ -391,7 +391,7 @@ function FileTransferAgent(context) {
         });
       }
       // Delete tmp folder
-      fs.rm(meta['tmpDir'], { recursive: true, force: true }, (err) => {
+      fs.rmdir(meta['tmpDir'], (err) => {
         if (err) {
           throw (err);
         }

--- a/lib/file_transfer_agent/file_transfer_agent.js
+++ b/lib/file_transfer_agent/file_transfer_agent.js
@@ -378,20 +378,8 @@ function FileTransferAgent(context) {
       meta['errorDetails'] = err.toString();
       meta['errorDetails'] += ` file=${meta['srcFileName']}, real file=${meta['realSrcFilePath']}`;
     } finally {
-      // Remove all files inside tmp folder
-      const matchingFileNames = getMatchingFilePaths(meta['tmpDir'], meta['srcFileName'] + '*');
-      for (const matchingFileName of matchingFileNames) {
-        await new Promise((resolve, reject) => {
-          fs.unlink(matchingFileName, err => {
-            if (err) {
-              reject(err);
-            }
-            resolve();
-          });
-        });
-      }
       // Delete tmp folder
-      fs.rmdir(meta['tmpDir'], (err) => {
+      fs.rm(meta['tmpDir'], { recursive: true, force: true }, (err) => {
         if (err) {
           throw (err);
         }

--- a/lib/file_transfer_agent/file_transfer_agent.js
+++ b/lib/file_transfer_agent/file_transfer_agent.js
@@ -378,6 +378,18 @@ function FileTransferAgent(context) {
       meta['errorDetails'] = err.toString();
       meta['errorDetails'] += ` file=${meta['srcFileName']}, real file=${meta['realSrcFilePath']}`;
     } finally {
+      // Remove all files inside tmp folder
+      const matchingFileNames = getMatchingFilePaths(meta['tmpDir'], meta['srcFileName'] + '*');
+      for (const matchingFileName of matchingFileNames) {
+        await new Promise((resolve, reject) => {
+          fs.unlink(matchingFileName, err => {
+            if (err) {
+              reject(err);
+            }
+            resolve();
+          });
+        });
+      }
       // Delete tmp folder
       fs.rm(meta['tmpDir'], { recursive: true, force: true }, (err) => {
         if (err) {

--- a/lib/file_transfer_agent/file_transfer_agent.js
+++ b/lib/file_transfer_agent/file_transfer_agent.js
@@ -625,7 +625,7 @@ function FileTransferAgent(context) {
 
               const fileInfo = fs.statSync(matchingFileName);
               const currFileObj = {};
-              currFileObj['srcFileName'] = matchingFileName.substring(matchingFileName.lastIndexOf('/') + 1);
+              currFileObj['srcFileName'] = matchingFileName.substring(matchingFileName.lastIndexOf(path.sep) + 1);
               currFileObj['srcFilePath'] = matchingFileName;
               currFileObj['srcFileSize'] = fileInfo.size;
 

--- a/lib/file_transfer_agent/file_transfer_agent.js
+++ b/lib/file_transfer_agent/file_transfer_agent.js
@@ -613,7 +613,7 @@ function FileTransferAgent(context) {
 
               const fileInfo = fs.statSync(matchingFileName);
               const currFileObj = {};
-              currFileObj['srcFileName'] = matchingFileName.substring(matchingFileName.lastIndexOf(path.sep) + 1);
+              currFileObj['srcFileName'] = path.basename(matchingFileName);
               currFileObj['srcFilePath'] = matchingFileName;
               currFileObj['srcFileSize'] = fileInfo.size;
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "fast-xml-parser": "^4.2.5",
     "fastest-levenshtein": "^1.0.16",
     "generic-pool": "^3.8.2",
-    "glob": "^9.0.0",
+    "glob": "^10.0.0",
     "https-proxy-agent": "^7.0.2",
     "jsonwebtoken": "^9.0.0",
     "mime-types": "^2.1.29",


### PR DESCRIPTION
### Summary

1. Used `path.basename` in a place where a slash was used to obtain the name of a file from a path (the slash does not work well in Windows)
2. Updated glob from v9 to v10

### Description of the first change

In `file_transfer_agent.js`, there was a place where a slash was used as the path separator (instead of the more general `path.sep`, or using `path.basename` directly). This caused the files uploaded (from Windows) with PUT to be uploaded with their absolute path instead of the corresponding relative path (see screenshot below).
<img width="1674" alt="image" src="https://github.com/snowflakedb/snowflake-connector-nodejs/assets/127364992/0abb5366-72e8-4864-a490-7195ca4108d6">

### Description of the second change
I updated **glob** from `^9.0.0` to `^10.0.0`. With v9, there was a problem that caused `glob.sync` to not find some paths in Windows (particularly in a Windows virtual machine running on Parallels. I actually believe this is working well in the Windows machines that are used to run tests with Github Actions). An example of this behavior:
```
it('test', () => {
    const pattern = 'C:/Users/LMONTE~1/AppData/Local/Temp/tmpGAO3bZ/testUploadDownload*';
    const paths = glob.sync(pattern);
    assert.strictEqual(JSON.stringify(paths), 'dummy');
  });
```
I ran this dummy test while having these two files in my filesystem (these were generated after running a PUT command over multiple files)

- C:\\Users\\LMONTE~1\\AppData\\Local\\Temp\\tmpGAO3bZ\\testUploadDownloadMultifiles-21352f62-8719-40a4-aa31-dc0766a7c7a6fae6a43d-1c27-40b2-8f6d-1a606404d2d1_c.gz#0c919e32-d05e-4abc-a95e-3a3a1ebb4b2b.undefined
- C:\\Users\\LMONTE~1\\AppData\\Local\\Temp\\tmpGAO3bZ\\testUploadDownloadMultifiles-21352f62-8719-40a4-aa31-dc0766a7c7a6fae6a43d-1c27-40b2-8f6d-1a606404d2d1_c.gz

When using glob v9, it finds an empty array. With v10, it finds both of those files. Not finding them means that the `finally` block in the `uploadOneFile` function does not manage to delete all the temporary files that were created and then fails to delete the temporary directory that was created to contain those files. When uploading multiple files, this results in the first file being uploaded, but the other files are not uploaded, and an error is thrown.

I know that version 10 comes with breaking changes but after reading through the [changelog](https://github.com/isaacs/node-glob/blob/main/changelog.md) I don't think those affect this repo. Plus, we only have one usage of glob in the repo and the tests are passing, so I don't think changing the major is risky in this case.

### Checklist
- [x] Format code according to the existing code style (run `npm run lint:check -- CHANGED_FILES` and fix problems in changed code)
- [ ] Create tests which fail without the change (if possible)
- [x] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [ ] Extend the README / documentation and ensure is properly displayed (if necessary)
- [ ] Provide JIRA issue id (if possible) or GitHub issue id in commit message
