### PR TITLE
SNOW-2198697 Use GCP XML API when useVirtualUrl=true

### DIFF
--- a/lib/file_transfer_agent/gcs_util.js
+++ b/lib/file_transfer_agent/gcs_util.js
@@ -4,7 +4,7 @@ const FileHeader = require('../file_util').FileHeader;
 const getProxyAgent = require('../http/node').getProxyAgent;
 const ProxyUtil = require('../proxy_util');
 const Util = require('../util');
-const { shouldPerformGCPBucket, lstrip } = require('../util');
+const { lstrip } = require('../util');
 
 const GCS_METADATA_PREFIX = 'x-goog-meta-';
 const SFC_DIGEST = 'sfc-digest';
@@ -147,11 +147,7 @@ function GCSUtil(connectionConfig, httpClient) {
         let matDescKey;
 
         try {
-          if (
-            shouldPerformGCPBucket(accessToken) &&
-            !isProxyEnabled &&
-            !meta['stageInfo']['useVirtualUrl']
-          ) {
+          if (this.shouldUseJsonApi(meta)) {
             const gcsLocation = this.extractBucketNameAndPath(meta['stageInfo']['location']);
             const metadata = await meta['client'].gcsClient
               .bucket(gcsLocation.bucketName)
@@ -291,11 +287,7 @@ function GCSUtil(connectionConfig, httpClient) {
     }
 
     try {
-      if (
-        shouldPerformGCPBucket(accessToken) &&
-        !isProxyEnabled &&
-        !meta['stageInfo']['useVirtualUrl']
-      ) {
+      if (this.shouldUseJsonApi(meta)) {
         const gcsLocation = this.extractBucketNameAndPath(meta['stageInfo']['location']);
 
         await meta['client'].gcsClient
@@ -367,11 +359,7 @@ function GCSUtil(connectionConfig, httpClient) {
     let size;
 
     try {
-      if (
-        shouldPerformGCPBucket(accessToken) &&
-        !isProxyEnabled &&
-        !meta['stageInfo']['useVirtualUrl']
-      ) {
+      if (this.shouldUseJsonApi(meta)) {
         const gcsLocation = this.extractBucketNameAndPath(meta['stageInfo']['location']);
         await meta['client'].gcsClient
           .bucket(gcsLocation.bucketName)
@@ -512,6 +500,18 @@ function GCSUtil(connectionConfig, httpClient) {
         axios = require('axios');
       }
     }
+  };
+
+  this.shouldUseJsonApi = function (meta) {
+    const accessToken = meta['client'].gcsToken;
+    const useVirtualUrl = meta['stageInfo']['useVirtualUrl'];
+
+    return (
+      !!accessToken &&
+      process.env.SNOWFLAKE_FORCE_GCP_USE_DOWNSCOPED_CREDENTIAL !== 'true' &&
+      !isProxyEnabled &&
+      !useVirtualUrl
+    );
   };
 }
 

--- a/lib/file_transfer_agent/gcs_util.js
+++ b/lib/file_transfer_agent/gcs_util.js
@@ -147,7 +147,11 @@ function GCSUtil(connectionConfig, httpClient) {
         let matDescKey;
 
         try {
-          if (shouldPerformGCPBucket(accessToken) && !isProxyEnabled) {
+          if (
+            shouldPerformGCPBucket(accessToken) &&
+            !isProxyEnabled &&
+            !meta['stageInfo']['useVirtualUrl']
+          ) {
             const gcsLocation = this.extractBucketNameAndPath(meta['stageInfo']['location']);
             const metadata = await meta['client'].gcsClient
               .bucket(gcsLocation.bucketName)
@@ -287,7 +291,11 @@ function GCSUtil(connectionConfig, httpClient) {
     }
 
     try {
-      if (shouldPerformGCPBucket(accessToken) && !isProxyEnabled) {
+      if (
+        shouldPerformGCPBucket(accessToken) &&
+        !isProxyEnabled &&
+        !meta['stageInfo']['useVirtualUrl']
+      ) {
         const gcsLocation = this.extractBucketNameAndPath(meta['stageInfo']['location']);
 
         await meta['client'].gcsClient
@@ -359,7 +367,11 @@ function GCSUtil(connectionConfig, httpClient) {
     let size;
 
     try {
-      if (shouldPerformGCPBucket(accessToken) && !isProxyEnabled) {
+      if (
+        shouldPerformGCPBucket(accessToken) &&
+        !isProxyEnabled &&
+        !meta['stageInfo']['useVirtualUrl']
+      ) {
         const gcsLocation = this.extractBucketNameAndPath(meta['stageInfo']['location']);
         await meta['client'].gcsClient
           .bucket(gcsLocation.bucketName)

--- a/lib/file_transfer_agent/gcs_util.js
+++ b/lib/file_transfer_agent/gcs_util.js
@@ -82,7 +82,7 @@ function GCSUtil(connectionConfig, httpClient) {
       client = null;
     }
 
-    process.nextTick(() => this.setupHttpClient(endPoint));
+    this.setupHttpClient(endPoint);
 
     return client;
   };

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -540,10 +540,6 @@ export function checkParametersDefined(...parameters: any[]) {
   return parameters.every((element) => element !== undefined && element !== null);
 }
 
-export function shouldPerformGCPBucket(accessToken: string) {
-  return !!accessToken && process.env.SNOWFLAKE_FORCE_GCP_USE_DOWNSCOPED_CREDENTIAL !== 'true';
-}
-
 /**
  * Checks if the provided file or directory permissions are correct.
  * @param filePath

--- a/test/unit/file_transfer_agent/gcs_test.js
+++ b/test/unit/file_transfer_agent/gcs_test.js
@@ -2,7 +2,6 @@ const assert = require('assert');
 const sinon = require('sinon');
 const fs = require('fs');
 const SnowflakeGCSUtil = require('./../../../lib/file_transfer_agent/gcs_util');
-const Util = require('../../../lib/util');
 const resultStatus = require('../../../lib/file_util').resultStatus;
 
 describe('GCS client', function () {
@@ -443,13 +442,10 @@ describe('GCS client', function () {
           const util = new SnowflakeGCSUtil(connectionConfig, httpClient());
           util.createClient(meta.stageInfo);
 
-          process.nextTick(() => {
-            const result = util.shouldUseJsonApi(meta);
+          const result = util.shouldUseJsonApi(meta);
+          assert.strictEqual(result, expectedResult);
 
-            assert.strictEqual(result, expectedResult);
-
-            delete process.env.SNOWFLAKE_FORCE_GCP_USE_DOWNSCOPED_CREDENTIAL;
-          });
+          delete process.env.SNOWFLAKE_FORCE_GCP_USE_DOWNSCOPED_CREDENTIAL;
         });
       },
     );

--- a/test/unit/util_test.js
+++ b/test/unit/util_test.js
@@ -1059,43 +1059,6 @@ describe('Util', function () {
     }
   });
 
-  describe('shouldPerformGCPBucket function test', () => {
-    const testCases = [
-      {
-        name: 'test - default',
-        accessToken: 'Token',
-        forceGCPUseDownscopedCredential: false,
-        result: true,
-      },
-      {
-        name: 'test - when the disableGCPTokenUpload is enabled',
-        accessToken: 'Token',
-        forceGCPUseDownscopedCredential: true,
-        result: false,
-      },
-      {
-        name: 'test - when token is empty but the disableGCPTokenUpload is enabled',
-        accessToken: null,
-        forceGCPUseDownscopedCredential: true,
-        result: false,
-      },
-      {
-        name: 'test - when token is empty but the disableGCPTokenUpload is disabled',
-        accessToken: null,
-        forceGCPUseDownscopedCredential: false,
-        result: false,
-      },
-    ];
-
-    testCases.forEach(({ name, accessToken, forceGCPUseDownscopedCredential, result }) => {
-      it(name, () => {
-        process.env.SNOWFLAKE_FORCE_GCP_USE_DOWNSCOPED_CREDENTIAL = forceGCPUseDownscopedCredential;
-        assert.strictEqual(Util.shouldPerformGCPBucket(accessToken), result);
-        delete process.env.SNOWFLAKE_FORCE_GCP_USE_DOWNSCOPED_CREDENTIAL;
-      });
-    });
-  });
-
   describe('getEnvVar function Test', function () {
     const testCases = [
       {


### PR DESCRIPTION
### Description

This PR is identical to https://github.com/snowflakedb/snowflake-connector-nodejs/pull/1119 but with removal of unneeded `.nextTick`

https://snowflakecomputing.atlassian.net/browse/SNOW-2198697

https://github.com/snowflakedb/snowflake-connector-nodejs/pull/1059 introduced handling for the `useVirtualUrl` but the implementation is incomplete.

The problem is that virtual domains are now used with the Json API which doesn’t support virtual-style domains. The issue is that the virtual-style domains are used with the GCP client [snowflake-connector-nodejs/lib/file_transfer_agent/gcs_util.js at master · snowflakedb/snowflake-connector-nodejs](https://github.com/snowflakedb/snowflake-connector-nodejs/blob/master/lib/file_transfer_agent/gcs_util.js#L293-L305) , so the full URL is like https://{bucket}.storage.googleapis.com/v1/{bucket}/{path}. GCP then sees the object as if it was an object{bucket}/{path} and produces errors:

```
Test PUT for internal stage. Compress=true
/app/node_modules/snowflake-sdk/dist/lib/file_transfer_agent/file_transfer_agent.js:191
                        throw new Error(errorDetails);
                              ^

Error: Error: Error: Multiple errors occurred during the request. Please see the `errors` array for complete details.

    1. Forbidden
    2. <?xml version='1.0' encoding='UTF-8'?><Error><Code>AccessDenied</Code><Message>Access denied.</Message><Details>gcpeuropewest4-1380616-stage@europe-west4-stage1-386e.iam.gserviceaccount.com does not have storage.objects.get access to the Google Cloud Storage object. Permission 'storage.objects.get' denied on resource (or it may not exist).</Details></Error>

 file=test_file.txt, real file=/tmp/tmpN72J4y/test_file.txt_c.gz
    at FileTransferAgent.result (/app/node_modules/snowflake-sdk/dist/lib/file_transfer_agent/file_transfer_agent.js:191:31)
    at executeFileTransferRequest (/app/node_modules/snowflake-sdk/dist/lib/connection/statement.js:695:28)
    at async FileStatementPreExec.context.onStatementRequestSucc (/app/node_modules/snowflake-sdk/dist/lib/connection/statement.js:667:9)
    at async BaseStatement.context.onStatementRequestComp (/app/node_modules/snowflake-sdk/dist/lib/connection/statement.js:474:13)
    at async callback (/app/node_modules/snowflake-sdk/dist/lib/connection/statement.js:1303:17)
    at async options.callback (/app/node_modules/snowflake-sdk/dist/lib/connection/statement.js:1261:13)
    at async options.callback (/app/node_modules/snowflake-sdk/dist/lib/services/sf.js:1159:17)
    at async Object.callback (/app/node_modules/snowflake-sdk/dist/lib/services/sf.js:595:21)
```

In reality, the issue is that XML API is not used at all, and the full URL is not the expected https://{bucket}.storage.googleapis.com/{path}.

This change is hard to test with unit tests in `gcs_test.js`, because the test already uses the proxy mode so the additional check is never reached. I am setting up periodic tests that run in Snowpark container services on GCP on all deployments, and that's how I caught this issue. Those workload tests will be updated to use this new client version.

### Checklist

- [ ] Create tests which fail without the change (if possible)
- [x] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [x] Extend the types in index.d.ts file (if necessary)
- [x] Extend the README / documentation and ensure is properly displayed (if necessary)
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message
