### PR TITLE
Fix husky crush on CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
   },
   "scripts": {
     "prepack": "node ci/build_typescript.js",
-    "prepare": "husky",
+    "prepare": "husky || true",
     "lint:check": "eslint . && check-dts index.d.ts",
     "lint:fix": "eslint --fix",
     "prettier:check": "prettier --check .",


### PR DESCRIPTION
### Description
Our Jenkins job for publishing on npm fails because the node on that machine doesn't have the driver dev dependencies installed.

Husky recommendation is to add `|| true` to let it fail with exit code 0 - https://typicode.github.io/husky/how-to.html#ci-server-and-docker

### Checklist

- [x] Create tests which fail without the change (if possible)
- [x] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [x] Extend the types in index.d.ts file (if necessary)
- [x] Extend the README / documentation and ensure is properly displayed (if necessary)
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message
