### PR TITLE
SNOW-2139123 extractQueryStatus can occassionally break if getQueryResponse returns null response so lets verify that

### DIFF
--- a/lib/connection/connection.js
+++ b/lib/connection/connection.js
@@ -571,13 +571,19 @@ function Connection(context) {
    * @returns {String} the query status.
    */
   function extractQueryStatus(queryResponse) {
-    const queries = queryResponse['data']['queries'];
+    // queryResponse == response['data'], from getQueryResponse
     let status = QueryStatus.code.NO_QUERY_DATA; // default status
-    if ( queries.length > 0) {
-      status =  queries[0]['status'];
+    if (!queryResponse || !queryResponse['data'] || !queryResponse['data']['queries']) {
+      Logger.getInstance().trace('Connection[id: %s] - No query data found, returning NO_QUERY_DATA status', id);
+      return status;
+    }
+    
+    const queries = queryResponse['data']['queries'];
+    if (queries.length > 0) {
+      status = queries[0]['status'];
     }
 
-    Logger.getInstance().trace('Connection[id: %s] - Extracted query status: %s', status);
+    Logger.getInstance().trace('Connection[id: %s] - Extracted query status: %s', id, status);
     return status;
   }
 
@@ -602,7 +608,7 @@ function Connection(context) {
    */
   this.getQueryStatusThrowIfError = async function (queryId) {
     Logger.getInstance().trace('Connection[id: %s] - getQueryStatusThrowIfError called for Query[id: %s]', this.getId(), queryId);
-    const response = await getQueryResponse(queryId);
+    const response = await getQueryResponse(queryId); // returns response['data']
     const status =  extractQueryStatus(response);
     let sqlState = null;
 
@@ -610,7 +616,7 @@ function Connection(context) {
       let message = response['message'] || '';
       const code = response['code'] || -1;
 
-      if (response['data']) {
+      if (response && response['data'] && response['data']['queries']) {
         message += response['data']['queries'].length > 0 ? response['data']['queries'][0]['errorMessage'] : '';
         sqlState = response['data']['sqlState'];
       }


### PR DESCRIPTION

### Description
This is for https://github.com/snowflakedb/snowflake-connector-nodejs/issues/1092 , where it works most of the time, but we can also fail occassionally with
```
caused by: TypeError: Cannot read properties of null (reading 'queries')
    at extractQueryStatus (/home/node/app/node_modules/.pnpm/snowflake-sdk@2.0.3_patch_hash=77f126781d642dc70452557b598376038510406856a095fbefcbb18b_23a55c56c9513defa71ad947d3ce0c69/node_modules/snowflake-sdk/lib/connection/connection.js:566:42)
    at Connection.getQueryStatusThrowIfError (/home/node/app/node_modules/.pnpm/snowflake-sdk@2.0.3_patch_hash=77f126781d642dc70452557b598376038510406856a095fbefcbb18b_23a55c56c9513defa71ad947d3ce0c69/node_modules/snowflake-sdk/lib/connection/connection.js:598:21)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Connection.getResultsFromQueryId (/home/node/app/node_modules/.pnpm/snowflake-sdk@2.0.3_patch_hash=77f126781d642dc70452557b598376038510406856a095fbefcbb18b_23a55c56c9513defa71ad947d3ce0c69/node_modules/snowflake-sdk/lib/connection/connection.js:637:16)
    at async getResultsWithAbortSignal (/home/node/app/packages/backend/core/sources/snowflake/index.js:767:15)
    at async executeSnowflakeStatement (/home/node/app/packages/backend/core/sources/snowflake/index.js:1022:18)
```

This is an attempt to fix it, by 
* introducing more validation in `extractQueryStatus`
* similarly in `getQueryStatusThrowIfError`

### Checklist
- [x] Format code according to the existing code style (run `npm run lint:check -- CHANGED_FILES` and fix problems in changed code)
- [ ] Create tests which fail without the change (if possible)
- [ ] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [ ] Extend the types in index.d.ts file (if necessary)
- [ ] Extend the README / documentation and ensure is properly displayed (if necessary)
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message
