### PR TITLE
Types: Serialized connection is a lowercase string from JSON.stringify, not the nonstandard String 

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -547,7 +547,7 @@ declare module 'snowflake-sdk' {
         /*
          * Returns a serialized version of this connection.
          */
-        serialize(): String;
+        serialize(): string;
     }
 
     export interface StatementOption {


### PR DESCRIPTION
### Description
The type is a little off. JSON.stringify returns a string, not a String.

This causes a linting error for clients. 

I'm guessing since this repo uses all of the interfaces instead of the primitives for the JSDocs, string was typo'd as String in the types file. 

<img width="659" alt="image" src="https://github.com/user-attachments/assets/2fa06b6f-ce03-40c0-a032-ea662f661e41">

### Checklist
- [x] Format code according to the existing code style (run `npm run lint:check -- CHANGED_FILES` and fix problems in changed code)
- [x] Create tests which fail without the change (if possible)
- [x] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [x] Extend the README / documentation and ensure is properly displayed (if necessary)
- [ ] Provide JIRA issue id (if possible) or GitHub issue id in commit message
