### PR TITLE
SNOW-1935764: Fix account value in jenkins tests

### DIFF
--- a/system_test/connectionOptions.js
+++ b/system_test/connectionOptions.js
@@ -14,7 +14,7 @@ let snowflakeTestProxyPort = process.env.SNOWFLAKE_TEST_PROXY_PORT;
 const snowflakeTestProxyProtocol = process.env.SNOWFLAKE_TEST_PROXY_PROTOCOL;
 const snowflakeTestProxyUser = process.env.SNOWFLAKE_TEST_PROXY_USER;
 const snowflakeTestProxyPassword = process.env.SNOWFLAKE_TEST_PROXY_PASSWORD;
-const snowflakeTestAccount = process.env.SNOWFLAKE_TEST_ACCOUNT;
+let snowflakeTestAccount = process.env.SNOWFLAKE_TEST_ACCOUNT;
 const snowflakeTestUser = process.env.SNOWFLAKE_TEST_USER;
 const snowflakeTestDatabase = process.env.SNOWFLAKE_TEST_DATABASE;
 const snowflakeTestWarehouse = process.env.SNOWFLAKE_TEST_WAREHOUSE;
@@ -28,6 +28,10 @@ if (snowflakeTestProtocol === undefined) {
 
 if (snowflakeTestHost === undefined) {
   snowflakeTestHost = snowflakeTestAccount + '.snowflakecomputing.com';
+}
+
+if (snowflakeTestHost.endsWith('reg.local')) {
+  snowflakeTestAccount = snowflakeTestHost.split('.')[0];
 }
 
 if (snowflakeTestPort === undefined) {


### PR DESCRIPTION
### Description
SNOW-1935764: on jenkins tests account name may be set to different than host parameter - let's read the value from host parameter then

### Checklist
- [x] Format code according to the existing code style (run `npm run lint:check -- CHANGED_FILES` and fix problems in changed code)
- [ ] Create tests which fail without the change (if possible)
- [ ] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [ ] Extend the types in index.d.ts file (if necessary)
- [ ] Extend the README / documentation and ensure is properly displayed (if necessary)
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message
