### PR TITLE
[APPS-45767] Add a way for an externalBrowserCallback to be passed in to connection parameters

### DIFF
--- a/lib/authentication/auth_idtoken.js
+++ b/lib/authentication/auth_idtoken.js
@@ -7,12 +7,14 @@ const AuthWeb = require('./auth_web');
 /**
  * Creates an ID token authenticator.
  *
- * @param {String} token
+ * @param {Object} connectionConfig
+ * @param {Object} httpClient
+ * @param {module} webbrowser
  *
- * @returns {Object}
+ * @returns {Object} the authenticator
  * @constructor
  */
-function AuthIDToken(connectionConfig, httpClient) {
+function AuthIDToken(connectionConfig, httpClient, externalBrowserCallback) {
 
   this.idToken = connectionConfig.idToken;
 
@@ -31,7 +33,7 @@ function AuthIDToken(connectionConfig, httpClient) {
   this.authenticate = async function () {};
 
   this.reauthenticate = async function (body) {
-    const auth = new AuthWeb(connectionConfig, httpClient);
+    const auth = new AuthWeb(connectionConfig, httpClient, externalBrowserCallback);
     await auth.authenticate(connectionConfig.getAuthenticator(),
       connectionConfig.getServiceName(),
       connectionConfig.account,

--- a/lib/authentication/authentication.js
+++ b/lib/authentication/authentication.js
@@ -62,14 +62,15 @@ exports.formAuthJSON = function formAuthJSON(
  */
 exports.getAuthenticator = function getAuthenticator(connectionConfig, httpClient) {
   const authType = connectionConfig.getAuthenticator();
+  const externalBrowserCallback = connectionConfig.externalBrowserCallback;
   let auth;
   if (authType === AuthenticationTypes.DEFAULT_AUTHENTICATOR || authType === AuthenticationTypes.USER_PWD_MFA_AUTHENTICATOR) {
     auth = new AuthDefault(connectionConfig);
   } else if (authType === AuthenticationTypes.EXTERNAL_BROWSER_AUTHENTICATOR) {
     if (connectionConfig.getClientStoreTemporaryCredential() && !!connectionConfig.idToken) {
-      auth = new AuthIDToken(connectionConfig, httpClient);
+      auth = new AuthIDToken(connectionConfig, httpClient, externalBrowserCallback);
     } else {
-      auth = new AuthWeb(connectionConfig, httpClient);
+      auth = new AuthWeb(connectionConfig, httpClient, externalBrowserCallback);
     }
   } else if (authType === AuthenticationTypes.KEY_PAIR_AUTHENTICATOR) {
     auth = new AuthKeypair(connectionConfig);

--- a/lib/connection/connection_config.js
+++ b/lib/connection/connection_config.js
@@ -893,6 +893,7 @@ function ConnectionConfig(options, validateCredentials, qaMode, clientInfo) {
   this.masterTokenExpirationTime = options.masterTokenExpirationTime;
   this.sessionTokenExpirationTime = options.sessionTokenExpirationTime;
   this.clientConfigFile = options.clientConfigFile;
+  this.externalBrowserCallback = options.externalBrowserCallback;
 
   // create the parameters array
   const parameters = createParameters();


### PR DESCRIPTION
Since January 2023, the VS Code extension for Snowflake has patched in a way to use an externalBrowserCallback to the snowflake-connector-nodejs code so that VS Code API function openExternal can be passed in as the method to open the SSO url. This is because a subset of users experience SSO issues otherwise. For example, users using dev containers seem to have some kind of set up (perhaps proxy settings or other things) that make it so that VS Code's openExternal works but the npm open package does not. 

[APPS-19052](https://snowflakecomputing.atlassian.net/browse/APPS-19052)

I'd like to propose explicitly adding this connection config param to the snowflake-connector-nodejs for easier maintainability. 

### Checklist
- [ ] Format code according to the existing code style (run `npm run lint:check -- CHANGED_FILES` and fix problems in changed code)
- [ ] Create tests which fail without the change (if possible)
- [ ] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [ ] Extend the README / documentation and ensure is properly displayed (if necessary)
- [ ] Provide JIRA issue id (if possible) or GitHub issue id in commit message


[APPS-19052]: https://snowflakecomputing.atlassian.net/browse/APPS-19052?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ