### PR TITLE
Add rowMode to StatementOption interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -467,6 +467,11 @@ declare module 'snowflake-sdk' {
         queryId?: string;
 
         /**
+         * Returns the rowMode string value ('array', 'object' or 'object_with_renamed_duplicated_columns'). Could be null or undefined.
+         */
+        rowMode?: RowMode;
+
+        /**
          * You can also consume a result as a stream of rows by setting the streamResult connection parameter to true in connection.execute
          * when calling the statement.streamRows() method.
          * Detailed Information: https://docs.snowflake.com/en/developer-guide/node-js/nodejs-driver-consume.


### PR DESCRIPTION
### Description
Please explain the changes you made here.

PR adds `rowMode` to the `StatementOption` interface so that it can be used when using `execute` function per [the docs](https://docs.snowflake.com/en/developer-guide/node-js/nodejs-driver-consume#returning-result-sets-that-contain-duplicate-column-names):
```
connection.execute({
  rowMode: 'array',
  sqlText: 'SELECT 1',
});
```

### Checklist
- [x] Format code according to the existing code style (run `npm run lint:check -- CHANGED_FILES` and fix problems in changed code)
- [x] Create tests which fail without the change (if possible)
- [x] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [x] Extend the README / documentation and ensure is properly displayed (if necessary)
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message
