### PR TITLE
Fix index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,12 +1,11 @@
 import { WIP_ConnectionOptions } from './lib/connection/types';
+import ErrorCodeEnum from './lib/error_code';
 
 /**
  * The snowflake-sdk module provides an instance to connect to the Snowflake server
  * @see [source] {@link https://docs.snowflake.com/en/developer-guide/node-js/nodejs-driver}
  */
 declare module 'snowflake-sdk' {
-  export const ErrorCode: typeof import('./lib/error_code').default;
-
   export type CustomParser = (rawColumnValue: string) => any;
   export type Bind = string | number;
   export type InsertBinds = Bind[][];
@@ -731,7 +730,7 @@ declare module 'snowflake-sdk' {
   }
 
   export interface SnowflakeError extends Error {
-    code?: ErrorCode;
+    code?: ErrorCodeEnum;
     sqlState?: string;
     data?: Record<string, any>;
     response?: Record<string, any>;
@@ -746,6 +745,8 @@ declare module 'snowflake-sdk' {
     end?: number;
     fetchAsString?: DataType[];
   }
+
+  export const ErrorCode: typeof ErrorCodeEnum;
 
   /**
    * Online Certificate Status Protocol (OCSP), detailed information: https://docs.snowflake.com/en/user-guide/ocsp.

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "fast-xml-parser": "^4.2.5",
     "fastest-levenshtein": "^1.0.16",
     "generic-pool": "^3.8.2",
-    "glob": "^10.0.0",
+    "glob": "^11.0.3",
     "google-auth-library": "^10.1.0",
     "https-proxy-agent": "^7.0.2",
     "jsonwebtoken": "^9.0.0",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -8,7 +8,6 @@
     "allowJs": true,
     "esModuleInterop": true,
     "resolveJsonModule": true,
-    "strict": true,
-    "skipLibCheck": true
+    "strict": true
   }
 }


### PR DESCRIPTION
### Description
Fixes broken index.d.ts 

Root cause is failing check in `check-dts`. It skips validation if `skipLibCheck` is set in `tsconfig`. Bumped `glob` library to a higher version which allowed to remove `skipLibCheck`.

### Checklist

- [x] Create tests which fail without the change (if possible)
- [x] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [x] Extend the types in index.d.ts file (if necessary)
- [x] Extend the README / documentation and ensure is properly displayed (if necessary)
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message
