### PR TITLE
SNOW-1230605 default loglevel for Easy Logging init messages (INFO-> DEBUG)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -181,7 +181,7 @@ declare module 'snowflake-sdk' {
     export type StatementCallback = (err: SnowflakeError | undefined, stmt: RowStatement | FileAndStageBindStatement, rows?: Array<any> | undefined) => void;
     export type ConnectionCallback = (err: SnowflakeError | undefined, conn: Connection) => void;
     export type RowMode = "object" | "array" | "object_with_renamed_duplicated_columns";
-    export type LogLevel = "ERROR" | "WARN" | "INFO" | "DEBUG" | "TRACE";
+    export type LogLevel = "ERROR" | "WARN" | "INFO" | "DEBUG" | "TRACE" | "OFF";
     export type DataType = "String" | "Boolean" | "Number" | "Date" | "JSON" | "Buffer";
     export type QueryStatus = "RUNNING" | "ABORTING" | "SUCCESS" | "FAILED_WITH_ERROR" | "ABORTED" | "QUEUED" | "FAILED_WITH_INCIDENT" | "DISCONNECTED" | "RESUMING_WAREHOUSE" | "QUEUED_REPARING_WAREHOUSE" | "RESTARTED" | "BLOCKED" | "NO_DATA";
     export type StatementStatus = "fetching" | "complete";

--- a/lib/configuration/client_configuration.js
+++ b/lib/configuration/client_configuration.js
@@ -198,20 +198,20 @@ function ConfigurationUtil(fsPromisesModule, processModule) {
 
   async function findConfig(filePathFromConnectionString) {
     if (exists(filePathFromConnectionString)) {
-      Logger.getInstance().info('Using client configuration path from a connection string: %s', filePathFromConnectionString);
+      Logger.getInstance().debug('Using client configuration path from a connection string: %s', filePathFromConnectionString);
       return filePathFromConnectionString;
     }
     const filePathFromEnvVariable = await getFilePathFromEnvironmentVariable();
     if (exists(filePathFromEnvVariable)) {
-      Logger.getInstance().info('Using client configuration path from an environment variable: %s', filePathFromEnvVariable);
+      Logger.getInstance().debug('Using client configuration path from an environment variable: %s', filePathFromEnvVariable);
       return filePathFromEnvVariable;
     }
     const fileFromDefDirs = await searchForConfigInDefaultDirectories();
     if (exists(fileFromDefDirs)) {
-      Logger.getInstance().info('Using client configuration path from %s directory: %s', fileFromDefDirs.dirDescription, fileFromDefDirs.configPath);
+      Logger.getInstance().debug('Using client configuration path from %s directory: %s', fileFromDefDirs.dirDescription, fileFromDefDirs.configPath);
       return fileFromDefDirs.configPath;
     }
-    Logger.getInstance().info('No client config file found in default directories');
+    Logger.getInstance().debug('No client config file found in default directories');
     return null;
   }
 

--- a/lib/logger/easy_logging_starter.js
+++ b/lib/logger/easy_logging_starter.js
@@ -24,10 +24,10 @@ exports.init = async function (configFilePathFromConnectionString) {
     if (!allowedToInitialize(configFilePathFromConnectionString)) {
       return;
     }
-    Logger.getInstance().info('Trying to initialize Easy Logging');
+    Logger.getInstance().debug('Trying to initialize Easy Logging');
     const config = await getClientConfig(configFilePathFromConnectionString);
     if (!config) {
-      Logger.getInstance().info('Easy Logging is disabled as no config has been found');
+      Logger.getInstance().debug('Easy Logging is disabled as no config has been found');
       initTrialParameters = {
         configFilePathFromConnectionString: configFilePathFromConnectionString
       };
@@ -36,7 +36,7 @@ exports.init = async function (configFilePathFromConnectionString) {
     const logLevel = mapLogLevel(config);
     const logPath = await getLogPath(config);
     const logger = Logger.getInstance();
-    logger.info('Initializing Easy Logging with logPath=%s and logLevel=%s from file: %s', logPath, config.loggingConfig.logLevel, config.configPath);
+    logger.debug('Initializing Easy Logging with logPath=%s and logLevel=%s from file: %s', logPath, config.loggingConfig.logLevel, config.configPath);
     logger.configure({
       level: logLevel,
       filePath: path.join(logPath, 'snowflake.log'),


### PR DESCRIPTION
### Description
This is a small change trying to address user feedback (e.g. https://github.com/snowflakedb/snowflake-connector-nodejs/issues/794) which shows messages added with Easy Logging -while useful for troubleshooting- are a bit distracting at their current `INFO` loglevel.

Setting their loglevel to `DEBUG` hopefully still will allow easier troubleshooting when it's needed, where we recommend to set `DEBUG` / `TRACE` loglevel anyways.

In addition to that, added `OFF` as a possible loglevel to the typing, as it is a [valid LogLevel](https://github.com/snowflakedb/snowflake-connector-nodejs/blob/v1.12.0/lib/logger/core.js#L46-L48).

### Checklist
- [ ] Format code according to the existing code style (run `npm run lint:check -- CHANGED_FILES` and fix problems in changed code)
- [ ] Create tests which fail without the change (if possible)
- [ ] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [ ] Extend the README / documentation and ensure is properly displayed (if necessary)
- [ ] Provide JIRA issue id (if possible) or GitHub issue id in commit message
