### PR TITLE
SNOW-2129006: Add ErrorCode to core instance.

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -100,6 +100,7 @@ function Core(options) {
   const instance =
     {
       ocspModes: ocspModes,
+      ErrorCode: ErrorCodes,
       /**
        * Creates a connection object that can be used to communicate with
        * Snowflake.

--- a/test/unit/snowflake_test.js
+++ b/test/unit/snowflake_test.js
@@ -298,6 +298,12 @@ describe('snowflake.createConnection() synchronous errors', function () {
   }
 });
 
+describe('snowflake.ErrorCode property', function () {
+  it('snowflake.ErrorCodes returns an enum', () => {
+    assert.strictEqual(snowflake.ErrorCode, ErrorCodes);
+  });
+});
+
 describe('snowflake.createConnection() success', function () {
   it('createConnection() returns connection', function () {
     const connection = snowflake.createConnection(connectionOptions);


### PR DESCRIPTION
### Description
Fixes a inconsistency where `ErrorCode` was defined in d.ts file but not exported at runtime, causing runtime errors despite TypeScript compilation success.

### Changes
- Added `ErrorCode: ErrorCodes` property to the core module instance
- Error codes are now accessible via `snowflake.ErrorCode` at runtime
- TypeScript definitions already included the enum, now matching the JavaScript implementation