### PR TITLE
SNOW-1800528 don't log anything if logLevel is set to `OFF`

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -187,13 +187,13 @@ function Core(options) {
         const additionalLogToConsole = options.additionalLogToConsole;
 
         if (logLevel != null || logFilePath) {
-          Logger.getInstance().info('Configuring logger with level: %s, filePath: %s, additionalLogToConsole: %s', logLevel, logFilePath, additionalLogToConsole);
           Logger.getInstance().configure(
             {
               level: logLevel,
               filePath: logFilePath,
               additionalLogToConsole: additionalLogToConsole
             });
+          Logger.getInstance().info('Configuring logger with level: %s, filePath: %s, additionalLogToConsole: %s', logLevel, logFilePath, additionalLogToConsole);
         }
 
         const insecureConnect = options.insecureConnect;


### PR DESCRIPTION
### Description
In https://github.com/snowflakedb/snowflake-connector-nodejs/issues/957 is was reported that even with
`snowflake.configure({ logLevel: OFF });`

which is expected to disable logging; a single logline is still logged
```
{"level":"INFO","message":"[2:27:54.321 PM]: Configuring logger with level: -1, filePath: undefined, additionalLogToConsole: undefined"}
```
at default `INFO` level before setting loglevel to `-1` and actually disabling logging. 

Moving this logline to after the logger has been configured with local loglevel allows for preserve the same information for the ones who need it for tracking purposes, and stop logging it for the ones who wish the driver to not emit logs.

### Checklist
- [ ] Format code according to the existing code style (run `npm run lint:check -- CHANGED_FILES` and fix problems in changed code)
- [ ] Create tests which fail without the change (if possible)
- [ ] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [ ] Extend the README / documentation and ensure is properly displayed (if necessary)
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message
