### PR TITLE
SNOW-1902245 Fix workload identity config options

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -127,11 +127,6 @@ declare module 'snowflake-sdk' {
     authenticator?: keyof typeof import('./lib/authentication/authentication_types').default;
 
     /**
-     * Allows to set experimental authenticator: 'WORKLOAD_IDENTITY'
-     */
-    enableExperimentalWorkloadIdentityAuth?: boolean;
-
-    /**
      * Specifies the timeout, in milliseconds, for browser activities related to SSO authentication. The default value is 120000 (milliseconds).
      */
     browserActionTimeout?: number;

--- a/lib/connection/connection_config.js
+++ b/lib/connection/connection_config.js
@@ -74,8 +74,8 @@ const DEFAULT_PARAMS =
   'oauthScope',
   'oauthChallengeMethod',
   'oauthHttpAllowed', //only for tests
-  'enableExperimentalWorkloadIdentityAuth',
-  'workloadIdentity'
+  'workloadIdentityProvider',
+  'workloadIdentityAzureEntraIdResource'
 ];
 
 function consolidateHostAndAccount(options) {
@@ -996,8 +996,8 @@ function ConnectionConfig(options, validateCredentials, qaMode, clientInfo) {
   this.clientConfigFile = options.clientConfigFile;
   this.openExternalBrowserCallback = options.openExternalBrowserCallback;
   this.oauthEnableSingleUseRefreshTokens = options.oauthEnableSingleUseRefreshTokens;
-  this.enableExperimentalWorkloadIdentityAuth = options.enableExperimentalWorkloadIdentityAuth;
-  this.workloadIdentity = options.workloadIdentity;
+  this.workloadIdentityProvider = options.workloadIdentityProvider;
+  this.workloadIdentityAzureEntraIdResource = options.workloadIdentityAzureEntraIdResource;
 
   // create the parameters array
   const parameters = createParameters();

--- a/lib/connection/types.ts
+++ b/lib/connection/types.ts
@@ -17,21 +17,19 @@ export interface WIP_ConnectionConfig {
    */
   oauthEnableSingleUseRefreshTokens?: boolean;
 
-  enableExperimentalWorkloadIdentityAuth?: boolean;
-  workloadIdentity?: {
-    /**
-     * Specifies the workload identity provider, available options:
-     * * AWS - Uses `@aws-sdk` to find credentials and encodes signed GetCallerIdentity request as token
-     * * AZURE - Uses `@azure/identity` find credentials and get JWT token
-     * * GCP - Uses `google-auth-library` to find credentials and get JWT token
-     * * OIDC - Reads JWT token from `ConnectionOptions.token`
-     *
-     * When none is passed, the driver will try to auto-detect the provider.
-     */
-    provider?: WorkloadIdentityProviderKey;
-    /**
-     * Customize Azure Entra Id Resource used to obrain auth token
-     */
-    azureEntraIdResource?: string;
-  }
+  /**
+   * When authenticator=WORKLOAD_IDENTITY, specifies the identity provider. Available options:
+   * * AWS - Uses `@aws-sdk` to find credentials and encodes signed GetCallerIdentity request as token
+   * * AZURE - Uses `@azure/identity` find credentials and get JWT token
+   * * GCP - Uses `google-auth-library` to find credentials and get JWT token
+   * * OIDC - Reads JWT token from `ConnectionOptions.token`
+   *
+   * When none is passed, the driver will try to auto-detect the provider.
+   */
+  workloadIdentityProvider?: WorkloadIdentityProviderKey;
+
+  /**
+   * Customize Azure Entra Id Resource used to obrain workload identity auth token
+   */
+  workloadIdentityAzureEntraIdResource?: string;
 }

--- a/lib/connection/types.ts
+++ b/lib/connection/types.ts
@@ -29,7 +29,7 @@ export interface WIP_ConnectionConfig {
   workloadIdentityProvider?: WorkloadIdentityProviderKey;
 
   /**
-   * Customize Azure Entra Id Resource used to obrain workload identity auth token
+   * Customize Azure Entra Id Resource used to obtain workload identity auth token
    */
   workloadIdentityAzureEntraIdResource?: string;
 }

--- a/lib/connection/types.ts
+++ b/lib/connection/types.ts
@@ -20,7 +20,7 @@ export interface WIP_ConnectionConfig {
   /**
    * When authenticator=WORKLOAD_IDENTITY, specifies the identity provider. Available options:
    * * AWS - Uses `@aws-sdk` to find credentials and encodes signed GetCallerIdentity request as token
-   * * AZURE - Uses `@azure/identity` find credentials and get JWT token
+   * * AZURE - Uses `@azure/identity` to find credentials and get JWT token
    * * GCP - Uses `google-auth-library` to find credentials and get JWT token
    * * OIDC - Reads JWT token from `ConnectionOptions.token`
    *

--- a/test/unit/authentication/authentication_test.js
+++ b/test/unit/authentication/authentication_test.js
@@ -613,6 +613,15 @@ describe('test getAuthenticator()', () => {
     { name: 'workload identity', providedAuth: AuthenticationTypes.WORKLOAD_IDENTITY, expectedAuth: 'AuthWorkloadIdentity' },
     { name: 'unknown', providedAuth: 'unknown', expectedAuth: 'AuthDefault' }
   ].forEach(({ name, providedAuth, expectedAuth, idToken }) => {
+    before(() => {
+      sinon.stub(process, 'env').value({
+        SF_ENABLE_EXPERIMENTAL_AUTHENTICATION: 'true'
+      });
+    });
+    after(() => {
+      sinon.restore();
+    });
+
     it(`${name}`, () => {
       const connectionConfig = {
         getBrowserActionTimeout: () => 100,
@@ -631,7 +640,6 @@ describe('test getAuthenticator()', () => {
         getPasscodeInPassword: () => false,
         idToken: idToken || null,
         host: 'host',
-        enableExperimentalWorkloadIdentityAuth: true,
         workloadIdentityProvider: 'AWS',
       };
 


### PR DESCRIPTION
### Description
1. feature flag in evn variable instead of ConnectionOptions to be consistent with other drivers
2. `workloadIdentity` object replaced with 2 separate keys because .toml config don't support nested fields

### Checklist
- [x] Format code according to the existing code style (run `npm run lint:check -- CHANGED_FILES` and fix problems in changed code)
- [x] Create tests which fail without the change (if possible)
- [x] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [x] Extend the types in index.d.ts file (if necessary)
- [x] Extend the README / documentation and ensure is properly displayed (if necessary)
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message
