### PR TITLE
SNOW-2069227 : Update jira_close.yml workflow

### DIFF
--- a/.github/workflows/jira_close.yml
+++ b/.github/workflows/jira_close.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Extract issue from title
         id: extract
         env:
-          TITLE: "${{ github.event.issue.title }}"
+          TITLE: '${{ github.event.issue.title }}'
         run: |
           jira=$(echo -n $TITLE | awk '{print $1}' | sed -e 's/://')
           echo ::set-output name=jira::$jira


### PR DESCRIPTION
### Description

Workflows like jira_close.yml use deprecated atlassian JIRA actions and have a dependency on the gh-actions repo. This is not ideal and unecessarily complex. Updated jira_close workflow to use direct API calls via curl. It preserves custom fields used too.

### Checklist

- [ ] Create tests which fail without the change (if possible)
- [ ] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [ ] Extend the types in index.d.ts file (if necessary)
- [ ] Extend the README / documentation and ensure is properly displayed (if necessary)
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message
