### PR TITLE
SNOW-1369242 - In node.js driver jwt token is not recreated for each login endpoint call

### DIFF
--- a/lib/authentication/auth_keypair.js
+++ b/lib/authentication/auth_keypair.js
@@ -17,10 +17,13 @@ const util = require('../util');
  * @returns {Object}
  * @constructor
  */
-function AuthKeypair(privateKey, privateKeyPath, privateKeyPass, cryptomod, jwtmod, filesystem) {
+function AuthKeypair(connectionConfig, cryptomod, jwtmod, filesystem) {
   const crypto = typeof cryptomod !== 'undefined' ? cryptomod : require('crypto');
   const jwt = typeof jwtmod !== 'undefined' ? jwtmod : require('jsonwebtoken');
   const fs = typeof filesystem !== 'undefined' ? filesystem : require('fs');
+  let privateKey = connectionConfig.getPrivateKey();
+  const privateKeyPath = connectionConfig.getPrivateKeyPath();
+  const privateKeyPass =  connectionConfig.getPrivateKeyPass();
 
   let jwtToken;
 
@@ -134,7 +137,7 @@ function AuthKeypair(privateKey, privateKeyPath, privateKeyPass, cryptomod, jwtm
 
     // Current time + 120 seconds
     const currentTime = Date.now();
-    const jwtTokenExp = currentTime + LIFETIME;
+    const jwtTokenExp = currentTime + (LIFETIME * 1000);
 
     // Create payload containing jwt token and lifetime span
     const payload = {
@@ -146,6 +149,15 @@ function AuthKeypair(privateKey, privateKeyPath, privateKeyPass, cryptomod, jwtm
 
     // Sign payload with RS256 algorithm
     jwtToken = jwt.sign(payload, privateKey, { algorithm: ALGORITHM });
+  };
+
+  this.reauthenticate = async function (body) {
+    this.authenticate(connectionConfig.getAuthenticator(),
+      connectionConfig.getServiceName(),
+      connectionConfig.account,
+      connectionConfig.username);
+
+    this.updateBody(body);
   };
 }
 

--- a/lib/authentication/authentication.js
+++ b/lib/authentication/authentication.js
@@ -78,9 +78,7 @@ exports.getAuthenticator = function getAuthenticator(connectionConfig, httpClien
   } else if (authType === authenticationTypes.EXTERNAL_BROWSER_AUTHENTICATOR) {
     auth = new AuthWeb(connectionConfig, httpClient);
   } else if (authType === authenticationTypes.KEY_PAIR_AUTHENTICATOR) {
-    auth = new AuthKeypair(connectionConfig.getPrivateKey(),
-      connectionConfig.getPrivateKeyPath(),
-      connectionConfig.getPrivateKeyPass());
+    auth = new AuthKeypair(connectionConfig);
   } else if (authType === authenticationTypes.OAUTH_AUTHENTICATOR) {
     auth = new AuthOauth(connectionConfig.getToken());
   } else if (this.isOktaAuth(authType)) {

--- a/lib/services/sf.js
+++ b/lib/services/sf.js
@@ -57,6 +57,7 @@ const QueryContextCache = require('../queryContextCache');
 const Logger = require('../logger');
 const { getCurrentAuth } = require('../authentication/authentication');
 const AuthOkta = require('../authentication/auth_okta');
+const AuthKeypair = require('../authentication/auth_keypair');
 
 function isRetryableNetworkError(err) {
   // anything other than REVOKED error can be retryable.
@@ -1078,7 +1079,7 @@ StateConnecting.prototype.continue = function () {
   Logger.getInstance().debug('Total retryTimeout is for the retries = ' + maxRetryTimeout === 0 ? 
     'unlimited' : maxRetryTimeout);
   const parent = this;
-  const requestCallback = function (err, body) {
+  const requestCallback = async function (err, body) {
     // clear credential-related information
     connectionConfig.clearCredentials();
 
@@ -1109,7 +1110,7 @@ StateConnecting.prototype.continue = function () {
           totalElapsedTime = jitter.totalElapsedTime;
 
           if (sleep <= 0) {
-            Logger.getInstance().debug('Reached out to the Login Timeout');
+            Logger.getInstance().debug('Reached out to the max Login Timeout');
             parent.snowflakeService.transitionToDisconnected();
           }
 
@@ -1128,6 +1129,10 @@ StateConnecting.prototype.continue = function () {
               return;
             });
           } else {
+            if (auth instanceof AuthKeypair) {
+              Logger.getInstance().debug('AuthKeyPair authentication requires token refresh.');
+              await auth.reauthenticate(context.options.json);
+            }
             setTimeout(sendRequest, sleep * 1000);
             return;
           }

--- a/test/unit/authentication/authentication_test.js
+++ b/test/unit/authentication/authentication_test.js
@@ -198,19 +198,19 @@ describe('key-pair authentication', function () {
         assert.strictEqual(options.key, mockPrivateKeyFile);
 
         if (options.passphrase) {
-          assert.strictEqual(options.passphrase, connectionOptionsKeyPairPath.privateKeyPass);
+          assert.strictEqual(options.passphrase, connectionOptionsKeyPairPath.getPrivateKeyPass());
         }
 
         function privKeyObject() {
           this.export = function () {
-            return connectionOptionsKeyPair.privateKey;
+            return connectionOptionsKeyPair.getPrivateKey();
           };
         }
 
         return new privKeyObject;
       },
       createPublicKey: function (options) {
-        assert.strictEqual(options.key, connectionOptionsKeyPair.privateKey);
+        assert.strictEqual(options.key, connectionOptionsKeyPair.getPrivateKey());
 
         function pubKeyObject() {
           this.export = function () {
@@ -250,9 +250,7 @@ describe('key-pair authentication', function () {
   });
 
   it('key-pair - authenticate method is thenable', done => {
-    const auth = new AuthKeypair(connectionOptionsKeyPair.privateKey,
-      connectionOptionsKeyPair.privateKeyPath,
-      connectionOptionsKeyPair.privateKeyPass,
+    const auth = new AuthKeypair(connectionOptionsKeyPair,
       cryptomod, jwtmod, filesystem);
 
     auth.authenticate(connectionOptionsKeyPair.authenticator, '', connectionOptionsKeyPair.account, connectionOptionsKeyPair.username)
@@ -261,9 +259,7 @@ describe('key-pair authentication', function () {
   });
 
   it('key-pair - get token with private key', function () {
-    const auth = new AuthKeypair(connectionOptionsKeyPair.privateKey,
-      connectionOptionsKeyPair.privateKeyPath,
-      connectionOptionsKeyPair.privateKeyPass,
+    const auth = new AuthKeypair(connectionOptionsKeyPair,
       cryptomod, jwtmod, filesystem);
 
     auth.authenticate(connectionOptionsKeyPair.authenticator, '', connectionOptionsKeyPair.account, connectionOptionsKeyPair.username);
@@ -275,10 +271,19 @@ describe('key-pair authentication', function () {
       body['data']['TOKEN'], mockToken, 'Token should be equal');
   });
 
+  it('key-pair - get token with private key by reauthentication', async function () {
+    const auth = new AuthKeypair(connectionOptionsKeyPair,
+      cryptomod, jwtmod, filesystem);
+
+    const body = { data: { 'TOKEN': 'wrongToken' } };
+    await auth.reauthenticate(body);
+
+    assert.strictEqual(
+      body['data']['TOKEN'], mockToken, 'Token should be equal');
+  });
+
   it('key-pair - get token with private key path with passphrase', function () {
-    const auth = new AuthKeypair(connectionOptionsKeyPairPath.privateKey,
-      connectionOptionsKeyPairPath.privateKeyPath,
-      connectionOptionsKeyPairPath.privateKeyPass,
+    const auth = new AuthKeypair(connectionOptionsKeyPairPath,
       cryptomod, jwtmod, filesystem);
 
     auth.authenticate(connectionOptionsKeyPairPath.authenticator, '',
@@ -293,9 +298,7 @@ describe('key-pair authentication', function () {
   });
 
   it('key-pair - get token with private key path without passphrase', function () {
-    const auth = new AuthKeypair(connectionOptionsKeyPairPath.privateKey,
-      connectionOptionsKeyPairPath.privateKeyPath,
-      '',
+    const auth = new AuthKeypair(connectionOptionsKeyPairPath,
       cryptomod, jwtmod, filesystem);
 
     auth.authenticate(connectionOptionsKeyPairPath.authenticator, '',

--- a/test/unit/mock/mock_test_util.js
+++ b/test/unit/mock/mock_test_util.js
@@ -109,7 +109,11 @@ const connectionOptionsKeyPair =
   accessUrl: 'http://fakeaccount.snowflakecomputing.com',
   username: 'fakeusername',
   account: 'fakeaccount',
-  privateKey: 'fakeprivatekey',
+  getPrivateKey: () => 'fakeprivatekey',
+  getPrivateKeyPath: () => '',
+  getPrivateKeyPass: () => '',
+  getAuthenticator: () => 'SNOWFLAKE_JWT',
+  getServiceName: () => '',
   authenticator: 'SNOWFLAKE_JWT'
 };
 
@@ -118,8 +122,9 @@ const connectionOptionsKeyPairPath =
   accessUrl: 'http://fakeaccount.snowflakecomputing.com',
   username: 'fakeusername',
   account: 'fakeaccount',
-  privateKeyPath: 'fakeprivatekeypath',
-  privateKeyPass: 'fakeprivatekeypass',
+  getPrivateKey: () => '',
+  getPrivateKeyPath: () => 'fakeprivatekeypath',
+  getPrivateKeyPass: () => 'fakeprivatekeypass',
   authenticator: 'SNOWFLAKE_JWT'
 };
 


### PR DESCRIPTION
### Description
Please explain the changes you made here.
- [x] Fixed the timeout for the jwt token authentication. The token expiry time was 120 milliseconds.
- [x] Added reauthentication methods, so this will refresh the token if the connection needs the retry.
- [x] Fixed the JWT authentication parameters.  
- [x] Added testing.

### Checklist
- [ ] Format code according to the existing code style (run `npm run lint:check -- CHANGED_FILES` and fix problems in changed code)
- [ ] Create tests which fail without the change (if possible)
- [ ] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [ ] Extend the README / documentation and ensure is properly displayed (if necessary)
- [ ] Provide JIRA issue id (if possible) or GitHub issue id in commit message
