### PR TITLE
Extend deprecated api

### DIFF
--- a/lib/agent/check.js
+++ b/lib/agent/check.js
@@ -30,7 +30,6 @@
 
 const http = require('http');
 const url = require('url');
-const util = require('util');
 
 const ocsp = require('@techteamer/ocsp');
 const rfc2560 = require('asn1.js-rfc2560');

--- a/lib/agent/check.js
+++ b/lib/agent/check.js
@@ -57,7 +57,7 @@ function getResponse(uri, req, cb) {
   uri = url.parse(uri);
 
   const timeout = process.env.SF_OCSP_TEST_OCSP_RESPONDER_TIMEOUT || 10000;
-  const options = util._extend({
+  const options = Object.assign({
     timeout: Number(timeout),
     method: 'POST',
     headers: {

--- a/lib/agent/ocsp_response_cache.js
+++ b/lib/agent/ocsp_response_cache.js
@@ -270,7 +270,7 @@ function OcspResponseCache() {
 
     const uri = url.parse(OCSP_URL);
     const timeout = process.env.SF_OCSP_TEST_OCSP_RESPONSE_CACHE_SERVER_TIMEOUT || 5000;
-    const options = util._extend({
+    const options =  Object.assign({
       timeout: Number(timeout),
       method: 'GET',
       agent: proxyAgent,

--- a/lib/agent/ocsp_response_cache.js
+++ b/lib/agent/ocsp_response_cache.js
@@ -4,7 +4,6 @@
 
 const http = require('http');
 const url = require('url');
-const util = require('util');
 
 const path = require('path');
 const fs = require('fs');


### PR DESCRIPTION
### Description
Please explain the changes you made here.
- Node v22+ is now alerting about deprecation of util._extend and suggests using Object.assign instead.

### Checklist
- [x] Format code according to the existing code style (run `npm run lint:check -- CHANGED_FILES` and fix problems in changed code)
- [ ] Create tests which fail without the change (if possible)
- [ ] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [ ] Extend the types in index.d.ts file (if necessary)
- [ ] Extend the README / documentation and ensure is properly displayed (if necessary)
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message
