### PR TITLE
[APPS-42445] Support AES 256 encryption/decryption

### DIFF
--- a/lib/file_transfer_agent/encrypt_util.js
+++ b/lib/file_transfer_agent/encrypt_util.js
@@ -7,8 +7,6 @@ const crypto = require('crypto');
 const os = require('os');
 const fs = require('fs');
 const Logger = require('../logger');
-const AES_CBC = 'aes-128-cbc';
-const AES_ECB = 'aes-128-ecb';
 const AES_BLOCK_SIZE = 128;
 const blockSize = parseInt(AES_BLOCK_SIZE / 8);  // in bytes
 
@@ -31,6 +29,14 @@ function EncryptionMetadata(key, iv, matDesc) {
     'iv': iv,
     'matDesc': matDesc
   };
+}
+
+function aesCbc(keySizeInBytes) {
+  return `aes-${keySizeInBytes * 8}-cbc`;
+}
+
+function aesEcb(keySizeInBytes) {
+  return `aes-${keySizeInBytes * 8}-ecb`;
 }
 
 exports.EncryptionMetadata = EncryptionMetadata;
@@ -136,16 +142,16 @@ function EncryptUtil(encrypt, filestream, temp) {
 
     // Get secure random bytes with block size
     const ivData = getSecureRandom(blockSize);
-    const fileKey = getSecureRandom(blockSize);
+    const fileKey = getSecureRandom(keySize);
 
     // Create cipher with file key, AES CBC, and iv data
-    let cipher = crypto.createCipheriv(AES_CBC, fileKey, ivData);
+    let cipher = crypto.createCipheriv(aesCbc(keySize), fileKey, ivData);
     const encrypted = cipher.update(fileStream);
     const final = cipher.final();
     const encryptedData = Buffer.concat([encrypted, final]);
 
     // Create key cipher with decoded key and AES ECB
-    cipher = crypto.createCipheriv(AES_ECB, decodedKey, null);
+    cipher = crypto.createCipheriv(aesEcb(keySize), decodedKey, null);
 
     // Encrypt with file key
     const encKek = Buffer.concat([
@@ -187,10 +193,10 @@ function EncryptUtil(encrypt, filestream, temp) {
 
     // Get secure random bytes with block size
     const ivData = getSecureRandom(blockSize);
-    const fileKey = getSecureRandom(blockSize);
+    const fileKey = getSecureRandom(keySize);
 
     // Create cipher with file key, AES CBC, and iv data
-    let cipher = crypto.createCipheriv(AES_CBC, fileKey, ivData);
+    let cipher = crypto.createCipheriv(aesCbc(keySize), fileKey, ivData);
 
     // Create temp file
     const tmpobj = tmp.fileSync({ dir: tmpDir, prefix: path.basename(inFileName) + '#' });
@@ -214,7 +220,7 @@ function EncryptUtil(encrypt, filestream, temp) {
     });
 
     // Create key cipher with decoded key and AES ECB
-    cipher = crypto.createCipheriv(AES_ECB, decodedKey, null);
+    cipher = crypto.createCipheriv(aesEcb(keySize), decodedKey, null);
 
     // Encrypt with file key
     const encKek = Buffer.concat([
@@ -261,6 +267,7 @@ function EncryptUtil(encrypt, filestream, temp) {
 
     // Get decoded key from base64 encoded value
     const decodedKey = Buffer.from(encryptionMaterial[QUERY_STAGE_MASTER_KEY], BASE64);
+    const keySize = decodedKey.length;
 
     // Get key bytes and iv bytes from base64 encoded value
     const keyBytes = new Buffer.from(keyBase64, BASE64);
@@ -281,14 +288,14 @@ function EncryptUtil(encrypt, filestream, temp) {
     });
 
     // Create key decipher with decoded key and AES ECB
-    let decipher = crypto.createDecipheriv(AES_ECB, decodedKey, null);
+    let decipher = crypto.createDecipheriv(aesEcb(keySize), decodedKey, null);
     const fileKey = Buffer.concat([
       decipher.update(keyBytes),
       decipher.final()
     ]);
 
     // Create decipher with file key, iv bytes, and AES CBC
-    decipher = crypto.createDecipheriv(AES_CBC, fileKey, ivBytes);
+    decipher = crypto.createDecipheriv(aesCbc(keySize), fileKey, ivBytes);
 
     await new Promise(function (resolve) {
       const infile = fs.createReadStream(inFileName, { highWaterMark: chunkSize });

--- a/test/unit/file_transfer_agent/encrypt_util_test.js
+++ b/test/unit/file_transfer_agent/encrypt_util_test.js
@@ -141,7 +141,7 @@ describe('Encryption util', function () {
   });
 
   it('encrypt file with AES-256', async function () {
-    encryptionMaterial.queryStageMasterKey ='QUJDREFCQ0RBQkNEQUJDREFCQ0RBQkNEQUJDREFCQ0Q=';
+    encryptionMaterial.queryStageMasterKey = 'QUJDREFCQ0RBQkNEQUJDREFCQ0RBQkNEQUJDREFCQ0Q=';
     await runEncryptionTest();
   });
 });


### PR DESCRIPTION
### Description

Add support for AES 256 encryption, so that PUT/GET statements work when the account parameter `CLIENT_ENCRYPTION_KEY_SIZE` is set to 256 (currently, an error is thrown and the files are not uploaded/downloaded). This is achieved by:

1. Making sure the file key has the appropriate size.
2. Passing the corresponding string to the `crypto` methods (`aes-128-cbc`, `aes-256-cbc`, `aes-128-ecb` or `aes-256-ecb`, depending on the case).

### Checklist
- [x] Format code according to the existing code style (run `npm run lint:check -- CHANGED_FILES` and fix problems in changed code)
- [x] Create tests which fail without the change (if possible)
- [x] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [x] Extend the README / documentation and ensure is properly displayed (if necessary)
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message

[APPS-42445]: https://snowflakecomputing.atlassian.net/browse/APPS-42445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ