### PR TITLE
NO-SNOW improve logging for `searchForConfigInDefaultDirectories`

### DIFF
--- a/lib/configuration/client_configuration.js
+++ b/lib/configuration/client_configuration.js
@@ -259,7 +259,7 @@ function ConfigurationUtil(fsPromisesModule, processModule) {
   }
 
   async function searchForConfigInDefaultDirectories() {
-    Logger.getInstance().debug(`Searching for config in default directories: ${defaultDirectories}`);
+    Logger.getInstance().debug(`Searching for config in default directories: ${JSON.stringify(defaultDirectories)}`);
     for (const directory of defaultDirectories) {
       const configPath = await searchForConfigInDictionary(directory.dir, directory.dirDescription);
       if (exists(configPath)) {


### PR DESCRIPTION
### Description
Randomly stumbled into this one during testing something else. Looks like upon calling `searchForConfigInDefaultDirectories`, we log the directory discovery as:
```
{"level":"DEBUG","message":"[1:46:34.380 PM]: Searching for config in default directories: [object Object],[object Object]"}
```

and it doesn't give much pointers where we looking at.

By simply `JSON.stringify`ing the object, we get:
```
{"level":"DEBUG","message":"[1:48:17.190 PM]: Searching for config in default directories: [{\"dir\":\"/test/snowflake-connector-nodejs/lib\",\"dirDescription\":\"driver\"},{\"dir\":\"/root\",\"dirDescription\":\"home\"}]"}
```

which can be a bit more informative.

### Checklist
- [ ] Format code according to the existing code style (run `npm run lint:check -- CHANGED_FILES` and fix problems in changed code)
- [ ] Create tests which fail without the change (if possible)
- [ ] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [ ] Extend the README / documentation and ensure is properly displayed (if necessary)
- [ ] Provide JIRA issue id (if possible) or GitHub issue id in commit message
