### PR TITLE
SNOW-1454926 statement.cancel isn't available anymore with Typescript (v1.11.0 regression) - missing types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -618,7 +618,7 @@ declare module 'snowflake-sdk' {
          *  Cancels this statement if possible.
          *  @param {Function} [callback]
          */
-        cancel(): void;
+        cancel(callback: StatementCallback): void;
 
         /**
          * Streams the rows in this statement's result. If start and end values are

--- a/index.d.ts
+++ b/index.d.ts
@@ -123,6 +123,9 @@ declare module 'snowflake-sdk' {
         ERR_CONN_CREATE_INVALID_ACCOUNT_REGEX = 404045,
         ERR_CONN_CREATE_INVALID_REGION_REGEX = 404046,
         ERR_CONN_CREATE_INVALID_DISABLE_CONSOLE_LOGIN = 404047,
+        ERR_CONN_CREATE_INVALID_FORCE_GCP_USE_DOWNSCOPED_CREDENTIAL = 404048,
+        ERR_CONN_CREATE_INVALID_REPRESENT_NULL_AS_STRING_NULL = 404050,
+        ERR_CONN_CREATE_INVALID_DISABLE_SAML_URL_CHECK = 404051,
 
         // 405001
         ERR_CONN_CONNECT_INVALID_CALLBACK = 405001,
@@ -281,6 +284,8 @@ declare module 'snowflake-sdk' {
          */
         host?: string;
 
+        // keepAlive?: string;
+
         /**
          * Specifies a fully-qualified endpoint for connecting to Snowflake.
          */
@@ -302,14 +307,40 @@ declare module 'snowflake-sdk' {
         authenticator?: string;
 
         /**
+         * Specifies the timeout, in milliseconds, for browser activities related to SSO authentication. The default value is 120000 (milliseconds).
+         */
+        browserActionTimeout?: number;
+
+        /**
+         * Specifies the lists of hosts that the driver should connect to directly, bypassing the proxy server (e.g. *.amazonaws.com to bypass Amazon S3 access). For multiple hosts, separate the hostnames with a pipe symbol (|). 
+         * You can also use an asterisk as a wild card. For example: noProxy: "*.amazonaws.com|*.my_company.com"
+         */
+        noProxy?: string;
+
+        /**
          * Specifies the hostname of an authenticated proxy server.
          */
         proxyHost?: string;
 
         /**
+         * Specifies the username used to connect to an authenticated proxy server.
+         */
+        proxyUser?: string;
+
+        /**
          * Specifies the password for the user specified by proxyUser.
          */
+        proxyPassword?: string;
+
+        /**
+         * Specifies the port of an authenticated proxy server.
+         */
         proxyPort?: number;
+
+        /**
+         * Specifies the protocol used to connect to the authenticated proxy server. Use this property to specify the HTTP protocol: http or https.
+         */
+        proxyProtocol?: string;
 
         /**
          * Specifies the serviceName.
@@ -350,6 +381,11 @@ declare module 'snowflake-sdk' {
          * The default schema to use for the session after connecting.
          */
         schema?: string;
+
+        /**
+         * Number of milliseconds to keep the connection alive with no response. Default: 90000 (1 minute 30 seconds).
+         */
+        timeout?: number;
 
         /**
          * The default security role to use for the session after connecting.
@@ -397,42 +433,64 @@ declare module 'snowflake-sdk' {
         arrayBindingThreshold?: number;
 
         /**
-         * Set whether the retry reason is included or not in the retry url.
-         */
-        includeRetryReason?: boolean;
-
-        /**
-         * The option to disable the query context cache.
-         * 
-         */
-        disableQueryContextCache?: boolean,
-
-        /**
          * The max login timeout value. This value is either 0 or over 300.
          */
         retryTimeout?: number;
 
         /**
-         * The option to disable the web authentication console login.
-         * 
+          * The option to skip the SAML URL check in the Okta authentication
+          */
+        disableSamlUrlCheck?: boolean;
+
+        /**
+          * The option to fetch all the null values in the columns as the string null.
+          */
+        representNullAsStringNull?: boolean;
+
+        /**
+         * Number of threads for clients to use to prefetch large result sets. Valid values: 1-10.
          */
-        disableConsoleLogin?: boolean
+        resultPrefetch?: number;
+
+
+        //Connection options Options but not on the web document.
+        /**
+         * Set whether the retry reason is included or not in the retry url.
+         */
+        includeRetryReason?: boolean;
+
+        /**
+         * Number of retries for the login request.
+         */
+        sfRetryMaxLoginRetries?: number,
+
+        forceStageBindError
+
+        /**
+         * The option to disable the query context cache.
+         */
+        disableQueryContextCache?: boolean;
+
+        /**
+         * The option to disable GCS_USE_DOWNSCOPED_CREDENTIAL session parameter
+         */
+        gcsUseDownscopedCredential?: boolean;
 
         /**
          * The option to use https request only for the snowflake server if other GCP metadata or configuration is already set on the machine.
          * The default value is false.
          */
-        forceGCPUseDownscopedCredential?: boolean,
+        forceGCPUseDownscopedCredential?: boolean;
 
         /**
-          * The option to skip the SAML URL check in the Okta authentication
-          */
-        disableSamlUrlCheck?: boolean,
+         * The option to disable the web authentication console login.
+         */
+        disableConsoleLogin?: boolean;
 
         /**
-          * The option to fetch all the null values in the columns as the string null.
-          */
-        representNullAsStringNull?: boolean,
+         *  Turn on the validation function which checks whether all the connection configuration from users are valid or not. 
+         */
+        validateDefaultParameters?: boolean;
     }
 
     export interface Connection {
@@ -509,6 +567,11 @@ declare module 'snowflake-sdk' {
          * Checks whether the given status means that there has been an error.
          */
         isAnError(): boolean;
+
+        /*
+         * Returns a serialized version of this connection.
+         */
+        serialize(): String;
     }
 
     export interface StatementOption {
@@ -614,17 +677,13 @@ declare module 'snowflake-sdk' {
         getQueryId(): string;
 
         /**
-         * 
          *  Cancels this statement if possible.
-         *  @param {Function} [callback]
          */
-        cancel(callback: StatementCallback): void;
+        cancel(callback?: StatementCallback): void;
 
         /**
          * Streams the rows in this statement's result. If start and end values are
          * specified, only rows in the specified range are streamed.
-         *
-         * @param {Object} options
          */
         streamRows(options?: StreamOptions): Readable;
 
@@ -632,8 +691,6 @@ declare module 'snowflake-sdk' {
          * Fetches the rows in this statement's result and invokes each()
          * callback on each row. If start and end values are specified each()
          * callback will only be invoked on rows in the specified range.
-         *
-         * @param {Object} options
          */
         fetchRows(options?: StreamOptions): Readable;
     }

--- a/index.d.ts
+++ b/index.d.ts
@@ -462,9 +462,12 @@ declare module 'snowflake-sdk' {
         /**
          * Number of retries for the login request.
          */
-        sfRetryMaxLoginRetries?: number,
+        sfRetryMaxLoginRetries?: number;
 
-        forceStageBindError
+        /**
+         * The option to throw an error on the bind stage if this is enabled.
+         */
+        forceStageBindError?: number;
 
         /**
          * The option to disable the query context cache.

--- a/index.d.ts
+++ b/index.d.ts
@@ -228,24 +228,32 @@ declare module 'snowflake-sdk' {
     type Readable = import('stream').Readable;
     type Pool<T> = import('generic-pool').Pool<T>;
 
+    export interface XMlParserConfigOption {
+        ignoreAttributes?: boolean;
+        alwaysCreateTextNode?: boolean;
+        attributeNamePrefix?: string;
+        attributesGroupName?: false | null | string;
+    }
+
     export interface ConfigureOptions {
         /**
          * Set the logLevel and logFilePath,
          * https://docs.snowflake.com/en/developer-guide/node-js/nodejs-driver-logs.
          */
-        logLevel?: LogLevel | undefined;
-        logFilePath?: string | undefined;
+        logLevel?: LogLevel;
+        logFilePath?: string;
+        additionalLogToConsole?: boolean | null;
 
         /**
          * Check the ocsp checking is off.
          */
-        insecureConnect?: boolean | undefined;
+        insecureConnect?: boolean;
 
         /**
          * The default value is true.
          * Detailed information: https://docs.snowflake.com/en/user-guide/ocsp.
          */
-        ocspFailOpen?: boolean | undefined;
+        ocspFailOpen?: boolean;
 
         /**
          * The Snowflake Node.js driver provides the following default parsers for processing JSON and XML data in result sets.
@@ -254,10 +262,12 @@ declare module 'snowflake-sdk' {
         jsonColumnVariantParser?: CustomParser;
         xmlColumnVariantParser?: CustomParser;
 
+        xmlParserConfig?: XMlParserConfigOption;
+
         /**
          * Specifies whether to enable keep-alive functionality on the socket immediately after receiving a new connection request.
          */
-        keepAlive?: boolean,
+        keepAlive?: boolean;
     }
 
     export interface ConnectionOptions {
@@ -611,6 +621,11 @@ declare module 'snowflake-sdk' {
          * Detailed information: https://docs.snowflake.com/en/developer-guide/node-js/nodejs-driver-execute.
          */
         parameters?: Record<string, any>;
+
+        /**
+         * Returns the rowMode string value ('array', 'object' or 'object_with_renamed_duplicated_columns'). Could be null or undefined.
+         */
+        rowMode?: RowMode;
     }
 
     export interface RowStatement {

--- a/index.d.ts
+++ b/index.d.ts
@@ -372,6 +372,11 @@ declare module 'snowflake-sdk' {
         fetchAsString?: DataType[] | undefined;
 
         /**
+         * Path to the client configuration file associated with the easy logging feature.
+         */
+        clientConfigFile?: string;
+
+        /**
          * By default, client connections typically time out approximately 3-4 hours after the most recent query was executed.
          */
         clientSessionKeepAlive?: boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -405,7 +405,7 @@ declare module 'snowflake-sdk' {
          * The option to disable the query context cache.
          * 
          */
-        disableQueryContextCache: boolean,
+        disableQueryContextCache?: boolean,
 
         /**
          * The max login timeout value. This value is either 0 or over 300.
@@ -416,7 +416,7 @@ declare module 'snowflake-sdk' {
          * The option to disable the web authentication console login.
          * 
          */
-        disableConsoleLogin: boolean
+        disableConsoleLogin?: boolean
 
         /**
          * The option to use https request only for the snowflake server if other GCP metadata or configuration is already set on the machine.
@@ -427,12 +427,12 @@ declare module 'snowflake-sdk' {
         /**
           * The option to skip the SAML URL check in the Okta authentication
           */
-        disableSamlUrlCheck: boolean,
+        disableSamlUrlCheck?: boolean,
 
         /**
           * The option to fetch all the null values in the columns as the string null.
           */
-        representNullAsStringNull: boolean,
+        representNullAsStringNull?: boolean,
     }
 
     export interface Connection {

--- a/index.d.ts
+++ b/index.d.ts
@@ -402,15 +402,37 @@ declare module 'snowflake-sdk' {
         includeRetryReason?: boolean;
 
         /**
+         * The option to disable the query context cache.
+         * 
+         */
+        disableQueryContextCache: boolean,
+
+        /**
          * The max login timeout value. This value is either 0 or over 300.
          */
         retryTimeout?: number;
 
         /**
+         * The option to disable the web authentication console login.
+         * 
+         */
+        disableConsoleLogin: boolean
+
+        /**
          * The option to use https request only for the snowflake server if other GCP metadata or configuration is already set on the machine.
          * The default value is false.
          */
-        forceGCPUseDownscopedCredential?: boolean
+        forceGCPUseDownscopedCredential?: boolean,
+
+        /**
+          * The option to skip the SAML URL check in the Okta authentication
+          */
+        disableSamlUrlCheck: boolean,
+
+        /**
+          * The option to fetch all the null values in the columns as the string null.
+          */
+        representNullAsStringNull: boolean,
     }
 
     export interface Connection {
@@ -590,6 +612,13 @@ declare module 'snowflake-sdk' {
          * yet, this method will return undefined.
          */
         getQueryId(): string;
+
+        /**
+         * 
+         *  Cancels this statement if possible.
+         *  @param {Function} [callback]
+         */
+        cancel(): void;
 
         /**
          * Streams the rows in this statement's result. If start and end values are

--- a/index.d.ts
+++ b/index.d.ts
@@ -284,8 +284,6 @@ declare module 'snowflake-sdk' {
          */
         host?: string;
 
-        // keepAlive?: string;
-
         /**
          * Specifies a fully-qualified endpoint for connecting to Snowflake.
          */
@@ -451,7 +449,6 @@ declare module 'snowflake-sdk' {
          * Number of threads for clients to use to prefetch large result sets. Valid values: 1-10.
          */
         resultPrefetch?: number;
-
 
         //Connection options Options but not on the web document.
         /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -242,6 +242,10 @@ declare module 'snowflake-sdk' {
          */
         logLevel?: LogLevel;
         logFilePath?: string;
+
+        /**
+         * additionalLogToConsole is a Boolean value that indicates whether to send log messages also to the console when a filePath is specified.
+         */
         additionalLogToConsole?: boolean | null;
 
         /**
@@ -413,7 +417,7 @@ declare module 'snowflake-sdk' {
         /**
          * return the following data types as strings: Boolean, Number, Date, Buffer, and JSON.
          */
-        fetchAsString?: DataType[] | undefined;
+        fetchAsString?: DataType[];
 
         /**
          * Path to the client configuration file associated with the easy logging feature.
@@ -589,6 +593,11 @@ declare module 'snowflake-sdk' {
         complete: StatementCallback;
 
         /**
+         * Enable asynchronous queries by including asyncExec: true in the connection.execute method.
+         */
+        asyncExec?: boolean;
+
+        /**
          * The requestId is for resubmitting requests.
          * Detailed Information: https://docs.snowflake.com/en/developer-guide/node-js/nodejs-driver-execute.
          */
@@ -626,11 +635,6 @@ declare module 'snowflake-sdk' {
          * Returns the rowMode string value ('array', 'object' or 'object_with_renamed_duplicated_columns'). Could be null or undefined.
          */
         rowMode?: RowMode;
-
-        /**
-         * Enable asynchronous queries by including asyncExec: true in the connection.execute method.
-         */
-        asyncExec?: boolean;
     }
 
     export interface RowStatement {
@@ -865,7 +869,7 @@ declare module 'snowflake-sdk' {
     export interface StreamOptions {
         start?: number;
         end?: number;
-        fetchAsString?: DataType[] | undefined;
+        fetchAsString?: DataType[];
     }
 
     /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -626,6 +626,11 @@ declare module 'snowflake-sdk' {
          * Returns the rowMode string value ('array', 'object' or 'object_with_renamed_duplicated_columns'). Could be null or undefined.
          */
         rowMode?: RowMode;
+
+        /**
+         * Enable asynchronous queries by including asyncExec: true in the connection.execute method.
+         */
+        asyncExec?: boolean;
     }
 
     export interface RowStatement {

--- a/lib/connection/connection_config.js
+++ b/lib/connection/connection_config.js
@@ -55,8 +55,8 @@ const DEFAULT_PARAMS =
   'retryTimeout',
   'disableConsoleLogin',
   'forceGCPUseDownscopedCredential',
-  'disableSamlUrlCheck',
   'representNullAsStringNull',
+  'disableSamlURLCheck',
 ];
 const Logger = require('../logger');
 

--- a/lib/connection/connection_config.js
+++ b/lib/connection/connection_config.js
@@ -57,7 +57,6 @@ const DEFAULT_PARAMS =
   'forceGCPUseDownscopedCredential',
   'disableSamlUrlCheck',
   'representNullAsStringNull',
-  'disableSamlURLCheck'
 ];
 const Logger = require('../logger');
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snowflake-sdk",
-  "version": "1.10.1",
+  "version": "1.11.0",
   "description": "Node.js driver for Snowflake",
   "dependencies": {
     "@aws-sdk/client-s3": "^3.388.0",


### PR DESCRIPTION
### Description
- [x] Added the cancel method in the statement and some new connection config options.
- [x] removed the redundant option in the connection config file. 

### Checklist
- [x] Format code according to the existing code style (run `npm run lint:check -- CHANGED_FILES` and fix problems in changed code)
- [x] Create tests which fail without the change (if possible)
- [x] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [x] Extend the README / documentation and ensure is properly displayed (if necessary)
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message
