### PR TITLE
SNOW-1226630 Parameter to disable SAML URL check for Node.js driver(2)

### DIFF
--- a/lib/authentication/auth_okta.js
+++ b/lib/authentication/auth_okta.js
@@ -244,7 +244,7 @@ function AuthOkta(connectionConfig, httpClient) {
     // Validate the post back url come back with the SAML response
     // contains the same prefix as the Snowflake's server url, which is the
     // intended destination url to Snowflake.
-    if (!connectionConfig.getDisableSamlUrlCheck()) {
+    if (!connectionConfig.getDisableSamlURLCheck()) {
       if (postBackUrl.substring(0, 20) !== fullUrl.substring(0, 20)) {
         throw new Error(util.format('The specified authenticator and destination URL ' +
           'in the SAML assertion do not match: expected: %s postback: %s', fullUrl, postBackUrl));      

--- a/lib/connection/connection_config.js
+++ b/lib/connection/connection_config.js
@@ -53,7 +53,7 @@ const DEFAULT_PARAMS =
   'disableQueryContextCache',
   'retryTimeout',
   'forceGCPUseDownscopedCredential',
-  'disableSamlUrlCheck'
+  'disableSamlURLCheck'
 ];
 const Logger = require('../logger');
 
@@ -492,12 +492,12 @@ function ConnectionConfig(options, validateCredentials, qaMode, clientInfo) {
     process.env.SNOWFLAKE_FORCE_GCP_USE_DOWNSCOPED_CREDENTIAL = false;
   }
 
-  let disableSamlUrlCheck = false;
-  if (Util.exists(options.disableSamlUrlCheck)) {
-    Errors.checkArgumentValid(Util.isBoolean(options.disableSamlUrlCheck),
+  let disableSamlURLCheck = false;
+  if (Util.exists(options.disableSamlURLCheck)) {
+    Errors.checkArgumentValid(Util.isBoolean(options.disableSamlURLCheck),
       ErrorCodes.ERR_CONN_CREATE_INVALID_DISABLE_SAML_URL_CHECK);
 
-    disableSamlUrlCheck = options.disableSamlUrlCheck;
+    disableSamlURLCheck = options.disableSamlURLCheck;
   }
 
   /**
@@ -785,8 +785,8 @@ function ConnectionConfig(options, validateCredentials, qaMode, clientInfo) {
    * 
    * @returns {Boolean}
    */
-  this.getDisableSamlUrlCheck = function () {
-    return disableSamlUrlCheck;
+  this.getdisableSamlURLCheck = function () {
+    return disableSamlURLCheck;
   };
 
   // save config options

--- a/lib/connection/connection_config.js
+++ b/lib/connection/connection_config.js
@@ -785,7 +785,7 @@ function ConnectionConfig(options, validateCredentials, qaMode, clientInfo) {
    * 
    * @returns {Boolean}
    */
-  this.getdisableSamlURLCheck = function () {
+  this.getDisableSamlURLCheck = function () {
     return disableSamlURLCheck;
   };
 

--- a/lib/constants/error_messages.js
+++ b/lib/constants/error_messages.js
@@ -73,7 +73,7 @@ exports[404045] = 'Invalid account. The specified value must be a valid subdomai
 exports[404046] = 'Invalid region. The specified value must be a valid subdomain string.';
 exports[404047] = 'Invalid disableConsoleLogin. The specified value must be a boolean';
 exports[404048] = 'Invalid disableGCPTokenUpload. The specified value must be a boolean';
-exports[404051] = 'Invalid disableSamlUrlCheck. The specified value must be a boolean';
+exports[404051] = 'Invalid disableSamlURLCheck. The specified value must be a boolean';
 
 // 405001
 exports[405001] = 'Invalid callback. The specified value must be a function.';

--- a/test/unit/connection/connection_config_test.js
+++ b/test/unit/connection/connection_config_test.js
@@ -1390,13 +1390,13 @@ describe('ConnectionConfig: basic', function () {
     const testCases =
     [
       {
-        name: 'disableSamlUrlCheck',
+        name: 'disableSamlURLCheck',
         input: {
           ...mandatoryOption,
-          disableSamlUrlCheck: true,
+          disableSamlURLCheck: true,
         },
         result: true,
-        getter: 'getDisableSamlUrlCheck',
+        getter: 'getDisableSamlURLCheck',
       },
     ];
 

--- a/test/unit/connection/connection_config_test.js
+++ b/test/unit/connection/connection_config_test.js
@@ -711,12 +711,12 @@ describe('ConnectionConfig: basic', function () {
         errorCode: ErrorCodes.ERR_CONN_CREATE_INVALID_FORCE_GCP_USE_DOWNSCOPED_CREDENTIAL
       },
       {
-        name: 'invalid disableSamlUrlCheck',
+        name: 'invalid disableSamlURLCheck',
         options: {
           account: 'account',
           username: 'username',
           password: 'password',
-          disableSamlUrlCheck: 'invalid'
+          disableSamlURLCheck: 'invalid'
         },
         errorCode: ErrorCodes.ERR_CONN_CREATE_INVALID_DISABLE_SAML_URL_CHECK
       },

--- a/test/unit/mock/mock_test_util.js
+++ b/test/unit/mock/mock_test_util.js
@@ -147,7 +147,7 @@ const connectionOptionsOkta =
   getTimeout: () => 90,
   getRetryTimeout: () => 300,
   getRetrySfMaxLoginRetries: () => 7,
-  getDisableSamlUrlCheck: () => false
+  getDisableSamlURLCheck: () => false
 };
 
 exports.connectionOptions =


### PR DESCRIPTION
### Description
Please explain the changes you made here.
- [x] As the Go driver needs to use 'disableSamlURLCheck' in order to pass Go's format check, To equate it, I converted the parameter name to DisableSamlURLCheck.

### Checklist
- [ ] Format code according to the existing code style (run `npm run lint:check -- CHANGED_FILES` and fix problems in changed code)
- [ ] Create tests which fail without the change (if possible)
- [ ] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [ ] Extend the README / documentation and ensure is properly displayed (if necessary)
- [ ] Provide JIRA issue id (if possible) or GitHub issue id in commit message
