### PR TITLE
[APPS-45767] Let an external browser callback be provided to use, supports Snowflake VS Code Extension SSO

### DIFF
--- a/lib/authentication/auth_idtoken.js
+++ b/lib/authentication/auth_idtoken.js
@@ -7,12 +7,14 @@ const AuthWeb = require('./auth_web');
 /**
  * Creates an ID token authenticator.
  *
- * @param {String} token
- *
- * @returns {Object}
+ * @param {Object} connectionConfig
+ * @param {Object} httpClient
+ * @param {module} webbrowser
+ * 
+ * @returns {Object} the authenticator
  * @constructor
  */
-function AuthIDToken(connectionConfig, httpClient) {
+function AuthIDToken(connectionConfig, httpClient, webbrowser) {
 
   this.idToken = connectionConfig.idToken;
 
@@ -31,7 +33,7 @@ function AuthIDToken(connectionConfig, httpClient) {
   this.authenticate = async function () {};
 
   this.reauthenticate = async function (body) {
-    const auth = new AuthWeb(connectionConfig, httpClient);
+    const auth = new AuthWeb(connectionConfig, httpClient, webbrowser);
     await auth.authenticate(connectionConfig.getAuthenticator(),
       connectionConfig.getServiceName(),
       connectionConfig.account,

--- a/lib/authentication/authentication.js
+++ b/lib/authentication/authentication.js
@@ -62,15 +62,15 @@ exports.formAuthJSON = function formAuthJSON(
  */
 exports.getAuthenticator = function getAuthenticator(connectionConfig, httpClient) {
   const authType = connectionConfig.getAuthenticator();
-  const externalBrowserCallback = connectionConfig.externalBrowserCallback;
+  const openExternalBrowserCallback = connectionConfig.openExternalBrowserCallback; // Important for SSO in the Snowflake VS Code extension
   let auth;
   if (authType === AuthenticationTypes.DEFAULT_AUTHENTICATOR || authType === AuthenticationTypes.USER_PWD_MFA_AUTHENTICATOR) {
     auth = new AuthDefault(connectionConfig);
   } else if (authType === AuthenticationTypes.EXTERNAL_BROWSER_AUTHENTICATOR) {
     if (connectionConfig.getClientStoreTemporaryCredential() && !!connectionConfig.idToken) {
-      auth = new AuthIDToken(connectionConfig, httpClient, externalBrowserCallback);
+      auth = new AuthIDToken(connectionConfig, httpClient, openExternalBrowserCallback);
     } else {
-      auth = new AuthWeb(connectionConfig, httpClient, externalBrowserCallback);
+      auth = new AuthWeb(connectionConfig, httpClient, openExternalBrowserCallback);
     }
   } else if (authType === AuthenticationTypes.KEY_PAIR_AUTHENTICATOR) {
     auth = new AuthKeypair(connectionConfig);

--- a/lib/authentication/authentication.js
+++ b/lib/authentication/authentication.js
@@ -62,14 +62,15 @@ exports.formAuthJSON = function formAuthJSON(
  */
 exports.getAuthenticator = function getAuthenticator(connectionConfig, httpClient) {
   const authType = connectionConfig.getAuthenticator();
+  const externalBrowserCallback = connectionConfig.externalBrowserCallback;
   let auth;
   if (authType === AuthenticationTypes.DEFAULT_AUTHENTICATOR || authType === AuthenticationTypes.USER_PWD_MFA_AUTHENTICATOR) {
     auth = new AuthDefault(connectionConfig);
   } else if (authType === AuthenticationTypes.EXTERNAL_BROWSER_AUTHENTICATOR) {
     if (connectionConfig.getClientStoreTemporaryCredential() && !!connectionConfig.idToken) {
-      auth = new AuthIDToken(connectionConfig, httpClient);
+      auth = new AuthIDToken(connectionConfig, httpClient, externalBrowserCallback);
     } else {
-      auth = new AuthWeb(connectionConfig, httpClient);
+      auth = new AuthWeb(connectionConfig, httpClient, externalBrowserCallback);
     }
   } else if (authType === AuthenticationTypes.KEY_PAIR_AUTHENTICATOR) {
     auth = new AuthKeypair(connectionConfig);

--- a/lib/connection/connection_config.js
+++ b/lib/connection/connection_config.js
@@ -860,7 +860,7 @@ function ConnectionConfig(options, validateCredentials, qaMode, clientInfo) {
   this.masterTokenExpirationTime = options.masterTokenExpirationTime;
   this.sessionTokenExpirationTime = options.sessionTokenExpirationTime;
   this.clientConfigFile = options.clientConfigFile;
-  this.externalBrowserCallback = options.externalBrowserCallback;
+  this.openExternalBrowserCallback = options.openExternalBrowserCallback;
 
   // create the parameters array
   const parameters = createParameters();

--- a/lib/connection/connection_config.js
+++ b/lib/connection/connection_config.js
@@ -860,6 +860,7 @@ function ConnectionConfig(options, validateCredentials, qaMode, clientInfo) {
   this.masterTokenExpirationTime = options.masterTokenExpirationTime;
   this.sessionTokenExpirationTime = options.sessionTokenExpirationTime;
   this.clientConfigFile = options.clientConfigFile;
+  this.externalBrowserCallback = options.externalBrowserCallback;
 
   // create the parameters array
   const parameters = createParameters();

--- a/test/unit/authentication/authentication_test.js
+++ b/test/unit/authentication/authentication_test.js
@@ -231,8 +231,19 @@ describe('external browser authentication', function () {
       body['data']['AUTHENTICATOR'], AuthenticationTypes.EXTERNAL_BROWSER_AUTHENTICATOR, 'Authenticator should be EXTERNALBROWSER');
   });
 
-  it('external browser - id token', async function () {
+  it('external browser - id token, no webbrowser', async function () {
     const auth = new AuthIDToken(connectionOptionsIdToken, httpclient);
+    await auth.authenticate(credentials.authenticator, '', credentials.account, credentials.username, credentials.host);
+
+    const body = { data: {} };
+    auth.updateBody(body);
+
+    assert.strictEqual(body['data']['TOKEN'], connectionOptionsIdToken.idToken);
+    assert.strictEqual(body['data']['AUTHENTICATOR'], AuthenticationTypes.ID_TOKEN_AUTHENTICATOR);
+  });
+
+  it('external browser - id token, webbrowser cb provided', async function () {
+    const auth = new AuthIDToken(connectionOptionsIdToken, httpclient, webbrowser.open);
     await auth.authenticate(credentials.authenticator, '', credentials.account, credentials.username, credentials.host);
 
     const body = { data: {} };


### PR DESCRIPTION
We've been patching this for 1.5 years on our end. Without it, there are SSO problems when customers login, since the VS Code API has an API to openExternal: https://code.visualstudio.com/api/references/vscode-api (search for openExternal) that controls how browser windows open from extensions. 

Can we have this officially inside the node connector? 

### Description
Please explain the changes you made here.

### Checklist
- [ ] Format code according to the existing code style (run `npm run lint:check -- CHANGED_FILES` and fix problems in changed code)
- [x] Create tests which fail without the change (if possible)
- [x] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [ ] Extend the types in index.d.ts file (if necessary)
- [ ] Extend the README / documentation and ensure is properly displayed (if necessary)
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message
