### PR TITLE
SNOW-1878222 bump node-http-handler to next major, v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "2.0.1",
   "description": "Node.js driver for Snowflake",
   "dependencies": {
-    "@aws-sdk/client-s3": "^3.388.0",
-    "@smithy/node-http-handler": "^3.2.5",
+    "@aws-sdk/client-s3": "^3.726.0",
+    "@smithy/node-http-handler": "^4.0.1",
     "@azure/storage-blob": "12.18.x",
     "@google-cloud/storage": "^7.7.0",
     "@techteamer/ocsp": "1.0.1",


### PR DESCRIPTION
### Description
* `@aws-sdk/client-s3` - the current dependency specification anyways installs latest `3.726.0` already, but since already changing package.json, i figured I can note this too
* `@smithy/node-http-handler` - we currently install latest v3 , `3.3.3`. They released a new major version because they dropped support for node:16 (reference: https://github.com/smithy-lang/smithy-typescript/releases/tag/%40smithy%2Fnode-http-handler%404.0.0) and we already dropped support for node:16 in snowflake-sdk earlier.

### Checklist
- [ ] Format code according to the existing code style (run `npm run lint:check -- CHANGED_FILES` and fix problems in changed code)
- [ ] Create tests which fail without the change (if possible)
- [ ] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [ ] Extend the types in index.d.ts file (if necessary)
- [ ] Extend the README / documentation and ensure is properly displayed (if necessary)
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message
