### PR TITLE
SNOW-1346341 adding destination to httpsAgent cache key to be able to apply separate settings for separate destinations

### DIFF
--- a/lib/http/node.js
+++ b/lib/http/node.js
@@ -157,9 +157,4 @@ function getAgentCacheSize() {
   return httpsAgentCache.size;
 }
 
-//This is for the testing purpose.
-function clearAgentCache() {
-  return httpsAgentCache.clear();
-}
-
-module.exports = { NodeHttpClient, getProxyAgent, getAgentCacheSize, clearAgentCache };
+module.exports = { NodeHttpClient, getProxyAgent, getAgentCacheSize };

--- a/lib/http/node.js
+++ b/lib/http/node.js
@@ -127,9 +127,11 @@ function getProxyAgent(proxyOptions, parsedUrl, destination, mock) {
   try {
     destHost = new URL(destination).hostname;
   } catch (err) {
+    Logger.getInstance().error(`Failed to parse the destination to URL with the error: ${err}. Use the full destination as the host: ${destHost}`);
     destHost = destination;
   }
-  Logger.getInstance().debug(`Destination is ${destHost}`);
+  Logger.getInstance().debug(`The destination host is: ${destHost}`);
+
   const agentId = createAgentId(agentOptions.protocol, agentOptions.hostname, destHost, agentOptions.keepAlive);
   const bypassProxy = isBypassProxy(proxyOptions, destination);
   let agent;
@@ -155,4 +157,9 @@ function createAgentId(protocol, hostname, destination, keepAlive) {
   return `${protocol}//${hostname}-${destination}-${keepAlive ? 'keepAlive' : 'noKeepAlive'}`;
 }
 
-module.exports = { NodeHttpClient, getProxyAgent };
+//This is for the testing purpose.
+function getAgentCacheSize() {
+  return httpsAgentCache.size;
+}
+
+module.exports = { NodeHttpClient, getProxyAgent, getAgentCacheSize };

--- a/lib/http/node.js
+++ b/lib/http/node.js
@@ -123,8 +123,14 @@ function getProxyAgent(proxyOptions, parsedUrl, destination, mock) {
       return mockAgent;
     }
   }
-
-  const agentId = createAgentId(agentOptions.protocol, agentOptions.hostname, agentOptions.keepAlive);
+  let destHost;
+  try {
+    destHost = new URL(destination).hostname;
+  } catch (err) {
+    destHost = destination;
+  }
+  Logger.getInstance().debug(`Destination is ${destHost}`);
+  const agentId = createAgentId(agentOptions.protocol, agentOptions.hostname, destHost, agentOptions.keepAlive);
   const bypassProxy = isBypassProxy(proxyOptions, destination);
   let agent;
   const isHttps = agentOptions.protocol === 'https:';
@@ -145,8 +151,8 @@ function getProxyAgent(proxyOptions, parsedUrl, destination, mock) {
   return agent;
 }
 
-function createAgentId(protocol, hostname, keepAlive) {
-  return `${protocol}//${hostname}-${keepAlive ? 'keepAlive' : 'noKeepAlive'}`;
+function createAgentId(protocol, hostname, destination, keepAlive) {
+  return `${protocol}//${hostname}-${destination}-${keepAlive ? 'keepAlive' : 'noKeepAlive'}`;
 }
 
 module.exports = { NodeHttpClient, getProxyAgent };

--- a/lib/http/node.js
+++ b/lib/http/node.js
@@ -157,4 +157,9 @@ function getAgentCacheSize() {
   return httpsAgentCache.size;
 }
 
-module.exports = { NodeHttpClient, getProxyAgent, getAgentCacheSize };
+//This is for the testing purpose.
+function clearAgentCache() {
+  return httpsAgentCache.clear();
+}
+
+module.exports = { NodeHttpClient, getProxyAgent, getAgentCacheSize, clearAgentCache };

--- a/lib/http/node.js
+++ b/lib/http/node.js
@@ -123,13 +123,8 @@ function getProxyAgent(proxyOptions, parsedUrl, destination, mock) {
       return mockAgent;
     }
   }
-  let destHost;
-  try {
-    destHost = new URL(destination).hostname;
-  } catch (err) {
-    Logger.getInstance().error(`Failed to parse the destination to URL with the error: ${err}. Use the full destination as the host: ${destHost}`);
-    destHost = destination;
-  }
+
+  const destHost = Util.getHostFromURL(destination);
   Logger.getInstance().debug(`The destination host is: ${destHost}`);
 
   const agentId = createAgentId(agentOptions.protocol, agentOptions.hostname, destHost, agentOptions.keepAlive);

--- a/lib/util.js
+++ b/lib/util.js
@@ -905,6 +905,7 @@ exports.getHostFromURL = function (destination) {
     Logger.getInstance().error(`Failed to parse the destination to URL with the error: ${err}. Return destination as the host: ${destination}`);
     return destination;
   }
+};
 
 exports.isNotEmptyAsString = function (variable) {
   if (typeof variable === 'string') {

--- a/lib/util.js
+++ b/lib/util.js
@@ -893,3 +893,16 @@ exports.getNoProxyEnv = function () {
   }
   return undefined;
 };
+
+exports.getHostFromURL = function (destination) {
+  if (destination.indexOf('://') === -1) {
+    destination = 'https' + '://' + destination;
+  }
+
+  try {
+    return new URL(destination).hostname;
+  } catch (err) {
+    Logger.getInstance().error(`Failed to parse the destination to URL with the error: ${err}. Return destination as the host: ${destination}`);
+    return destination;
+  }
+};

--- a/test/unit/agent_cache_test.js
+++ b/test/unit/agent_cache_test.js
@@ -1,0 +1,70 @@
+const GlobalConfig = require('./../../lib/global_config');
+const getProxyAgent = require('./../../lib/http/node').getProxyAgent;
+const getAgentCacheSize = require('./../../lib/http/node').getAgentCacheSize;
+const assert = require('assert');
+
+describe('getProxtAgent', function () {
+  const mockProxy = new URL('https://user:pass@myproxy.server.com:1234');
+  const fakeAccessUrl = new URL('http://fakeaccount.snowflakecomputing.com');
+
+  const testCases = [
+    {
+      destination: 'test.destination.com',
+      isNewAgent: true,
+      keepAlive: true
+    },
+    {
+      destination: 's3.amazonaws.com',
+      isNewAgent: true,
+      keepAlive: true
+    },
+    {
+      destination: 'http://test.destination.com/login/somewhere',
+      isNewAgent: false,
+      keepAlive: true
+    },
+    {
+      destination: 'http://s3.amazonaws.com',
+      isNewAgent: false,
+      keepAlive: true
+    },
+    {
+      destination: 'https://s3.amazonaws.com',
+      isNewAgent: true,
+      keepAlive: false
+    },
+    {
+      destination: 'https://test.destination.com/login/somewhere',
+      isNewAgent: true,
+      keepAlive: false
+    },
+    {
+      destination: 'https://fakeaccount.snowflakecomputing.com/login/sessionId=something',
+      isNewAgent: true,
+      keepAlive: true
+    },
+    {
+      destination: 'https://fakeaccount.snowflakecomputing.com/other/request',
+      isNewAgent: false,
+      keepAlive: true
+    },
+    {
+      destination: 'http://fakeaccount.snowflakecomputing.com/another/request',
+      isNewAgent: true,
+      keepAlive: false
+    },
+  ];
+
+  it('test http(s) agent cache', () => {
+    let numofAgent = 0;
+    testCases.forEach(({ destination, isNewAgent, keepAlive }) => {
+      GlobalConfig.setKeepAlive(keepAlive);
+      getProxyAgent(mockProxy, fakeAccessUrl, destination);
+      if (isNewAgent) {
+        numofAgent++;
+      }
+      assert.strictEqual(getAgentCacheSize(), numofAgent);
+    });
+  });
+});
+  

--- a/test/unit/agent_cache_test.js
+++ b/test/unit/agent_cache_test.js
@@ -1,7 +1,6 @@
 const GlobalConfig = require('./../../lib/global_config');
 const getProxyAgent = require('./../../lib/http/node').getProxyAgent;
 const getAgentCacheSize = require('./../../lib/http/node').getAgentCacheSize;
-const clearAgentCache = require('./../../lib/http/node').clearAgentCache;
 const assert = require('assert');
 
 describe('getProxtAgent', function () {
@@ -25,7 +24,7 @@ describe('getProxtAgent', function () {
       keepAlive: true
     },
     {
-      destination: 's3.amazonaws.com',
+      destination: 's4.amazonaws.com',
       isNewAgent: true,
       keepAlive: true
     },
@@ -35,12 +34,12 @@ describe('getProxtAgent', function () {
       keepAlive: true
     },
     {
-      destination: 'http://s3.amazonaws.com',
+      destination: 'http://s4.amazonaws.com',
       isNewAgent: false,
       keepAlive: true
     },
     {
-      destination: 'https://s3.amazonaws.com',
+      destination: 'https://s4.amazonaws.com',
       isNewAgent: true,
       keepAlive: false
     },
@@ -50,17 +49,17 @@ describe('getProxtAgent', function () {
       keepAlive: false
     },
     {
-      destination: 'https://fakeaccount.snowflakecomputing.com/login/sessionId=something',
+      destination: 'https://fakeaccounttesting.snowflakecomputing.com/login/sessionId=something',
       isNewAgent: true,
       keepAlive: true
     },
     {
-      destination: 'https://fakeaccount.snowflakecomputing.com/other/request',
+      destination: 'https://fakeaccounttesting.snowflakecomputing.com/other/request',
       isNewAgent: false,
       keepAlive: true
     },
     {
-      destination: 'http://fakeaccount.snowflakecomputing.com/another/request',
+      destination: 'http://fakeaccounttesting.snowflakecomputing.com/another/request',
       isNewAgent: true,
       keepAlive: false
     },

--- a/test/unit/agent_cache_test.js
+++ b/test/unit/agent_cache_test.js
@@ -14,6 +14,16 @@ describe('getProxtAgent', function () {
       keepAlive: true
     },
     {
+      destination: '://test.destination.com',
+      isNewAgent: true,
+      keepAlive: true
+    },
+    {
+      destination: 'This is not a URL',
+      isNewAgent: true,
+      keepAlive: true
+    },
+    {
       destination: 's3.amazonaws.com',
       isNewAgent: true,
       keepAlive: true

--- a/test/unit/agent_cache_test.js
+++ b/test/unit/agent_cache_test.js
@@ -1,6 +1,7 @@
 const GlobalConfig = require('./../../lib/global_config');
 const getProxyAgent = require('./../../lib/http/node').getProxyAgent;
 const getAgentCacheSize = require('./../../lib/http/node').getAgentCacheSize;
+const clearAgentCache = require('./../../lib/http/node').clearAgentCache;
 const assert = require('assert');
 
 describe('getProxtAgent', function () {
@@ -66,6 +67,7 @@ describe('getProxtAgent', function () {
   ];
 
   it('test http(s) agent cache', () => {
+    clearAgentCache();
     let numofAgent = 0;
     testCases.forEach(({ destination, isNewAgent, keepAlive }) => {
       GlobalConfig.setKeepAlive(keepAlive);

--- a/test/unit/agent_cache_test.js
+++ b/test/unit/agent_cache_test.js
@@ -67,8 +67,7 @@ describe('getProxtAgent', function () {
   ];
 
   it('test http(s) agent cache', () => {
-    clearAgentCache();
-    let numofAgent = 0;
+    let numofAgent = getAgentCacheSize();
     testCases.forEach(({ destination, isNewAgent, keepAlive }) => {
       GlobalConfig.setKeepAlive(keepAlive);
       getProxyAgent(mockProxy, fakeAccessUrl, destination);


### PR DESCRIPTION
### Description
Please explain the changes you made here.
- [x] Added the destination when the driver creates the agentID for httpsAgent cache.
- [x] Added the testing for HTTP agent cache. 

### Checklist
- [ ] Format code according to the existing code style (run `npm run lint:check -- CHANGED_FILES` and fix problems in changed code)
- [ ] Create tests which fail without the change (if possible)
- [ ] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [ ] Extend the README / documentation and ensure is properly displayed (if necessary)
- [ ] Provide JIRA issue id (if possible) or GitHub issue id in commit message
