### PR TITLE
SNOW-1781419: when proxy is set in Connection, driver does send traffic through the proxy to S3, but not to Azure blob / GCS bucket (only Snowflake). Works with proxy envvar (Azure)

### DIFF
--- a/lib/connection/connection_config.js
+++ b/lib/connection/connection_config.js
@@ -5,6 +5,7 @@
 const os = require('os');
 const url = require('url');
 const Util = require('../util');
+const ProxyUtil = require('../proxy_util');
 const Errors = require('../errors');
 const ConnectionConstants = require('../constants/connection_constants');
 const path = require('path');
@@ -223,7 +224,7 @@ function ConnectionConfig(options, validateCredentials, qaMode, clientInfo) {
       protocol: proxyProtocol,
       noProxy: noProxy
     };
-    Util.validateProxy(proxy);
+    ProxyUtil.validateProxy(proxy);
   }
 
   const serviceName = options.serviceName;

--- a/lib/file_transfer_agent/azure_util.js
+++ b/lib/file_transfer_agent/azure_util.js
@@ -6,6 +6,11 @@ const EncryptionMetadata = require('./encrypt_util').EncryptionMetadata;
 const FileHeader = require('./file_util').FileHeader;
 const expandTilde = require('expand-tilde');
 const resultStatus = require('./file_util').resultStatus;
+const getProxyAgent = require('../http/node').getProxyAgent;
+const Util = require('../util');
+const GlobalConfig = require('../global_config');
+const Logger = require('../logger');
+const axios = require('axios');
 
 const EXPIRED_TOKEN = 'ExpiredToken';
 
@@ -26,7 +31,7 @@ function AzureLocation(containerName, path) {
  * @returns {Object}
  * @constructor
  */
-function AzureUtil(azure, filestream) {
+function AzureUtil(connectionConfig, azure, filestream) {
   const AZURE = typeof azure !== 'undefined' ? azure : require('@azure/storage-blob');
   const fs = typeof filestream !== 'undefined' ? filestream : require('fs');
 
@@ -42,9 +47,24 @@ function AzureUtil(azure, filestream) {
     const sasToken = stageCredentials['AZURE_SAS_TOKEN'];
 
     const account = stageInfo['storageAccount'];
+    const connectionString = `https://${account}.blob.core.windows.net${sasToken}`;
+    let proxy = connectionConfig.getProxy();
+    if (!proxy && GlobalConfig.isEnvProxyActive()) {
+      proxy = Util.getProxyFromEnv();
+      if (proxy) {
+        Logger.getInstance().debug(`Azure Util loads the proxy info from the environment variable host: ${proxy.host}`);
+      }
+    }
+    const httpAgent = axios.create({
+      httpsAgent: getProxyAgent(proxy, new URL(connectionConfig.accessUrl), connectionString),
+      proxy: false
+    });
 
     const blobServiceClient = new AZURE.BlobServiceClient(
-      `https://${account}.blob.core.windows.net${sasToken}`
+      connectionString, null,
+      {
+        httpAgent: httpAgent
+      }
     );
 
     return blobServiceClient;

--- a/lib/file_transfer_agent/azure_util.js
+++ b/lib/file_transfer_agent/azure_util.js
@@ -8,6 +8,7 @@ const expandTilde = require('expand-tilde');
 const resultStatus = require('./file_util').resultStatus;
 const ProxyUtil = require('../proxy_util');
 const { isBypassProxy } = require('../http/node');
+const Logger = require('../logger');
 
 const EXPIRED_TOKEN = 'ExpiredToken';
 
@@ -46,8 +47,9 @@ function AzureUtil(connectionConfig, azure, filestream) {
     const account = stageInfo['storageAccount'];
     const connectionString = `https://${account}.blob.core.windows.net${sasToken}`;
     let proxy = ProxyUtil.getProxy(connectionConfig.getProxy(), 'Azure Util');
-    if (proxy) {
-      proxy = isBypassProxy(proxy, connectionString) ? undefined : ProxyUtil.getAzureProxy(proxy);
+    if (proxy && !isBypassProxy(proxy, connectionString)) {
+      proxy = ProxyUtil.getAzureProxy(proxy);
+      Logger.getInstance().debug(`The destination host is: ${ProxyUtil.getHostFromURL(connectionString)} and the proxy host is: ${proxy.host}`);
     }
     ProxyUtil.hideEnvironmentProxy();
     const blobServiceClient = new AZURE.BlobServiceClient(

--- a/lib/file_transfer_agent/azure_util.js
+++ b/lib/file_transfer_agent/azure_util.js
@@ -48,8 +48,11 @@ function AzureUtil(connectionConfig, azure, filestream) {
     const connectionString = `https://${account}.blob.core.windows.net${sasToken}`;
     let proxy = ProxyUtil.getProxy(connectionConfig.getProxy(), 'Azure Util');
     if (proxy && !isBypassProxy(proxy, connectionString)) {
-      proxy = ProxyUtil.getAzureProxy(proxy);
       Logger.getInstance().debug(`The destination host is: ${ProxyUtil.getHostFromURL(connectionString)} and the proxy host is: ${proxy.host}`);
+      Logger.getInstance().trace(`Initializing the proxy information for the Azure Client: ${ProxyUtil.describeProxy(proxy)}`);
+      
+      proxy = ProxyUtil.getAzureProxy(proxy);
+      Logger.getInstance().trace(connectionConfig.describe);
     }
     ProxyUtil.hideEnvironmentProxy();
     const blobServiceClient = new AZURE.BlobServiceClient(

--- a/lib/file_transfer_agent/azure_util.js
+++ b/lib/file_transfer_agent/azure_util.js
@@ -7,9 +7,7 @@ const FileHeader = require('./file_util').FileHeader;
 const expandTilde = require('expand-tilde');
 const resultStatus = require('./file_util').resultStatus;
 const getProxyAgent = require('../http/node').getProxyAgent;
-const Util = require('../util');
-const GlobalConfig = require('../global_config');
-const Logger = require('../logger');
+const ProxyUtil = require('../proxy_util');
 const axios = require('axios');
 
 const EXPIRED_TOKEN = 'ExpiredToken';
@@ -48,13 +46,7 @@ function AzureUtil(connectionConfig, azure, filestream) {
 
     const account = stageInfo['storageAccount'];
     const connectionString = `https://${account}.blob.core.windows.net${sasToken}`;
-    let proxy = connectionConfig.getProxy();
-    if (!proxy && GlobalConfig.isEnvProxyActive()) {
-      proxy = Util.getProxyFromEnv();
-      if (proxy) {
-        Logger.getInstance().debug(`Azure Util loads the proxy info from the environment variable host: ${proxy.host}`);
-      }
-    }
+    const proxy = ProxyUtil.getProxy(connectionConfig.getProxy(), 'Azure Util');
     const httpAgent = axios.create({
       httpsAgent: getProxyAgent(proxy, new URL(connectionConfig.accessUrl), connectionString),
       proxy: false

--- a/lib/file_transfer_agent/azure_util.js
+++ b/lib/file_transfer_agent/azure_util.js
@@ -6,9 +6,8 @@ const EncryptionMetadata = require('./encrypt_util').EncryptionMetadata;
 const FileHeader = require('./file_util').FileHeader;
 const expandTilde = require('expand-tilde');
 const resultStatus = require('./file_util').resultStatus;
-const getProxyAgent = require('../http/node').getProxyAgent;
 const ProxyUtil = require('../proxy_util');
-const axios = require('axios');
+const { isBypassProxy } = require('../http/node');
 
 const EXPIRED_TOKEN = 'ExpiredToken';
 
@@ -46,19 +45,18 @@ function AzureUtil(connectionConfig, azure, filestream) {
 
     const account = stageInfo['storageAccount'];
     const connectionString = `https://${account}.blob.core.windows.net${sasToken}`;
-    const proxy = ProxyUtil.getProxy(connectionConfig.getProxy(), 'Azure Util');
-    const httpAgent = axios.create({
-      httpsAgent: getProxyAgent(proxy, new URL(connectionConfig.accessUrl), connectionString),
-      proxy: false
-    });
-
+    let proxy = ProxyUtil.getProxy(connectionConfig.getProxy(), 'Azure Util');
+    if (proxy) {
+      proxy = isBypassProxy(proxy, connectionString) ? undefined : ProxyUtil.getAzureProxy(proxy);
+    }
+    ProxyUtil.hideEnvironmentProxy();
     const blobServiceClient = new AZURE.BlobServiceClient(
       connectionString, null,
       {
-        httpAgent: httpAgent
+        proxyOptions: proxy,
       }
     );
-
+    ProxyUtil.restoreEnvironmentProxy();
     return blobServiceClient;
   };
 
@@ -215,7 +213,7 @@ function AzureUtil(connectionConfig, azure, filestream) {
           blobContentEncoding: 'UTF-8',
           blobContentType: 'application/octet-stream'
         }
-      });
+      });    
     } catch (err) {
       if (err['statusCode'] === 403 && detectAzureTokenExpireError(err)) {
         meta['lastError'] = err;
@@ -227,7 +225,6 @@ function AzureUtil(connectionConfig, azure, filestream) {
       }
       return;
     }
-
     meta['dstFileSize'] = meta['uploadSize'];
     meta['resultStatus'] = resultStatus.UPLOADED;
   };
@@ -274,7 +271,6 @@ function AzureUtil(connectionConfig, azure, filestream) {
       }
       return;
     }
-
     meta['resultStatus'] = resultStatus.DOWNLOADED;
   };
 
@@ -294,5 +290,4 @@ function AzureUtil(connectionConfig, azure, filestream) {
       errstr.includes('Server failed to authenticate the request.');
   }
 }
-
 module.exports = AzureUtil;

--- a/lib/file_transfer_agent/remote_storage_util.js
+++ b/lib/file_transfer_agent/remote_storage_util.js
@@ -44,7 +44,7 @@ function RemoteStorageUtil(connectionConfig) {
     if (type === 'S3') {
       return new SnowflakeS3Util(connectionConfig);
     } else if (type === 'AZURE') {
-      return new SnowflakeAzureUtil();
+      return new SnowflakeAzureUtil(connectionConfig);
     } else if (type === 'GCS') {
       return new SnowflakeGCSUtil();
     } else {

--- a/lib/file_transfer_agent/s3_util.js
+++ b/lib/file_transfer_agent/s3_util.js
@@ -7,9 +7,7 @@ const EncryptionMetadata = require('./encrypt_util').EncryptionMetadata;
 const FileHeader = require('./file_util').FileHeader;
 const expandTilde = require('expand-tilde');
 const getProxyAgent = require('../http/node').getProxyAgent;
-const Util = require('../util');
-const Logger = require('../logger');
-const GlobalConfig = require('../global_config');
+const ProxyUtil = require('../proxy_util');
 
 const AMZ_IV = 'x-amz-iv';
 const AMZ_KEY = 'x-amz-key';
@@ -79,13 +77,7 @@ function S3Util(connectionConfig, s3, filestream) {
       useAccelerateEndpoint: useAccelerateEndpoint
     };
 
-    let proxy = connectionConfig.getProxy();
-    if (!proxy && GlobalConfig.isEnvProxyActive()) {
-      proxy = Util.getProxyFromEnv();
-      if (proxy) {
-        Logger.getInstance().debug(`S3 Util loads the proxy info from the environment variable host: ${proxy.host}`);
-      }
-    }
+    const proxy = ProxyUtil.getProxy(connectionConfig.getProxy(), 'S3 Util');
     if (proxy) {
       const proxyAgent = getProxyAgent(proxy, new URL(connectionConfig.accessUrl), endPoint || SNOWFLAKE_S3_DESTINATION);
       config.requestHandler = new NodeHttpHandler({

--- a/lib/http/node.js
+++ b/lib/http/node.js
@@ -3,6 +3,7 @@
  */
 
 const Util = require('../util');
+const ProxyUtil = require('../proxy_util');
 const Base = require('./base');
 const HttpsAgent = require('../agent/https_ocsp_agent');
 const HttpsProxyAgent = require('../agent/https_proxy_agent');
@@ -56,7 +57,7 @@ function getFromCacheOrCreate(agentClass, options, agentId) {
     Logger.getInstance().trace('Agent[id: %s] - new instance stored in cache.', agentId);
 
     // detect and log PROXY envvar + agent proxy settings
-    const compareAndLogEnvAndAgentProxies = Util.getCompareAndLogEnvAndAgentProxies(agentOptions);
+    const compareAndLogEnvAndAgentProxies = ProxyUtil.getCompareAndLogEnvAndAgentProxies(agentOptions);
     Logger.getInstance().debug('Agent[id: %s] - proxy settings used in requests: %s', agentId, compareAndLogEnvAndAgentProxies.messages);
     // if there's anything to warn on (e.g. both envvar + agent proxy used, and they are different)
     // log warnings on them
@@ -109,7 +110,7 @@ NodeHttpClient.prototype.getAgent = function (parsedUrl, proxy, mock) {
   Logger.getInstance().trace('Agent[url: %s] - getting an agent instance.', parsedUrl.href);
   if (!proxy && GlobalConfig.isEnvProxyActive()) {
     const isHttps = parsedUrl.protocol === 'https:';
-    proxy = Util.getProxyFromEnv(isHttps);
+    proxy = ProxyUtil.getProxyFromEnv(isHttps);
     if (proxy) {
       Logger.getInstance().debug('Agent[url: %s] - proxy info loaded from the environment variable. Proxy host: %s', parsedUrl.href, proxy.host);
     }
@@ -133,7 +134,7 @@ function getProxyAgent(proxyOptions, parsedUrl, destination, mock) {
     }
   }
 
-  const destHost = Util.getHostFromURL(destination);
+  const destHost = ProxyUtil.getHostFromURL(destination);
   const agentId = createAgentId(agentOptions.protocol, agentOptions.hostname, destHost, agentOptions.keepAlive);
   Logger.getInstance().debug('Agent[id: %s] - the destination host is: %s.', agentId, destHost);
 

--- a/lib/http/node.js
+++ b/lib/http/node.js
@@ -171,4 +171,4 @@ function getAgentCacheSize() {
   return httpsAgentCache.size;
 }
 
-module.exports = { NodeHttpClient, getProxyAgent, getAgentCacheSize };
+module.exports = { NodeHttpClient, getProxyAgent, getAgentCacheSize, isBypassProxy };

--- a/lib/proxy_util.js
+++ b/lib/proxy_util.js
@@ -220,9 +220,15 @@ exports.hideEnvironmentProxy = function () {
 };
 
 function saveProxyInfoInList(envVar) {
-  Logger.getInstance().debug(`Temporarily exclude ${envVar} from the environment variable value: ${process.env[envVar]}`);
+  const proxyEnv = process.env[envVar]
   envProxyList.push(process.env[envVar]);
   delete process.env[envVar];
+
+  if (Util.exists(proxyEnv)) {
+    Logger.getInstance().debug(`Temporarily exclude ${envVar} from the environment variable value: ${proxyEnv}`);
+  } else {
+    Logger.getInstance().debug(`${envVar} was not defined, nothing to do`);
+  }
 }
 
 exports.restoreEnvironmentProxy = function () {

--- a/lib/proxy_util.js
+++ b/lib/proxy_util.js
@@ -1,0 +1,181 @@
+const Logger = require('./logger');
+const Errors = require('./errors');
+const Util = require('./util');
+const GlobalConfig = require('./global_config');
+const ErrorCodes = Errors.codes;
+
+/**
+* remove http:// or https:// from the input, e.g. used with proxy URL
+* @param input
+* @returns {string}
+*/
+exports.removeScheme = function (input) {
+  return input.toString().replace(/(^\w+:|^)\/\//, '');
+};
+
+/**
+ * Try to get the PROXY environmental variables
+ * On Windows, envvar name is case-insensitive, but on *nix, it's case-sensitive
+ *
+ * Compare them with the proxy specified on the Connection, if any
+ * Return with the log constructed from the components detection and comparison
+ * If there's something to warn the user about, return that too
+ *
+ * @param the agentOptions object from agent creation
+ * @returns {object}
+ */
+exports.getCompareAndLogEnvAndAgentProxies = function (agentOptions) {
+  const envProxy = {};
+  const logMessages = { 'messages': '', 'warnings': '' };
+  envProxy.httpProxy = process.env.HTTP_PROXY || process.env.http_proxy;
+  envProxy.httpsProxy = process.env.HTTPS_PROXY || process.env.https_proxy;
+  envProxy.noProxy = process.env.NO_PROXY || process.env.no_proxy;
+  
+  envProxy.logHttpProxy = envProxy.httpProxy ?
+    'HTTP_PROXY: ' + envProxy.httpProxy : 'HTTP_PROXY: <unset>';
+  envProxy.logHttpsProxy = envProxy.httpsProxy ?
+    'HTTPS_PROXY: ' + envProxy.httpsProxy : 'HTTPS_PROXY: <unset>';
+  envProxy.logNoProxy = envProxy.noProxy ?
+    'NO_PROXY: ' + envProxy.noProxy : 'NO_PROXY: <unset>';
+  
+  // log PROXY envvars
+  if (envProxy.httpProxy || envProxy.httpsProxy) {
+    logMessages.messages = logMessages.messages + ' // PROXY environment variables: '
+        + `${envProxy.logHttpProxy} ${envProxy.logHttpsProxy} ${envProxy.logNoProxy}.`;
+  }
+  
+  // log proxy config on Connection, if any set
+  if (agentOptions.host) {
+    const proxyHostAndPort = agentOptions.host + ':' + agentOptions.port;
+    const proxyProtocolHostAndPort = agentOptions.protocol ?
+      ' protocol=' + agentOptions.protocol + ' proxy=' + proxyHostAndPort
+      : ' proxy=' + proxyHostAndPort;
+    const proxyUsername = agentOptions.user ? ' user=' + agentOptions.user : '';
+    logMessages.messages = logMessages.messages + ` // Proxy configured in Agent:${proxyProtocolHostAndPort}${proxyUsername}`;
+  
+    // check if both the PROXY envvars and Connection proxy config is set
+    // generate warnings if they are, and are also different
+    if (envProxy.httpProxy &&
+            this.removeScheme(envProxy.httpProxy).toLowerCase() !== this.removeScheme(proxyHostAndPort).toLowerCase()) {
+      logMessages.warnings = logMessages.warnings + ` Using both the HTTP_PROXY (${envProxy.httpProxy})`
+            + ` and the proxyHost:proxyPort (${proxyHostAndPort}) settings to connect, but with different values.`
+            + ' If you experience connectivity issues, try unsetting one of them.';
+    }
+    if (envProxy.httpsProxy &&
+            this.removeScheme(envProxy.httpsProxy).toLowerCase() !== this.removeScheme(proxyHostAndPort).toLowerCase()) {
+      logMessages.warnings = logMessages.warnings + ` Using both the HTTPS_PROXY (${envProxy.httpsProxy})`
+            + ` and the proxyHost:proxyPort (${proxyHostAndPort}) settings to connect, but with different values.`
+            + ' If you experience connectivity issues, try unsetting one of them.';
+    }
+  }
+  logMessages.messages = logMessages.messages ? logMessages.messages : ' none.';
+  
+  return logMessages;
+};
+
+exports.validateProxy = function (proxy) {
+  const { host, port, noProxy, user, password } = proxy;
+  // check for missing proxyHost
+  Errors.checkArgumentExists(Util.exists(host),
+    ErrorCodes.ERR_CONN_CREATE_MISSING_PROXY_HOST);
+  
+  // check for invalid proxyHost
+  Errors.checkArgumentValid(Util.isString(host),
+    ErrorCodes.ERR_CONN_CREATE_INVALID_PROXY_HOST);
+  
+  // check for missing proxyPort
+  Errors.checkArgumentExists(Util.exists(port),
+    ErrorCodes.ERR_CONN_CREATE_MISSING_PROXY_PORT);
+  
+  // check for invalid proxyPort
+  Errors.checkArgumentValid(Util.isNumber(port),
+    ErrorCodes.ERR_CONN_CREATE_INVALID_PROXY_PORT);
+  
+  if (Util.exists(noProxy)) {
+    // check for invalid noProxy
+    Errors.checkArgumentValid(Util.isString(noProxy),
+      ErrorCodes.ERR_CONN_CREATE_INVALID_NO_PROXY);
+  }
+  
+  if (Util.exists(user) || Util.exists(password)) {
+    // check for missing proxyUser
+    Errors.checkArgumentExists(Util.exists(user),
+      ErrorCodes.ERR_CONN_CREATE_MISSING_PROXY_USER);
+  
+    // check for invalid proxyUser
+    Errors.checkArgumentValid(Util.isString(user),
+      ErrorCodes.ERR_CONN_CREATE_INVALID_PROXY_USER);
+  
+    // check for missing proxyPassword
+    Errors.checkArgumentExists(Util.exists(password),
+      ErrorCodes.ERR_CONN_CREATE_MISSING_PROXY_PASS);
+  
+    // check for invalid proxyPassword
+    Errors.checkArgumentValid(Util.isString(password),
+      ErrorCodes.ERR_CONN_CREATE_INVALID_PROXY_PASS);
+  
+  } else {
+    delete proxy.user;
+    delete proxy.password;
+  }
+};
+  
+exports.validateEmptyString = function (value) {
+  return value !== '' ? value : undefined;
+};
+  
+exports.getProxyFromEnv = function (isHttps = true) {
+  const protocol = isHttps ? 'https' : 'http';
+  let proxyFromEnv = Util.getEnvVar(`${protocol}_proxy`);
+  if (!proxyFromEnv){
+    return null;
+  }
+  
+  Logger.getInstance().debug(`Util.getProxyEnv: Using ${protocol.toUpperCase()}_PROXY from the environment variable`);
+  if (proxyFromEnv.indexOf('://') === -1) {
+    Logger.getInstance().info('Util.getProxyEnv: the protocol was missing from the environment proxy. Use the HTTP protocol.');
+    proxyFromEnv = 'http' + '://' + proxyFromEnv;
+  }
+  proxyFromEnv = new URL(proxyFromEnv);
+  const proxy = {
+    host: Util.validateEmptyString(proxyFromEnv.hostname),
+    port: Number(Util.validateEmptyString(proxyFromEnv.port)),
+    user: Util.validateEmptyString(proxyFromEnv.username),
+    password: Util.validateEmptyString(proxyFromEnv.password),
+    protocol: Util.validateEmptyString(proxyFromEnv.protocol),
+    noProxy: this.getNoProxyEnv(),
+  };
+  this.validateProxy(proxy);
+  return proxy;
+};
+  
+exports.getNoProxyEnv = function () {
+  const noProxy = Util.getEnvVar('no_proxy');
+  if (noProxy) {
+    return noProxy.split(',').join('|');
+  }
+  return undefined;
+};
+
+exports.getHostFromURL = function (destination) {
+  if (destination.indexOf('://') === -1) {
+    destination = 'https' + '://' + destination;
+  }
+  
+  try {
+    return new URL(destination).hostname;
+  } catch (err) {
+    Logger.getInstance().error(`Failed to parse the destination to URL with the error: ${err}. Return destination as the host: ${destination}`);
+    return destination;
+  }
+};
+
+exports.getProxy = function (proxy, fileLocation, isHttps) {
+  if (!proxy && GlobalConfig.isEnvProxyActive()) {
+    proxy = this.getProxyFromEnv(isHttps);
+    if (proxy) {
+      Logger.getInstance().debug(`${fileLocation} loads the proxy info from the environment variable host: ${proxy.host}`);
+    }
+  }
+  return proxy;
+};

--- a/lib/proxy_util.js
+++ b/lib/proxy_util.js
@@ -6,7 +6,7 @@ const Logger = require('./logger');
 const Errors = require('./errors');
 const Util = require('./util');
 const GlobalConfig = require('./global_config');
-const LoggingUtil = require('./logger/logging_utils');
+const LoggingUtil = require('./logger/logging_util');
 const ErrorCodes = Errors.codes;
 /**
 * remove http:// or https:// from the input, e.g. used with proxy URL

--- a/lib/proxy_util.js
+++ b/lib/proxy_util.js
@@ -206,8 +206,11 @@ exports.getAzureProxy = function (proxy) {
 let envProxyList;
 const proxyEnvList = ['http_proxy', 'https_proxy', 'no_proxy'];
 exports.hideEnvironmentProxy = function () {
+  if (GlobalConfig.isEnvProxyActive()) {
+    return;
+  }
+
   envProxyList = [];
- 
   for (const envVar of proxyEnvList) {
     saveProxyInfoInList(envVar);
     if (!Util.isWindows()) {
@@ -222,6 +225,10 @@ function saveProxyInfoInList(envVar) {
 }
 
 exports.restoreEnvironmentProxy = function () {
+  if (GlobalConfig.isEnvProxyActive()) {
+    return;
+  }
+  
   const iterator = envProxyList[Symbol.iterator]();
   let nextValue = iterator.next().value;
   for (const envVar of proxyEnvList) {

--- a/lib/proxy_util.js
+++ b/lib/proxy_util.js
@@ -193,7 +193,7 @@ exports.getAzureProxy = function (proxy) {
 
   if (!Util.exists(AzureProxy.user) || !Util.exists(AzureProxy.password)) {
     delete AzureProxy.user;
-    delete proxy.password;
+    delete AzureProxy.password;
   }
   return AzureProxy;
 };

--- a/lib/proxy_util.js
+++ b/lib/proxy_util.js
@@ -209,7 +209,7 @@ exports.hideEnvironmentProxy = function () {
   if (GlobalConfig.isEnvProxyActive()) {
     return;
   }
-
+  Logger.getInstance().debug('As the useEnvProxy option is disabled, the proxy environment variables are temporarily hidden during the creation of an Azure client');
   envProxyList = [];
   for (const envVar of proxyEnvList) {
     saveProxyInfoInList(envVar);
@@ -220,6 +220,7 @@ exports.hideEnvironmentProxy = function () {
 };
 
 function saveProxyInfoInList(envVar) {
+  Logger.getInstance().debug(`Temporarily exclude ${envVar} from the environment variable value: ${process.env[envVar]}`);
   envProxyList.push(process.env[envVar]);
   delete process.env[envVar];
 }
@@ -228,20 +229,23 @@ exports.restoreEnvironmentProxy = function () {
   if (GlobalConfig.isEnvProxyActive()) {
     return;
   }
-  
+
   const iterator = envProxyList[Symbol.iterator]();
   let nextValue = iterator.next().value;
   for (const envVar of proxyEnvList) {
     if (Util.exists(nextValue)) {
+      Logger.getInstance().debug(`The ${envVar} value exists with the value: ${nextValue} Restore back the proxy environment variable values`);
       process.env[envVar] = nextValue;
     }
     nextValue = iterator.next().value;
 
     if (!Util.isWindows()) {
       if (Util.exists(nextValue)) {
+        Logger.getInstance().debug(`The ${envVar.toUpperCase()} value exists with the value: ${nextValue} Restore back the proxy environment variable values (for Non-Windows machine)`);
         process.env[envVar.toUpperCase()] = nextValue;
       }
       nextValue = iterator.next().value;
     }
   }
+  Logger.getInstance().debug('An Azure client has been created. Restore back the proxy environment variable values');
 };

--- a/lib/proxy_util.js
+++ b/lib/proxy_util.js
@@ -6,6 +6,7 @@ const Logger = require('./logger');
 const Errors = require('./errors');
 const Util = require('./util');
 const GlobalConfig = require('./global_config');
+const LoggingUtil = require('./logger/logging_utils');
 const ErrorCodes = Errors.codes;
 /**
 * remove http:// or https:// from the input, e.g. used with proxy URL
@@ -254,4 +255,10 @@ exports.restoreEnvironmentProxy = function () {
     }
   }
   Logger.getInstance().debug('An Azure client has been created. Restore back the proxy environment variable values');
+};
+
+exports.describeProxy = function (proxy) {
+  return `proxyHost: ${proxy.host}, proxyPort: ${proxy.port}, proxyUser: ${proxy.user}, `
+    + `proxyPassword is ${LoggingUtil.describePresence(proxy.password)}, `
+    + `proxyProtocol: ${proxy.protocol}, noProxy: ${proxy.noProxy}`;
 };

--- a/lib/proxy_util.js
+++ b/lib/proxy_util.js
@@ -7,7 +7,6 @@ const Errors = require('./errors');
 const Util = require('./util');
 const GlobalConfig = require('./global_config');
 const ErrorCodes = Errors.codes;
-
 /**
 * remove http:// or https:// from the input, e.g. used with proxy URL
 * @param input
@@ -31,9 +30,9 @@ exports.removeScheme = function (input) {
 exports.getCompareAndLogEnvAndAgentProxies = function (agentOptions) {
   const envProxy = {};
   const logMessages = { 'messages': '', 'warnings': '' };
-  envProxy.httpProxy = process.env.HTTP_PROXY || process.env.http_proxy;
-  envProxy.httpsProxy = process.env.HTTPS_PROXY || process.env.https_proxy;
-  envProxy.noProxy = process.env.NO_PROXY || process.env.no_proxy;
+  envProxy.httpProxy = process.env.http_proxy || process.env.HTTP_PROXY;
+  envProxy.httpsProxy = process.env.https_proxy || process.env.HTTPS_PROXY;
+  envProxy.noProxy = process.env.no_proxy || process.env.NO_PROXY;
   
   envProxy.logHttpProxy = envProxy.httpProxy ?
     'HTTP_PROXY: ' + envProxy.httpProxy : 'HTTP_PROXY: <unset>';
@@ -182,4 +181,60 @@ exports.getProxy = function (proxy, fileLocation, isHttps) {
     }
   }
   return proxy;
+};
+
+exports.getAzureProxy = function (proxy) {
+  const AzureProxy = {
+    ...proxy, host: `${proxy.protocol}${(proxy.protocol).endsWith(':') ? '' : ':'}//${proxy.host}`, 
+  };
+  delete AzureProxy.noProxy;
+  delete AzureProxy.protocol;
+
+  if (!Util.exists(AzureProxy.user) || !Util.exists(AzureProxy.password)) {
+    delete AzureProxy.user;
+    delete proxy.password;
+  }
+  return AzureProxy;
+};
+
+/**
+ * Currently, there is no way to disable loading the proxy information from the environment path in Azure/blob.
+ * To control this proxy option on the driver side, A temporary workaround is hide(remove) the environment proxy from the process
+ * when the client is created (At this time, the client loads the proxy from the environment variables internally). 
+ * After the client is created, restore them with the 'restoreEnvironmentProxy' function.
+ */
+let envProxyList;
+const proxyEnvList = ['http_proxy', 'https_proxy', 'no_proxy'];
+exports.hideEnvironmentProxy = function () {
+  envProxyList = [];
+ 
+  for (const envVar of proxyEnvList) {
+    saveProxyInfoInList(envVar);
+    if (!Util.isWindows()) {
+      saveProxyInfoInList(envVar.toUpperCase());
+    }
+  }
+};
+
+function saveProxyInfoInList(envVar) {
+  envProxyList.push(process.env[envVar]);
+  delete process.env[envVar];
+}
+
+exports.restoreEnvironmentProxy = function () {
+  const iterator = envProxyList[Symbol.iterator]();
+  let nextValue = iterator.next().value;
+  for (const envVar of proxyEnvList) {
+    if (Util.exists(nextValue)) {
+      process.env[envVar] = nextValue;
+    }
+    nextValue = iterator.next().value;
+
+    if (!Util.isWindows()) {
+      if (Util.exists(nextValue)) {
+        process.env[envVar.toUpperCase()] = nextValue;
+      }
+      nextValue = iterator.next().value;
+    }
+  }
 };

--- a/lib/proxy_util.js
+++ b/lib/proxy_util.js
@@ -220,7 +220,7 @@ exports.hideEnvironmentProxy = function () {
 };
 
 function saveProxyInfoInList(envVar) {
-  const proxyEnv = process.env[envVar]
+  const proxyEnv = process.env[envVar];
   envProxyList.push(process.env[envVar]);
   delete process.env[envVar];
 

--- a/lib/proxy_util.js
+++ b/lib/proxy_util.js
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2015-2024 Snowflake Computing Inc. All rights reserved.
+ */
+
 const Logger = require('./logger');
 const Errors = require('./errors');
 const Util = require('./util');

--- a/lib/util.js
+++ b/lib/util.js
@@ -8,7 +8,6 @@ const os = require('os');
 const Logger = require('./logger');
 const fs = require('fs');
 const Errors = require('./errors');
-const ErrorCodes = Errors.codes;
 
 /**
  * Note: A simple wrapper around util.inherits() for now, but this might change

--- a/lib/util.js
+++ b/lib/util.js
@@ -751,3 +751,7 @@ exports.isNotEmptyAsString = function (variable) {
   }
   return exports.exists(variable);
 };
+
+exports.isWindows = function () {
+  return os.platform() === 'win32';
+};

--- a/lib/util.js
+++ b/lib/util.js
@@ -618,66 +618,6 @@ exports.isCorrectSubdomain = function (value) {
   return subdomainRegex.test(value);
 };
 
-/**
- * Try to get the PROXY environmental variables
- * On Windows, envvar name is case-insensitive, but on *nix, it's case-sensitive
- *
- * Compare them with the proxy specified on the Connection, if any
- * Return with the log constructed from the components detection and comparison
- * If there's something to warn the user about, return that too
- *
- * @param the agentOptions object from agent creation
- * @returns {object}
- */
-exports.getCompareAndLogEnvAndAgentProxies = function (agentOptions) {
-  const envProxy = {};
-  const logMessages = { 'messages': '', 'warnings': '' };
-  envProxy.httpProxy = process.env.HTTP_PROXY || process.env.http_proxy;
-  envProxy.httpsProxy = process.env.HTTPS_PROXY || process.env.https_proxy;
-  envProxy.noProxy = process.env.NO_PROXY || process.env.no_proxy;
-
-  envProxy.logHttpProxy = envProxy.httpProxy ?
-    'HTTP_PROXY: ' + envProxy.httpProxy : 'HTTP_PROXY: <unset>';
-  envProxy.logHttpsProxy = envProxy.httpsProxy ?
-    'HTTPS_PROXY: ' + envProxy.httpsProxy : 'HTTPS_PROXY: <unset>';
-  envProxy.logNoProxy = envProxy.noProxy ?
-    'NO_PROXY: ' + envProxy.noProxy : 'NO_PROXY: <unset>';
-
-  // log PROXY envvars
-  if (envProxy.httpProxy || envProxy.httpsProxy) {
-    logMessages.messages = logMessages.messages + ' // PROXY environment variables: '
-      + `${envProxy.logHttpProxy} ${envProxy.logHttpsProxy} ${envProxy.logNoProxy}.`;
-  }
-
-  // log proxy config on Connection, if any set
-  if (agentOptions.host) {
-    const proxyHostAndPort = agentOptions.host + ':' + agentOptions.port;
-    const proxyProtocolHostAndPort = agentOptions.protocol ?
-      ' protocol=' + agentOptions.protocol + ' proxy=' + proxyHostAndPort
-      : ' proxy=' + proxyHostAndPort;
-    const proxyUsername = agentOptions.user ? ' user=' + agentOptions.user : '';
-    logMessages.messages = logMessages.messages + ` // Proxy configured in Agent:${proxyProtocolHostAndPort}${proxyUsername}`;
-
-    // check if both the PROXY envvars and Connection proxy config is set
-    // generate warnings if they are, and are also different
-    if (envProxy.httpProxy &&
-          this.removeScheme(envProxy.httpProxy).toLowerCase() !== this.removeScheme(proxyHostAndPort).toLowerCase()) {
-      logMessages.warnings = logMessages.warnings + ` Using both the HTTP_PROXY (${envProxy.httpProxy})`
-          + ` and the proxyHost:proxyPort (${proxyHostAndPort}) settings to connect, but with different values.`
-          + ' If you experience connectivity issues, try unsetting one of them.';
-    }
-    if (envProxy.httpsProxy &&
-          this.removeScheme(envProxy.httpsProxy).toLowerCase() !== this.removeScheme(proxyHostAndPort).toLowerCase()) {
-      logMessages.warnings = logMessages.warnings + ` Using both the HTTPS_PROXY (${envProxy.httpsProxy})`
-          + ` and the proxyHost:proxyPort (${proxyHostAndPort}) settings to connect, but with different values.`
-          + ' If you experience connectivity issues, try unsetting one of them.';
-    }
-  }
-  logMessages.messages = logMessages.messages ? logMessages.messages : ' none.';
-
-  return logMessages;
-};
-
 exports.buildCredentialCacheKey = function (host, username, credType) {
   if (!host || !username || !credType) {
     Logger.getInstance().debug('Cannot build the credential cache key because one of host, username, and credType is null');
@@ -708,15 +648,6 @@ exports.checkValidCustomCredentialManager = function (customCredentialManager) {
 
 exports.checkParametersDefined = function (...parameters) {
   return parameters.every((element) => element !== undefined && element !== null);
-};
-
-/**
-* remove http:// or https:// from the input, e.g. used with proxy URL
-* @param input
-* @returns {string}
-*/
-exports.removeScheme = function (input) {
-  return input.toString().replace(/(^\w+:|^)\/\//, '');
 };
 
 exports.buildCredentialCacheKey = function (host, username, credType) {
@@ -810,110 +741,8 @@ exports.getEnvVar = function (variable) {
   return process.env[variable.toLowerCase()] || process.env[variable.toUpperCase()];
 };
 
-exports.validateProxy = function (proxy) {
-  const { host, port, noProxy, user, password } = proxy;
-  // check for missing proxyHost
-  Errors.checkArgumentExists(this.exists(host),
-    ErrorCodes.ERR_CONN_CREATE_MISSING_PROXY_HOST);
-
-  // check for invalid proxyHost
-  Errors.checkArgumentValid(this.isString(host),
-    ErrorCodes.ERR_CONN_CREATE_INVALID_PROXY_HOST);
-
-  // check for missing proxyPort
-  Errors.checkArgumentExists(this.exists(port),
-    ErrorCodes.ERR_CONN_CREATE_MISSING_PROXY_PORT);
-
-  // check for invalid proxyPort
-  Errors.checkArgumentValid(this.isNumber(port),
-    ErrorCodes.ERR_CONN_CREATE_INVALID_PROXY_PORT);
-
-  if (this.exists(noProxy)) {
-    // check for invalid noProxy
-    Errors.checkArgumentValid(this.isString(noProxy),
-      ErrorCodes.ERR_CONN_CREATE_INVALID_NO_PROXY);
-  }
-
-  if (this.exists(user) || this.exists(password)) {
-    // check for missing proxyUser
-    Errors.checkArgumentExists(this.exists(user),
-      ErrorCodes.ERR_CONN_CREATE_MISSING_PROXY_USER);
-
-    // check for invalid proxyUser
-    Errors.checkArgumentValid(this.isString(user),
-      ErrorCodes.ERR_CONN_CREATE_INVALID_PROXY_USER);
-
-    // check for missing proxyPassword
-    Errors.checkArgumentExists(this.exists(password),
-      ErrorCodes.ERR_CONN_CREATE_MISSING_PROXY_PASS);
-
-    // check for invalid proxyPassword
-    Errors.checkArgumentValid(this.isString(password),
-      ErrorCodes.ERR_CONN_CREATE_INVALID_PROXY_PASS);
-
-  } else {
-    delete proxy.user;
-    delete proxy.password;
-  }
-};
-
 exports.validateEmptyString = function (value) {
   return value !== '' ? value : undefined;
-};
-
-exports.getProxyFromEnv = function (isHttps = true) {
-  const getDefaultPortIfNotSet = (proxyFromEnv) => {
-    const isProxyProtocolHttps = proxyFromEnv.protocol === 'https:';
-    if (!proxyFromEnv.port) {
-      return isProxyProtocolHttps ? 443 : 80;
-    } else {
-      return proxyFromEnv.port;
-    }
-  };
-  const protocol = isHttps ? 'https' : 'http';
-  let proxyFromEnv = this.getEnvVar(`${protocol}_proxy`);
-  if (!proxyFromEnv){
-    return null;
-  }
-
-  Logger.getInstance().debug(`Util.getProxyEnv: Using ${protocol.toUpperCase()}_PROXY from the environment variable`);
-  if (proxyFromEnv.indexOf('://') === -1) {
-    Logger.getInstance().info('Util.getProxyEnv: the protocol was missing from the environment proxy. Use the HTTP protocol.');
-    proxyFromEnv = 'http' + '://' + proxyFromEnv;
-  }
-  proxyFromEnv = new URL(proxyFromEnv);
-  const port = getDefaultPortIfNotSet(proxyFromEnv);
-  const proxy = {
-    host: this.validateEmptyString(proxyFromEnv.hostname),
-    port: Number(port),
-    user: this.validateEmptyString(proxyFromEnv.username),
-    password: this.validateEmptyString(proxyFromEnv.password),
-    protocol: this.validateEmptyString(proxyFromEnv.protocol),
-    noProxy: this.getNoProxyEnv(),
-  };
-  this.validateProxy(proxy);
-  return proxy;
-};
-
-exports.getNoProxyEnv = function () {
-  const noProxy = this.getEnvVar('no_proxy');
-  if (noProxy) {
-    return noProxy.split(',').join('|');
-  }
-  return undefined;
-};
-
-exports.getHostFromURL = function (destination) {
-  if (destination.indexOf('://') === -1) {
-    destination = 'https' + '://' + destination;
-  }
-
-  try {
-    return new URL(destination).hostname;
-  } catch (err) {
-    Logger.getInstance().error(`Failed to parse the destination to URL with the error: ${err}. Return destination as the host: ${destination}`);
-    return destination;
-  }
 };
 
 exports.isNotEmptyAsString = function (variable) {

--- a/test/unit/agent_cache_test.js
+++ b/test/unit/agent_cache_test.js
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2015-2024 Snowflake Computing Inc. All rights reserved.
+ */
+
 const GlobalConfig = require('./../../lib/global_config');
 const getProxyAgent = require('./../../lib/http/node').getProxyAgent;
 const getAgentCacheSize = require('./../../lib/http/node').getAgentCacheSize;

--- a/test/unit/file_transfer_agent/azure_test.js
+++ b/test/unit/file_transfer_agent/azure_test.js
@@ -16,6 +16,13 @@ describe('Azure client', function () {
   const mockKey = 'mockKey';
   const mockIv = 'mockIv';
   const mockMatDesc = 'mockMatDesc';
+  const noProxyConnectionConfig = {
+    getProxy: function () {
+      return null;
+    },
+    accessUrl: 'http://fakeaccount.snowflakecomputing.com',
+  };
+
 
   let Azure = null;
   let client = null;
@@ -106,7 +113,7 @@ describe('Azure client', function () {
     
     client = require('client');
     filestream = require('filestream');
-    Azure = new SnowflakeAzureUtil(client, filestream);
+    Azure = new SnowflakeAzureUtil(noProxyConnectionConfig, client, filestream);
   });
 
   it('extract bucket name and path', async function () {
@@ -131,7 +138,7 @@ describe('Azure client', function () {
       }, null));
 
     client = require('client');
-    Azure = new SnowflakeAzureUtil(client);
+    Azure = new SnowflakeAzureUtil(noProxyConnectionConfig, client);
 
     await Azure.getFileHeader(meta, dataFile);
     assert.strictEqual(meta['resultStatus'], resultStatus.RENEW_TOKEN);
@@ -146,7 +153,7 @@ describe('Azure client', function () {
       }, null));
 
     client = require('client');
-    const Azure = new SnowflakeAzureUtil(client);
+    const Azure = new SnowflakeAzureUtil(noProxyConnectionConfig, client);
 
     await Azure.getFileHeader(meta, dataFile);
     assert.strictEqual(meta['resultStatus'], resultStatus.NOT_FOUND_FILE);
@@ -161,7 +168,7 @@ describe('Azure client', function () {
       }, null));
 
     client = require('client');
-    Azure = new SnowflakeAzureUtil(client);
+    Azure = new SnowflakeAzureUtil(noProxyConnectionConfig, client);
 
     await Azure.getFileHeader(meta, dataFile);
     assert.strictEqual(meta['resultStatus'], resultStatus.RENEW_TOKEN);
@@ -176,7 +183,7 @@ describe('Azure client', function () {
       }, null));
 
     client = require('client');
-    Azure = new SnowflakeAzureUtil(client);
+    Azure = new SnowflakeAzureUtil(noProxyConnectionConfig, client);
 
     await Azure.getFileHeader(meta, dataFile);
     assert.strictEqual(meta['resultStatus'], resultStatus.ERROR);
@@ -192,7 +199,7 @@ describe('Azure client', function () {
     
     client = require('client');
     filestream = require('filestream');
-    Azure = new SnowflakeAzureUtil(client, filestream);
+    Azure = new SnowflakeAzureUtil(noProxyConnectionConfig, client, filestream);
 
     await Azure.uploadFile(dataFile, meta, encryptionMetadata);
     assert.strictEqual(meta['resultStatus'], resultStatus.UPLOADED);
@@ -212,7 +219,7 @@ describe('Azure client', function () {
     
     client = require('client');
     filestream = require('filestream');
-    Azure = new SnowflakeAzureUtil(client, filestream);
+    Azure = new SnowflakeAzureUtil(noProxyConnectionConfig, client, filestream);
 
     await Azure.uploadFile(dataFile, meta, encryptionMetadata);
     assert.strictEqual(meta['resultStatus'], resultStatus.RENEW_TOKEN);
@@ -232,7 +239,7 @@ describe('Azure client', function () {
     
     client = require('client');
     filestream = require('filestream');
-    Azure = new SnowflakeAzureUtil(client, filestream);
+    Azure = new SnowflakeAzureUtil(noProxyConnectionConfig, client, filestream);
 
     await Azure.uploadFile(dataFile, meta, encryptionMetadata);
     assert.strictEqual(meta['resultStatus'], resultStatus.NEED_RETRY);

--- a/test/unit/proxy_util_test.js
+++ b/test/unit/proxy_util_test.js
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2015-2024 Snowflake Computing Inc. All rights reserved.
+ */
+
 const Util = require('./../../lib/proxy_util');
 const assert = require('assert');
 

--- a/test/unit/proxy_util_test.js
+++ b/test/unit/proxy_util_test.js
@@ -1,0 +1,223 @@
+const Util = require('./../../lib/proxy_util');
+const assert = require('assert');
+
+describe('Util Test - removing http or https from string', () => {
+  const hostAndPortDone = 'my.pro.xy:8080';
+  const ipAndPortDone = '10.20.30.40:8080';
+  const somethingEntirelyDifferentDone = 'something ENTIRELY different';
+
+  [
+    { name: 'remove http from url', text: 'http://my.pro.xy:8080', shouldMatch: hostAndPortDone },
+    { name: 'remove https from url', text: 'https://my.pro.xy:8080', shouldMatch: hostAndPortDone },
+    { name: 'remove http from ip and port', text: 'http://10.20.30.40:8080', shouldMatch: ipAndPortDone },
+    { name: 'remove https from ip and port', text: 'https://10.20.30.40:8080', shouldMatch: ipAndPortDone },
+    { name: 'dont remove http(s) from hostname and port', text: 'my.pro.xy:8080', shouldMatch: hostAndPortDone },
+    { name: 'dont remove http(s) from ip and port', text: '10.20.30.40:8080', shouldMatch: ipAndPortDone },
+    { name: 'dont remove http(s) from simple string', text: somethingEntirelyDifferentDone, shouldMatch: somethingEntirelyDifferentDone }
+  ].forEach(({ name, text, shouldMatch }) => {
+    it(`${name}`, () => {
+      assert.deepEqual(Util.removeScheme(text), shouldMatch);
+    });
+  });
+});
+
+describe('Util Test - detecting PROXY envvars and compare with the agent proxy settings', () => {
+  [
+    {
+      name: 'detect http_proxy envvar, no agent proxy',
+      isWarn: false,
+      httpproxy: '10.20.30.40:8080',
+      HTTPSPROXY: '',
+      agentOptions: { 'keepalive': true },
+      shouldLog: ' // PROXY environment variables: HTTP_PROXY: 10.20.30.40:8080 HTTPS_PROXY: <unset> NO_PROXY: <unset>.'
+    }, {
+      name: 'detect HTTPS_PROXY envvar, no agent proxy',
+      isWarn: false,
+      httpproxy: '',
+      HTTPSPROXY: 'http://pro.xy:3128',
+      agentOptions: { 'keepalive': true },
+      shouldLog: ' // PROXY environment variables: HTTP_PROXY: <unset> HTTPS_PROXY: http://pro.xy:3128 NO_PROXY: <unset>.'
+    }, {
+      name: 'detect both http_proxy and HTTPS_PROXY envvar, no agent proxy',
+      isWarn: false,
+      httpproxy: '10.20.30.40:8080',
+      HTTPSPROXY: 'http://pro.xy:3128',
+      agentOptions: { 'keepalive': true },
+      shouldLog: ' // PROXY environment variables: HTTP_PROXY: 10.20.30.40:8080 HTTPS_PROXY: http://pro.xy:3128 NO_PROXY: <unset>.'
+    }, {
+      name: 'detect http_proxy envvar, agent proxy set to an unauthenticated proxy, same as the envvar',
+      isWarn: false,
+      httpproxy: '10.20.30.40:8080',
+      HTTPSPROXY: '',
+      agentOptions: { 'keepalive': true, 'host': '10.20.30.40', 'port': 8080 },
+      shouldLog: ' // PROXY environment variables: HTTP_PROXY: 10.20.30.40:8080 HTTPS_PROXY: <unset> NO_PROXY: <unset>. // Proxy configured in Agent: proxy=10.20.30.40:8080'
+    }, {
+      name: 'detect both http_proxy and HTTPS_PROXY envvar, agent proxy set to an unauthenticated proxy, same as the envvar',
+      isWarn: false,
+      httpproxy: '10.20.30.40:8080',
+      HTTPSPROXY: 'http://10.20.30.40:8080',
+      agentOptions: { 'keepalive': true, 'host': '10.20.30.40', 'port': 8080 },
+      shouldLog: ' // PROXY environment variables: HTTP_PROXY: 10.20.30.40:8080 HTTPS_PROXY: http://10.20.30.40:8080 NO_PROXY: <unset>. // Proxy configured in Agent: proxy=10.20.30.40:8080'
+    }, {
+      name: 'detect both http_proxy and HTTPS_PROXY envvar, agent proxy set to an authenticated proxy, same as the envvar',
+      isWarn: false,
+      httpproxy: '10.20.30.40:8080',
+      HTTPSPROXY: 'http://10.20.30.40:8080',
+      agentOptions: { 'keepalive': true, 'host': '10.20.30.40', 'port': 8080, 'user': 'PRX', 'password': 'proxypass' },
+      shouldLog: ' // PROXY environment variables: HTTP_PROXY: 10.20.30.40:8080 HTTPS_PROXY: http://10.20.30.40:8080 NO_PROXY: <unset>. // Proxy configured in Agent: proxy=10.20.30.40:8080 user=PRX'
+    }, {
+      name: 'detect both http_proxy and HTTPS_PROXY envvar, agent proxy set to an authenticated proxy, same as the envvar, with the protocol set',
+      isWarn: false,
+      httpproxy: '10.20.30.40:8080',
+      HTTPSPROXY: 'http://10.20.30.40:8080',
+      agentOptions: { 'keepalive': true, 'host': '10.20.30.40', 'port': 8080, 'user': 'PRX', 'password': 'proxypass', 'protocol': 'http' },
+      shouldLog: ' // PROXY environment variables: HTTP_PROXY: 10.20.30.40:8080 HTTPS_PROXY: http://10.20.30.40:8080 NO_PROXY: <unset>. // Proxy configured in Agent: protocol=http proxy=10.20.30.40:8080 user=PRX'
+    }, {
+      // now some WARN level messages
+      name: 'detect HTTPS_PROXY envvar, agent proxy set to an unauthenticated proxy, different from the envvar',
+      isWarn: true,
+      httpproxy: '',
+      HTTPSPROXY: 'http://pro.xy:3128',
+      agentOptions: { 'keepalive': true, 'host': '10.20.30.40', 'port': 8080 },
+      shouldLog: ' Using both the HTTPS_PROXY (http://pro.xy:3128) and the proxyHost:proxyPort (10.20.30.40:8080) settings to connect, but with different values. If you experience connectivity issues, try unsetting one of them.'
+    }, {
+      name: 'detect both http_proxy and HTTPS_PROXY envvar, different from each other, agent proxy set to an unauthenticated proxy, different from the envvars',
+      isWarn: true,
+      httpproxy: '169.254.169.254:8080',
+      HTTPSPROXY: 'http://pro.xy:3128',
+      agentOptions: { 'keepalive': true, 'host': '10.20.30.40', 'port': 8080 },
+      shouldLog: ' Using both the HTTP_PROXY (169.254.169.254:8080) and the proxyHost:proxyPort (10.20.30.40:8080) settings to connect, but with different values. If you experience connectivity issues, try unsetting one of them. Using both the HTTPS_PROXY (http://pro.xy:3128) and the proxyHost:proxyPort (10.20.30.40:8080) settings to connect, but with different values. If you experience connectivity issues, try unsetting one of them.'
+    }
+  ].forEach(({ name, isWarn, httpproxy, HTTPSPROXY, agentOptions, shouldLog }) => {
+    it(`${name}`, () => {
+      process.env.HTTP_PROXY = httpproxy;
+      process.env.HTTPS_PROXY = HTTPSPROXY;
+
+      const compareAndLogEnvAndAgentProxies = Util.getCompareAndLogEnvAndAgentProxies(agentOptions);
+      if (!isWarn) {
+        assert.deepEqual(compareAndLogEnvAndAgentProxies.messages, shouldLog, 'expected log message does not match!');
+      } else {
+        assert.deepEqual(compareAndLogEnvAndAgentProxies.warnings, shouldLog, 'expected warning message does not match!');
+      }
+    });
+  });
+
+  describe('getProxyEnv function test ', function () {
+    let originalHttpProxy = null;
+    let originalHttpsProxy = null;
+    let originalNoProxy = null;
+
+    before(() => {
+      originalHttpProxy = process.env.HTTP_PROXY;
+      originalHttpsProxy = process.env.HTTPS_PROXY;
+      originalNoProxy = process.env.NO_PROXY; 
+    });
+
+    beforeEach(() => {
+      delete process.env.HTTP_PROXY;
+      delete process.env.HTTPS_PROXY;
+      delete process.env.NO_PROXY;
+    });
+
+    after(() => {
+      originalHttpProxy ? process.env.HTTP_PROXY = originalHttpProxy : delete process.env.HTTP_PROXY;
+      originalHttpsProxy ? process.env.HTTPS_PROXY = originalHttpsProxy : delete process.env.HTTPS_PROXY;
+      originalNoProxy ? process.env.NO_PROXY = originalNoProxy : delete process.env.NO_PROXY; 
+    });
+
+    const testCases = [
+      {
+        name: 'HTTP PROXY without authentication and schema',
+        isHttps: false,
+        httpProxy: 'proxy.example.com:8080',
+        httpsProxy: undefined,
+        noProxy: '*.amazonaws.com',
+        result: {
+          host: 'proxy.example.com',
+          port: 8080,
+          protocol: 'http:',
+          noProxy: '*.amazonaws.com'
+        }
+      },
+      {
+        name: 'HTTP PROXY with authentication',
+        isHttps: false,
+        httpProxy: 'http://hello:world@proxy.example.com:8080',
+        httpsProxy: undefined,
+        noProxy: '*.amazonaws.com,*.my_company.com',
+        result: {
+          host: 'proxy.example.com',
+          user: 'hello',
+          password: 'world',
+          port: 8080,
+          protocol: 'http:',
+          noProxy: '*.amazonaws.com|*.my_company.com'
+        }
+      },
+      {
+        name: 'HTTPS PROXY with authentication without NO proxy',
+        isHttps: true,
+        httpsProxy: 'https://user:pass@myproxy.server.com:1234',
+        result: {
+          host: 'myproxy.server.com',
+          user: 'user',
+          password: 'pass',
+          port: 1234,
+          protocol: 'https:',
+          noProxy: undefined,
+        },
+      },
+      {
+        name: 'HTTPS PROXY with authentication without NO proxy No schema',
+        isHttps: true,
+        noProxy: '*.amazonaws.com,*.my_company.com,*.test.com',
+        httpsProxy: 'myproxy.server.com:1234',
+        result: {
+          host: 'myproxy.server.com',
+          port: 1234,
+          protocol: 'http:',
+          noProxy: '*.amazonaws.com|*.my_company.com|*.test.com',
+        },
+      },
+    ];
+
+    testCases.forEach(({ name, isHttps, httpsProxy, httpProxy, noProxy, result }) => {
+      it(name, function (){
+
+        if (httpProxy){
+          process.env.HTTP_PROXY = httpProxy;
+        }
+        if (httpsProxy) {
+          process.env.HTTPS_PROXY = httpsProxy; 
+        }
+        if (noProxy) {
+          process.env.NO_PROXY = noProxy; 
+        }
+        const proxy =  Util.getProxyFromEnv(isHttps);
+        const keys = Object.keys(result);
+        assert.strictEqual(keys.length, Object.keys(proxy).length);
+
+        for (const key of keys) {
+          assert.strictEqual(proxy[key], result[key]);
+        }
+      });
+    });
+  });
+
+  describe('getNoProxyEnv function Test', function () {
+    let original = null;
+
+    before( function (){
+      original = process.env.NO_PROXY; 
+      process.env.NO_PROXY = '*.amazonaws.com,*.my_company.com';
+    });
+
+    after(() => {
+      process.env.NO_PROXY = original;
+    });
+
+    it('test noProxy conversion', function (){
+      assert.strictEqual(Util.getNoProxyEnv(), '*.amazonaws.com|*.my_company.com');
+    });
+  });
+});

--- a/test/unit/proxy_util_test.js
+++ b/test/unit/proxy_util_test.js
@@ -4,6 +4,7 @@
 
 const ProxyUtil = require('./../../lib/proxy_util');
 const Util = require('./../../lib/util');
+const GlobalConfig = require('../../lib/global_config');
 
 const assert = require('assert');
 
@@ -228,7 +229,7 @@ describe('getNoProxyEnv function Test', function () {
   });
 });
 
-describe('getNoProxyEnv function Test', function () {
+describe('Proxy Util for Azure', function () {
   let originalhttpProxy = null;
   let originalhttpsProxy = null;
   let originalnoProxy = null;
@@ -237,6 +238,7 @@ describe('getNoProxyEnv function Test', function () {
   let originalNoProxy = null;
 
   before(() => {
+    GlobalConfig.setEnvProxy(false);
     originalHttpProxy = process.env.HTTP_PROXY;
     originalHttpsProxy = process.env.HTTPS_PROXY;
     originalNoProxy = process.env.NO_PROXY; 
@@ -248,6 +250,7 @@ describe('getNoProxyEnv function Test', function () {
   });
 
   after(() => {
+    GlobalConfig.setEnvProxy(true);
     originalHttpProxy ? process.env.HTTP_PROXY = originalHttpProxy : delete process.env.HTTP_PROXY;
     originalHttpsProxy ? process.env.HTTPS_PROXY = originalHttpsProxy : delete process.env.HTTPS_PROXY;
     originalNoProxy ? process.env.NO_PROXY = originalNoProxy : delete process.env.NO_PROXY; 

--- a/test/unit/util_test.js
+++ b/test/unit/util_test.js
@@ -910,262 +910,160 @@ describe('Util', function () {
     });
   });
 
-  describe('Util Test - removing http or https from string', () => {
-    const hostAndPortDone = 'my.pro.xy:8080';
-    const ipAndPortDone = '10.20.30.40:8080';
-    const somethingEntirelyDifferentDone = 'something ENTIRELY different';
+  describe('Util test - custom credential manager util functions', function () {
+    const mockUser = 'mockUser';
+    const mockHost = 'mockHost';
+    const mockCred = 'mockCred';
 
-    [
-      { name: 'remove http from url', text: 'http://my.pro.xy:8080', shouldMatch: hostAndPortDone },
-      { name: 'remove https from url', text: 'https://my.pro.xy:8080', shouldMatch: hostAndPortDone },
-      { name: 'remove http from ip and port', text: 'http://10.20.30.40:8080', shouldMatch: ipAndPortDone },
-      { name: 'remove https from ip and port', text: 'https://10.20.30.40:8080', shouldMatch: ipAndPortDone },
-      { name: 'dont remove http(s) from hostname and port', text: 'my.pro.xy:8080', shouldMatch: hostAndPortDone },
-      { name: 'dont remove http(s) from ip and port', text: '10.20.30.40:8080', shouldMatch: ipAndPortDone },
-      { name: 'dont remove http(s) from simple string', text: somethingEntirelyDifferentDone, shouldMatch: somethingEntirelyDifferentDone }
-    ].forEach(({ name, text, shouldMatch }) => {
-      it(`${name}`, () => {
-        assert.deepEqual(Util.removeScheme(text), shouldMatch);
+    describe('test function build credential key', function () {
+      const testCases = [
+        {
+          name: 'when all the parameters are null',
+          user: null,
+          host: null,
+          cred: null,
+          result: null
+        },
+        {
+          name: 'when two parameters are null or undefined',
+          user: mockUser,
+          host: null,
+          cred: undefined,
+          result: null
+        },
+        {
+          name: 'when one parameter is null',
+          user: mockUser,
+          host: mockHost,
+          cred: undefined,
+          result: null
+        },
+        {
+          name: 'when one parameter is undefined',
+          user: mockUser,
+          host: undefined,
+          cred: mockCred,
+          result: null
+        },
+        {
+          name: 'when all the parameters are valid',
+          user: mockUser,
+          host: mockHost,
+          cred: mockCred,
+          result: '{mockHost}:{mockUser}:{SF_NODE_JS_DRIVER}:{mockCred}}'
+        },
+      ];
+      testCases.forEach((name, user, host, cred, result) => {
+        it(`${name}`, function () {
+          if (!result) {
+            assert.strictEqual(Util.buildCredentialCacheKey(host, user, cred), null);
+          } else {
+            assert.strictEqual(Util.buildCredentialCacheKey(host, user, cred), result);
+          }
+        });
       });
     });
   });
 
-  describe('Util Test - detecting PROXY envvars and compare with the agent proxy settings', () => {
-    [
+  describe('test valid custom credential manager', function () {
+
+    function sampleManager() {
+      this.read = function () {};
+
+      this.write = function () {};
+
+      this.remove = function () {};
+    }
+
+    const testCases = [
       {
-        name: 'detect http_proxy envvar, no agent proxy',
-        isWarn: false,
-        httpproxy: '10.20.30.40:8080',
-        HTTPSPROXY: '',
-        agentOptions: { 'keepalive': true },
-        shouldLog: ' // PROXY environment variables: HTTP_PROXY: 10.20.30.40:8080 HTTPS_PROXY: <unset> NO_PROXY: <unset>.'
-      }, {
-        name: 'detect HTTPS_PROXY envvar, no agent proxy',
-        isWarn: false,
-        httpproxy: '',
-        HTTPSPROXY: 'http://pro.xy:3128',
-        agentOptions: { 'keepalive': true },
-        shouldLog: ' // PROXY environment variables: HTTP_PROXY: <unset> HTTPS_PROXY: http://pro.xy:3128 NO_PROXY: <unset>.'
-      }, {
-        name: 'detect both http_proxy and HTTPS_PROXY envvar, no agent proxy',
-        isWarn: false,
-        httpproxy: '10.20.30.40:8080',
-        HTTPSPROXY: 'http://pro.xy:3128',
-        agentOptions: { 'keepalive': true },
-        shouldLog: ' // PROXY environment variables: HTTP_PROXY: 10.20.30.40:8080 HTTPS_PROXY: http://pro.xy:3128 NO_PROXY: <unset>.'
-      }, {
-        name: 'detect http_proxy envvar, agent proxy set to an unauthenticated proxy, same as the envvar',
-        isWarn: false,
-        httpproxy: '10.20.30.40:8080',
-        HTTPSPROXY: '',
-        agentOptions: { 'keepalive': true, 'host': '10.20.30.40', 'port': 8080 },
-        shouldLog: ' // PROXY environment variables: HTTP_PROXY: 10.20.30.40:8080 HTTPS_PROXY: <unset> NO_PROXY: <unset>. // Proxy configured in Agent: proxy=10.20.30.40:8080'
-      }, {
-        name: 'detect both http_proxy and HTTPS_PROXY envvar, agent proxy set to an unauthenticated proxy, same as the envvar',
-        isWarn: false,
-        httpproxy: '10.20.30.40:8080',
-        HTTPSPROXY: 'http://10.20.30.40:8080',
-        agentOptions: { 'keepalive': true, 'host': '10.20.30.40', 'port': 8080 },
-        shouldLog: ' // PROXY environment variables: HTTP_PROXY: 10.20.30.40:8080 HTTPS_PROXY: http://10.20.30.40:8080 NO_PROXY: <unset>. // Proxy configured in Agent: proxy=10.20.30.40:8080'
-      }, {
-        name: 'detect both http_proxy and HTTPS_PROXY envvar, agent proxy set to an authenticated proxy, same as the envvar',
-        isWarn: false,
-        httpproxy: '10.20.30.40:8080',
-        HTTPSPROXY: 'http://10.20.30.40:8080',
-        agentOptions: { 'keepalive': true, 'host': '10.20.30.40', 'port': 8080, 'user': 'PRX', 'password': 'proxypass' },
-        shouldLog: ' // PROXY environment variables: HTTP_PROXY: 10.20.30.40:8080 HTTPS_PROXY: http://10.20.30.40:8080 NO_PROXY: <unset>. // Proxy configured in Agent: proxy=10.20.30.40:8080 user=PRX'
-      }, {
-        name: 'detect both http_proxy and HTTPS_PROXY envvar, agent proxy set to an authenticated proxy, same as the envvar, with the protocol set',
-        isWarn: false,
-        httpproxy: '10.20.30.40:8080',
-        HTTPSPROXY: 'http://10.20.30.40:8080',
-        agentOptions: { 'keepalive': true, 'host': '10.20.30.40', 'port': 8080, 'user': 'PRX', 'password': 'proxypass', 'protocol': 'http' },
-        shouldLog: ' // PROXY environment variables: HTTP_PROXY: 10.20.30.40:8080 HTTPS_PROXY: http://10.20.30.40:8080 NO_PROXY: <unset>. // Proxy configured in Agent: protocol=http proxy=10.20.30.40:8080 user=PRX'
-      }, {
-      // now some WARN level messages
-        name: 'detect HTTPS_PROXY envvar, agent proxy set to an unauthenticated proxy, different from the envvar',
-        isWarn: true,
-        httpproxy: '',
-        HTTPSPROXY: 'http://pro.xy:3128',
-        agentOptions: { 'keepalive': true, 'host': '10.20.30.40', 'port': 8080 },
-        shouldLog: ' Using both the HTTPS_PROXY (http://pro.xy:3128) and the proxyHost:proxyPort (10.20.30.40:8080) settings to connect, but with different values. If you experience connectivity issues, try unsetting one of them.'
-      }, {
-        name: 'detect both http_proxy and HTTPS_PROXY envvar, different from each other, agent proxy set to an unauthenticated proxy, different from the envvars',
-        isWarn: true,
-        httpproxy: '169.254.169.254:8080',
-        HTTPSPROXY: 'http://pro.xy:3128',
-        agentOptions: { 'keepalive': true, 'host': '10.20.30.40', 'port': 8080 },
-        shouldLog: ' Using both the HTTP_PROXY (169.254.169.254:8080) and the proxyHost:proxyPort (10.20.30.40:8080) settings to connect, but with different values. If you experience connectivity issues, try unsetting one of them. Using both the HTTPS_PROXY (http://pro.xy:3128) and the proxyHost:proxyPort (10.20.30.40:8080) settings to connect, but with different values. If you experience connectivity issues, try unsetting one of them.'
-      }
-    ].forEach(({ name, isWarn, httpproxy, HTTPSPROXY, agentOptions, shouldLog }) => {
-      it(`${name}`, () => {
-        process.env.HTTP_PROXY = httpproxy;
-        process.env.HTTPS_PROXY = HTTPSPROXY;
+        name: 'credential manager is an int',
+        credentialManager: 123,
+        result: false,
+      },
+      {
+        name: 'credential manager is a string',
+        credentialManager: 'credential manager',
+        result: false,
+      },
+      {
+        name: 'credential manager is an array',
+        credentialManager: ['write', 'read', 'remove'],
+        result: false,
+      },
+      {
+        name: 'credential manager is an empty obejct',
+        credentialManager: {},
+        result: false,
+      },
+      {
+        name: 'credential manager has property, but invalid types',
+        credentialManager: {
+          read: 'read',
+          write: 1234,
+          remove: []
+        },
+        result: false,
+      },
+      {
+        name: 'credential manager has property, but invalid types',
+        credentialManager: {
+          read: 'read',
+          write: 1234,
+          remove: []
+        },
+        result: false,
+      },
+      {
+        name: 'credential manager has two valid properties, but miss one',
+        credentialManager: {
+          read: function () {
 
-        const compareAndLogEnvAndAgentProxies = Util.getCompareAndLogEnvAndAgentProxies(agentOptions);
-        if (!isWarn) {
-          assert.deepEqual(compareAndLogEnvAndAgentProxies.messages, shouldLog, 'expected log message does not match!');
-        } else {
-          assert.deepEqual(compareAndLogEnvAndAgentProxies.warnings, shouldLog, 'expected warning message does not match!');
-        }
+          },
+          write: function () {
+
+          }
+        },
+        result: false,
+      },
+      {
+        name: 'credential manager has two valid properties, but miss one',
+        credentialManager: new sampleManager(),
+        result: true,
+      },
+    ];
+
+    for (const { name, credentialManager, result } of testCases) {
+      it(name, function () {
+        assert.strictEqual(Util.checkValidCustomCredentialManager(credentialManager), result);
       });
-    });
+    }
+  });
 
-    describe('Util test - custom credential manager util functions', function () {
-      const mockUser = 'mockUser';
-      const mockHost = 'mockHost';
-      const mockCred = 'mockCred';
-
-      describe('test function build credential key', function () {
-        const testCases = [
-          {
-            name: 'when all the parameters are null',
-            user: null,
-            host: null,
-            cred: null,
-            result: null
-          },
-          {
-            name: 'when two parameters are null or undefined',
-            user: mockUser,
-            host: null,
-            cred: undefined,
-            result: null
-          },
-          {
-            name: 'when one parameter is null',
-            user: mockUser,
-            host: mockHost,
-            cred: undefined,
-            result: null
-          },
-          {
-            name: 'when one parameter is undefined',
-            user: mockUser,
-            host: undefined,
-            cred: mockCred,
-            result: null
-          },
-          {
-            name: 'when all the parameters are valid',
-            user: mockUser,
-            host: mockHost,
-            cred: mockCred,
-            result: '{mockHost}:{mockUser}:{SF_NODE_JS_DRIVER}:{mockCred}}'
-          },
-        ];
-        testCases.forEach((name, user, host, cred, result) => {
-          it(`${name}`, function () {
-            if (!result) {
-              assert.strictEqual(Util.buildCredentialCacheKey(host, user, cred), null);
-            } else {
-              assert.strictEqual(Util.buildCredentialCacheKey(host, user, cred), result);
-            }
-          });
-        });
-      });
-    });
-
-    describe('test valid custom credential manager', function () {
-      
-      function sampleManager() {
-        this.read = function () {};
-    
-        this.write = function () {};
-    
-        this.remove = function () {};
-      }
-    
-      const testCases = [
-        {
-          name: 'credential manager is an int',
-          credentialManager: 123,
-          result: false,
-        },
-        {
-          name: 'credential manager is a string',
-          credentialManager: 'credential manager',
-          result: false,
-        },
-        {
-          name: 'credential manager is an array',
-          credentialManager: ['write', 'read', 'remove'],
-          result: false,
-        },
-        {
-          name: 'credential manager is an empty obejct',
-          credentialManager: {},
-          result: false,
-        },
-        {
-          name: 'credential manager has property, but invalid types',
-          credentialManager: {
-            read: 'read',
-            write: 1234,
-            remove: []
-          },
-          result: false,
-        },
-        {
-          name: 'credential manager has property, but invalid types',
-          credentialManager: {
-            read: 'read',
-            write: 1234,
-            remove: []
-          },
-          result: false,
-        },
-        {
-          name: 'credential manager has two valid properties, but miss one',
-          credentialManager: {
-            read: function () {
-
-            },
-            write: function () {
-
-            }
-          },
-          result: false,
-        },
-        {
-          name: 'credential manager has two valid properties, but miss one',
-          credentialManager: new sampleManager(),
-          result: true,
-        },
-      ];
-
-      for (const { name, credentialManager, result } of testCases) {
-        it(name, function () {
-          assert.strictEqual(Util.checkValidCustomCredentialManager(credentialManager), result);
-        });
-      }
-    });
-
-    describe('checkParametersDefined function Test', function () {
-      const testCases = [
-        {
-          name: 'all the parameters are null or undefined',
-          parameters: [null, undefined, null, null],
-          result: false
-        },
-        {
-          name: 'one parameter is null',
-          parameters: ['a', 2, true, null],
-          result: false
-        },
-        {
-          name: 'all the parameter are existing',
-          parameters: ['a', 123, ['testing'], {}],
-          result: true
-        },
-      ];
+  describe('checkParametersDefined function Test', function () {
+    const testCases = [
+      {
+        name: 'all the parameters are null or undefined',
+        parameters: [null, undefined, null, null],
+        result: false
+      },
+      {
+        name: 'one parameter is null',
+        parameters: ['a', 2, true, null],
+        result: false
+      },
+      {
+        name: 'all the parameter are existing',
+        parameters: ['a', 123, ['testing'], {}],
+        result: true
+      },
+    ];
   
-      for (const { name, parameters, result } of testCases) {
-        it(name, function () {
-          assert.strictEqual(Util.checkParametersDefined(...parameters), result);
-        });
-      }
-    });
+    for (const { name, parameters, result } of testCases) {
+      it(name, function () {
+        assert.strictEqual(Util.checkParametersDefined(...parameters), result);
+      });
+    }
   });
 
   if (os.platform() !== 'win32') {
@@ -1317,158 +1215,4 @@ describe('Util', function () {
     }
   });
 
-  describe('getProxyEnv function test ', function () {
-    let originalHttpProxy = null;
-    let originalHttpsProxy = null;
-    let originalNoProxy = null;
-
-    before(() => {
-      originalHttpProxy = process.env.HTTP_PROXY;
-      originalHttpsProxy = process.env.HTTPS_PROXY;
-      originalNoProxy = process.env.NO_PROXY; 
-    });
-
-    beforeEach(() => {
-      delete process.env.HTTP_PROXY;
-      delete process.env.HTTPS_PROXY;
-      delete process.env.NO_PROXY;
-    });
-
-    after(() => {
-      originalHttpProxy ? process.env.HTTP_PROXY = originalHttpProxy : delete process.env.HTTP_PROXY;
-      originalHttpsProxy ? process.env.HTTPS_PROXY = originalHttpsProxy : delete process.env.HTTPS_PROXY;
-      originalNoProxy ? process.env.NO_PROXY = originalNoProxy : delete process.env.NO_PROXY; 
-    });
-
-    const testCases = [
-      {
-        name: 'HTTP PROXY without authentication and schema',
-        isHttps: false,
-        httpProxy: 'proxy.example.com:8080',
-        httpsProxy: undefined,
-        noProxy: '*.amazonaws.com',
-        result: {
-          host: 'proxy.example.com',
-          port: 8080,
-          protocol: 'http:',
-          noProxy: '*.amazonaws.com'
-        }
-      },
-      {
-        name: 'HTTP PROXY with authentication',
-        isHttps: false,
-        httpProxy: 'http://hello:world@proxy.example.com:8080', //# pragma: allowlist secret
-        httpsProxy: undefined,
-        noProxy: '*.amazonaws.com,*.my_company.com',
-        result: {
-          host: 'proxy.example.com',
-          user: 'hello',
-          password: 'world',
-          port: 8080,
-          protocol: 'http:',
-          noProxy: '*.amazonaws.com|*.my_company.com'
-        }
-      },
-      {
-        name: 'HTTPS PROXY with authentication without NO proxy',
-        isHttps: true,
-        httpsProxy: 'https://user:pass@myproxy.server.com:1234', //# pragma: allowlist secret
-        result: {
-          host: 'myproxy.server.com',
-          user: 'user',
-          password: 'pass',
-          port: 1234,
-          protocol: 'https:',
-          noProxy: undefined,
-        },
-      },
-      {
-        name: 'HTTPS PROXY with authentication without NO proxy No schema',
-        isHttps: true,
-        noProxy: '*.amazonaws.com,*.my_company.com,*.test.com',
-        httpsProxy: 'myproxy.server.com:1234',
-        result: {
-          host: 'myproxy.server.com',
-          port: 1234,
-          protocol: 'http:',
-          noProxy: '*.amazonaws.com|*.my_company.com|*.test.com',
-        },
-      },
-      {
-        name: 'HTTPS PROXY with authentication without port and protocol',
-        isHttps: true,
-        noProxy: '*.amazonaws.com,*.my_company.com,*.test.com',
-        httpsProxy: 'myproxy.server.com',
-        result: {
-          host: 'myproxy.server.com',
-          port: 80,
-          protocol: 'http:',
-          noProxy: '*.amazonaws.com|*.my_company.com|*.test.com',
-        },
-      },
-      {
-        name: 'HTTP PROXY with authentication without port and protocol',
-        isHttps: false,
-        noProxy: '*.amazonaws.com,*.my_company.com,*.test.com',
-        httpProxy: 'myproxy.server.com',
-        result: {
-          host: 'myproxy.server.com',
-          port: 80,
-          protocol: 'http:',
-          noProxy: '*.amazonaws.com|*.my_company.com|*.test.com',
-        },
-      },
-      {
-        name: 'HTTPS PROXY with authentication without port',
-        isHttps: true,
-        noProxy: '*.amazonaws.com,*.my_company.com,*.test.com',
-        httpsProxy: 'https://myproxy.server.com',
-        result: {
-          host: 'myproxy.server.com',
-          port: 443,
-          protocol: 'https:',
-          noProxy: '*.amazonaws.com|*.my_company.com|*.test.com',
-        },
-      },
-    ];
-
-    testCases.forEach(({ name, isHttps, httpsProxy, httpProxy, noProxy, result }) => {
-      it(name, function (){
-
-        if (httpProxy){
-          process.env.HTTP_PROXY = httpProxy;
-        }
-        if (httpsProxy) {
-          process.env.HTTPS_PROXY = httpsProxy; 
-        }
-        if (noProxy) {
-          process.env.NO_PROXY = noProxy; 
-        }
-        const proxy =  Util.getProxyFromEnv(isHttps);
-        const keys = Object.keys(result);
-        assert.strictEqual(keys.length, Object.keys(proxy).length);
-
-        for (const key of keys) {
-          assert.strictEqual(proxy[key], result[key]);
-        }
-      });
-    });
-  });
-
-  describe('getNoProxyEnv function Test', function () {
-    let original = null;
-
-    before( function (){
-      original = process.env.NO_PROXY; 
-      process.env.NO_PROXY = '*.amazonaws.com,*.my_company.com';
-    });
-
-    after(() => {
-      process.env.NO_PROXY = original;
-    });
-
-    it('test noProxy conversion', function (){
-      assert.strictEqual(Util.getNoProxyEnv(), '*.amazonaws.com|*.my_company.com');
-    });
-  });
 });


### PR DESCRIPTION
### Description
Please explain the changes you made here.
- [x] Added the proxy setting in Azure_util
- [x] Separate the proxy util functions from util.js. Created proxy_util.js and proxy_util_test.js
- [x] Added connectionConfig in AzureUtil tests.
- [x] Refactored the code to validate and obtain proxy info in NoteHttpClient, Azure_util, and S3_util.
 
### Checklist
- [ ] Format code according to the existing code style (run `npm run lint:check -- CHANGED_FILES` and fix problems in changed code)
- [ ] Create tests which fail without the change (if possible)
- [ ] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [ ] Extend the README / documentation and ensure is properly displayed (if necessary)
- [ ] Provide JIRA issue id (if possible) or GitHub issue id in commit message
