### PR TITLE
SNOW-1658878: pass callback to heartbeat call

### DIFF
--- a/lib/connection/connection.js
+++ b/lib/connection/connection.js
@@ -176,7 +176,7 @@ function Connection(context) {
   function connectCallback(self, callback) {
     return function (err) {
       if (Parameters.getValue(Parameters.names.CLIENT_SESSION_KEEP_ALIVE)) {
-        self.keepalive = setInterval(self.heartbeat, Parameters.getValue(Parameters.names.CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY) * 1000, self);
+        self.keepalive = setInterval(self.heartbeat, Parameters.getValue(Parameters.names.CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY) * 1000, callback);
       }
       if (Util.isFunction(callback)) {
         callback(Errors.externalize(err), self);


### PR DESCRIPTION
### Description
Please explain the changes you made here.

Closes: https://github.com/snowflakedb/snowflake-connector-nodejs/issues/907

Pass the `callback` to `heartbeat` method.

This bug was introduced in https://github.com/snowflakedb/snowflake-connector-nodejs/pull/502

Traces:

```
[7:44:10.457 AM]: Failed to all retries to SF.
"[7:44:10.456 AM]: Encountered an error when sending the request. Details: {""code"":""ERR_INVALID_ARG_TYPE""}"
[7:44:10.319 AM]: CALL POST with timeout 90000: https://<redacted>.snowflakecomputing.com/session/v1/login-request?requestId=e80920bc-856b-4c35-aa16-97c5d90d36cd&warehouse=<redacted>&databaseName=<redacted>&schemaName=<redacted>&clientStartTime=1726213252067&retryCount=6
[7:44:10.318 AM]: Get agent with id: https://<redacted>.snowflakecomputing.com-keepAlive from cache
"[7:44:10.317 AM]: Contacting SF: /session/v1/login-request?requestId=e80920bc-856b-4c35-aa16-97c5d90d36cd&warehouse=<redacted>&databaseName=<redacted>&schemaName=<redacted>, (7/7)"
"[7:42:18.916 AM]: Encountered an error when sending the request. Details: {""code"":""ERR_INVALID_ARG_TYPE""}"
[7:42:18.775 AM]: CALL POST with timeout 90000: https://<redacted>.snowflakecomputing.com/session/v1/login-request?requestId=20c7701b-07fe-40e5-9cf2-1386cffa82ac&warehouse=<redacted>&databaseName=<redacted>&schemaName=<redacted>&clientStartTime=1726213252067&retryCount=5
[7:42:18.775 AM]: Get agent with id: https://<redacted>.snowflakecomputing.com-keepAlive from cache
"[7:42:18.774 AM]: Contacting SF: /session/v1/login-request?requestId=20c7701b-07fe-40e5-9cf2-1386cffa82ac&warehouse=<redacted>&databaseName=<redacted>&schemaName=<redacted>, (6/7)"
"[7:41:39.034 AM]: Encountered an error when sending the request. Details: {""code"":""ERR_INVALID_ARG_TYPE""}"
[7:41:38.917 AM]: CALL POST with timeout 90000: https://<redacted>.snowflakecomputing.com/session/v1/login-request?requestId=1c906127-5d9b-4d2d-9dc7-9dd628fb62fb&warehouse=<redacted>&databaseName=<redacted>&schemaName=<redacted>&clientStartTime=1726213252067&retryCount=4
[7:41:38.917 AM]: Get agent with id: https://<redacted>.snowflakecomputing.com-keepAlive from cache
"[7:41:38.916 AM]: Contacting SF: /session/v1/login-request?requestId=1c906127-5d9b-4d2d-9dc7-9dd628fb62fb&warehouse=<redacted>&databaseName=<redacted>&schemaName=<redacted>, (5/7)"
"[7:41:19.620 AM]: Encountered an error when sending the request. Details: {""code"":""ERR_INVALID_ARG_TYPE""}"
[7:41:19.509 AM]: CALL POST with timeout 90000: https://<redacted>.snowflakecomputing.com/session/v1/login-request?requestId=d403632c-43ef-4f41-9fa0-7acc11bd5caa&warehouse=<redacted>&databaseName=<redacted>&schemaName=<redacted>&clientStartTime=1726213252067&retryCount=3
[7:41:19.509 AM]: Get agent with id: https://<redacted>.snowflakecomputing.com-keepAlive from cache
"[7:41:19.508 AM]: Contacting SF: /session/v1/login-request?requestId=d403632c-43ef-4f41-9fa0-7acc11bd5caa&warehouse=<redacted>&databaseName=<redacted>&schemaName=<redacted>, (4/7)"
"[7:41:05.036 AM]: Encountered an error when sending the request. Details: {""code"":""ERR_INVALID_ARG_TYPE""}"
[7:41:04.905 AM]: CALL POST with timeout 90000: https://<redacted>.snowflakecomputing.com/session/v1/login-request?requestId=65fa7c93-675e-48c3-8133-1458c83a807b&warehouse=<redacted>&databaseName=<redacted>&schemaName=<redacted>&clientStartTime=1726213252067&retryCount=2
[7:41:04.905 AM]: Get agent with id: https://<redacted>.snowflakecomputing.com-keepAlive from cache
"[7:41:04.904 AM]: Contacting SF: /session/v1/login-request?requestId=65fa7c93-675e-48c3-8133-1458c83a807b&warehouse=<redacted>&databaseName=<redacted>&schemaName=<redacted>, (3/7)"
"[7:40:57.781 AM]: Encountered an error when sending the request. Details: {""code"":""ERR_INVALID_ARG_TYPE""}"
[7:40:57.626 AM]: CALL POST with timeout 90000: https://<redacted>.snowflakecomputing.com/session/v1/login-request?requestId=10560cf7-32f5-4c24-8f9c-9505cb8b67b7&warehouse=<redacted>&databaseName=<redacted>&schemaName=<redacted>
[7:40:57.625 AM]: Get agent with id: https://<redacted>.snowflakecomputing.com-keepAlive from cache
"[7:40:57.624 AM]: Contacting SF: /session/v1/login-request?requestId=10560cf7-32f5-4c24-8f9c-9505cb8b67b7&warehouse=<redacted>&databaseName=<redacted>&schemaName=<redacted>, (2/7)"
"[7:40:55.225 AM]: Encountered an error when sending the request. Details: {""code"":""ERR_INVALID_ARG_TYPE""}"
[7:40:55.093 AM]: CALL POST with timeout 90000: https://<redacted>.snowflakecomputing.com/session/v1/login-request?requestId=f118221b-fed5-400e-9170-aa583c2b3804&warehouse=<redacted>&databaseName=<redacted>&schemaName=<redacted>
[7:40:55.092 AM]: Get agent with id: https://<redacted>.snowflakecomputing.com-keepAlive from cache
"[7:40:55.091 AM]: Contacting SF: /session/v1/login-request?requestId=f118221b-fed5-400e-9170-aa583c2b3804&warehouse=<redacted>&databaseName=<redacted>&schemaName=<redacted>, (1/7)"
"[7:40:53.331 AM]: Encountered an error when sending the request. Details: {""code"":""ERR_INVALID_ARG_TYPE""}"
[7:40:53.036 AM]: OCSP validation succeeded for <redacted>.snowflakecomputing.com
[7:40:53.035 AM]: Writing OCSP cache file. /root/.cache/snowflake/ocsp_response_cache.json
[7:40:52.940 AM]: /root/.cache/snowflake/ocsp_response_cache.json
[7:40:52.938 AM]: Returning OCSP status for certificate A70E4A4C3482B77F from cache
[7:40:52.868 AM]: Returning OCSP status for certificate 067F944A2A27CDF3FAC2AE2B01F908EEB9C4C6 from cache
[7:40:52.860 AM]: Returning OCSP status for certificate 0773124CD406D267C0991CDD299A9F38317985 from cache
[7:40:52.849 AM]: Returning OCSP status for certificate 0173E8C6BA8A71A96CB18E308725297A from cache
[7:40:52.413 AM]: Finish OCSP Cache Server: http://ocsp.snowflakecomputing.com/ocsp_response_cache.json
[7:40:52.335 AM]: Contact OCSP Cache Server: http://ocsp.snowflakecomputing.com/ocsp_response_cache.json
"[7:40:52.275 AM]: Failed to read OCSP cache file: /root/.cache/snowflake/ocsp_response_cache.json, err: Error: ENOENT: no such file or directory, open '/root/.cache/snowflake/ocsp_response_cache.json'
    at Object.readFileSync (node:fs:448:20)
    at new OcspResponseCache (/usr/app/node_modules/snowflake-sdk/lib/agent/ocsp_response_cache.js:79:25)
    at getOcspResponseCache (/usr/app/node_modules/snowflake-sdk/lib/agent/socket_util.js:40:37)
    at getOcspResonseAndVerify (/usr/app/node_modules/snowflake-sdk/li"
[7:40:52.273 AM]: Reading OCSP cache file. /root/.cache/snowflake/ocsp_response_cache.json
[7:40:52.256 AM]: socket reused = false
[7:40:52.071 AM]: CALL POST with timeout 90000: https://<redacted>.snowflakecomputing.com/session/v1/login-request?requestId=<redacted>&warehouse=<redacted>&databaseName=<redacted>&schemaName=<redacted>
[7:40:52.070 AM]: Proxy settings used in requests: none.
[7:40:52.070 AM]: Create and add to cache new agent https://<redacted>.snowflakecomputing.com-keepAlive
"[7:40:52.068 AM]: Contacting SF: /session/v1/login-request?requestId=<redacted>&warehouse=<redacted>&databaseName=<redacted>&schemaName=<redacted>, (0/7)"
[7:40:52.068 AM]: 300
[7:40:52.066 AM]: Easy Logging is disabled as no config has been found
[7:40:52.065 AM]: No client config file found in default directories
[7:40:52.054 AM]: Trying to initialize Easy Logging
```

After `Failed to all retries to SF` we get the error:

```
Unhandled Rejection at Promise The "callback" argument must be of type function. Received undefined
at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
at /usr/app/node_modules/snowflake-sdk/lib/http/base.js:47:19
at Object.callback (/usr/app/node_modules/snowflake-sdk/lib/services/sf.js:639:43)
at Timeout.requestCallback (/usr/app/node_modules/snowflake-sdk/lib/services/sf.js:1148:23)
at Object.callback (/usr/app/node_modules/snowflake-sdk/lib/connection/connection.js:177:26)
at setInterval (node:timers:209:3)
```

### Checklist
- [x] Format code according to the existing code style (run `npm run lint:check -- CHANGED_FILES` and fix problems in changed code)
- [x] Create tests which fail without the change (if possible)
- [x] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [x] Extend the README / documentation and ensure is properly displayed (if necessary)
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message
