### PR TITLE
Add missing `Connection.getServiceName` type definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -297,7 +297,7 @@ declare module 'snowflake-sdk' {
         browserActionTimeout?: number;
 
         /**
-         * Specifies the lists of hosts that the driver should connect to directly, bypassing the proxy server (e.g. *.amazonaws.com to bypass Amazon S3 access). For multiple hosts, separate the hostnames with a pipe symbol (|). 
+         * Specifies the lists of hosts that the driver should connect to directly, bypassing the proxy server (e.g. *.amazonaws.com to bypass Amazon S3 access). For multiple hosts, separate the hostnames with a pipe symbol (|).
          * You can also use an asterisk as a wild card. For example: noProxy: "*.amazonaws.com|*.my_company.com"
          */
         noProxy?: string;
@@ -474,7 +474,7 @@ declare module 'snowflake-sdk' {
         disableConsoleLogin?: boolean;
 
         /**
-         *  Turn on the validation function which checks whether all the connection configuration from users are valid or not. 
+         *  Turn on the validation function which checks whether all the connection configuration from users are valid or not.
          */
         validateDefaultParameters?: boolean;
 
@@ -569,6 +569,11 @@ declare module 'snowflake-sdk' {
          *  Gets the results from a previously ran query based on queryId.
          */
         getResultsFromQueryId(options: StatementOption): Promise<RowStatement | FileAndStageBindStatement>;
+
+        /**
+         * Gets the results from a previously ran query based on queryId and throws if there's an error.
+         */
+        getServiceName(): string;
 
         /**
          * Checks whether the given status is currently running.

--- a/index.d.ts
+++ b/index.d.ts
@@ -571,7 +571,7 @@ declare module 'snowflake-sdk' {
         getResultsFromQueryId(options: StatementOption): Promise<RowStatement | FileAndStageBindStatement>;
 
         /**
-         * Gets the results from a previously ran query based on queryId and throws if there's an error.
+         * Returns the value of the SERVICE_NAME parameter
          */
         getServiceName(): string;
 


### PR DESCRIPTION
### Description
The type definition for `Connection` was missing `getServiceName()`

### Checklist
- [x] Format code according to the existing code style (run `npm run lint:check -- CHANGED_FILES` and fix problems in changed code)
- [ ] Create tests which fail without the change (if possible)
- [ ] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [ ] Extend the README / documentation and ensure is properly displayed (if necessary)
- [ ] Provide JIRA issue id (if possible) or GitHub issue id in commit message
