### PR TITLE
SNOW-2194593 add a simple TypeScript compilation check

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,3 +28,5 @@ jobs:
         run: npm run prettier:check
       - name: Check formatting
         run: npm run lint:check
+      - name: Check if TypeScript still compiles
+        run: npm run tsc

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "*.{js,ts}": "npm run lint:check"
   },
   "scripts": {
-    "tsc": "npm -g install typescript && echo \"import * as snowflake from 'snowflake-sdk';\" > canicompile.ts && tsc --noEmit canicompile.ts",
+    "tsc": "echo -n \"import * as snowflake from './';\" > canicompile.ts && tsc --noEmit canicompile.ts",
     "prepack": "node ci/build_typescript.js",
     "prepare": "husky",
     "lint:check": "eslint . && check-dts index.d.ts",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "*.{js,ts}": "npm run lint:check"
   },
   "scripts": {
+    "tsc": "npm -g install typescript && echo \"import * as snowflake from 'snowflake-sdk';\" > canicompile.ts && tsc --noEmit canicompile.ts",
     "prepack": "node ci/build_typescript.js",
     "prepare": "husky",
     "lint:check": "eslint . && check-dts index.d.ts",


### PR DESCRIPTION
### Description

Inspired by https://github.com/snowflakedb/snowflake-connector-nodejs/issues/1112 , which was raised because the whole release just failed to compile in TypeScript...

Adding this simple check hopefully helps from this issue repeating.

### Checklist

- [ ] Create tests which fail without the change (if possible)
- [ ] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [ ] Extend the types in index.d.ts file (if necessary)
- [ ] Extend the README / documentation and ensure is properly displayed (if necessary)
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message
