### PR TITLE
SNOW-2034298 replacing deprecated util._extend with Object.assign

### DIFF
--- a/lib/agent/check.js
+++ b/lib/agent/check.js
@@ -26,7 +26,6 @@
 
 const http = require('http');
 const url = require('url');
-const util = require('util');
 
 const ocsp = require('@techteamer/ocsp');
 const rfc2560 = require('asn1.js-rfc2560');
@@ -53,7 +52,7 @@ function getResponse(uri, req, cb) {
   uri = url.parse(uri);
 
   const timeout = process.env.SF_OCSP_TEST_OCSP_RESPONDER_TIMEOUT || 10000;
-  const options = util._extend({
+  const options = Object.assign({
     timeout: Number(timeout),
     method: 'POST',
     headers: {

--- a/lib/agent/ocsp_response_cache.js
+++ b/lib/agent/ocsp_response_cache.js
@@ -1,6 +1,5 @@
 const http = require('http');
 const url = require('url');
-const util = require('util');
 
 const path = require('path');
 const fs = require('fs');
@@ -266,7 +265,7 @@ function OcspResponseCache() {
 
     const uri = url.parse(OCSP_URL);
     const timeout = process.env.SF_OCSP_TEST_OCSP_RESPONSE_CACHE_SERVER_TIMEOUT || 5000;
-    const options = util._extend({
+    const options = Object.assign({
       timeout: Number(timeout),
       method: 'GET',
       agent: proxyAgent,


### PR DESCRIPTION
### Description
node 22 with `--track-deprecation` complains that
```
[2025-04-10T09:38:57.600Z] (node:292) [DEP0060] DeprecationWarning: The `util._extend` API is deprecated. Please use Object.assign() instead.
    at OcspResponseCache.downloadCache (/test/node_modules/snowflake-sdk/lib/agent/ocsp_response_cache.js:269:26)
    at getOcspCache (/test/node_modules/snowflake-sdk/lib/agent/socket_util.js:238:35)
    at /test/node_modules/snowflake-sdk/lib/agent/socket_util.js:297:11
    at process.processTicksAndRejections (node:internal/process/task_queues:85:11)
```

Per https://nodejs.org/docs/latest-v22.x/api/util.html#util_extendtarget-source, `Object.assign` should be used; which has the same input arguments as deprecated `util._extend`

### Checklist
- [x] Format code according to the existing code style (run `npm run lint:check -- CHANGED_FILES` and fix problems in changed code)
- [ ] Create tests which fail without the change (if possible)
- [x] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [ ] Extend the types in index.d.ts file (if necessary)
- [ ] Extend the README / documentation and ensure is properly displayed (if necessary)
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message
