### PR TITLE
SNOW-2032701 NodeJS driver support virtual-style domains(3)

### DIFF
--- a/lib/file_transfer_agent/gcs_util.js
+++ b/lib/file_transfer_agent/gcs_util.js
@@ -450,7 +450,7 @@ function GCSUtil(connectionConfig, httpClient, fileStream) {
     const fullFilePath = `${gcsLocation.path}${filename}`;
     const endPoint = this.getGCSCustomEndPoint(stageInfo);
     let link;
-    if (!Util.exists(stageInfo['endPoint']) && stageInfo['useVirtualUrl']) {
+    if (stageInfo['useVirtualUrl']) {
       link = `${endPoint}/${fullFilePath}`;
     } else {
       link = `${endPoint != null ? endPoint : 'https://storage.googleapis.com'}/${gcsLocation.bucketName}/${fullFilePath}`;

--- a/test/unit/file_transfer_agent/gcs_test.js
+++ b/test/unit/file_transfer_agent/gcs_test.js
@@ -188,7 +188,7 @@ describe('GCS client', function () {
           useVirtualUrl: true,
         },
         endPointResult: 'https://storage.specialEndPoint.rep.googleapis.com',
-        fileUrlResult: 'https://storage.specialEndPoint.rep.googleapis.com/sfc-eng-regression/stakeda/test_stg/test_sub_dir/mockFile'
+        fileUrlResult: 'https://storage.specialEndPoint.rep.googleapis.com/stakeda/test_stg/test_sub_dir/mockFile'
       },
     ];
 


### PR DESCRIPTION
### Description
Please explain the changes you made here.
- [x] Removed one condition from the generate URL function. If the VirtualUrl is enabled, the bucket name should not be included even if the endPoint is specified.

### Checklist
- [ ] Format code according to the existing code style (run `npm run lint:check -- CHANGED_FILES` and fix problems in changed code)
- [ ] Create tests which fail without the change (if possible)
- [ ] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [ ] Extend the types in index.d.ts file (if necessary)
- [ ] Extend the README / documentation and ensure is properly displayed (if necessary)
- [ ] Provide JIRA issue id (if possible) or GitHub issue id in commit message
