### PR TITLE
SNOW-2117146 Move some CRL options to GlobalConfig

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,5 @@
 import { WIP_ConnectionOptions } from './lib/connection/types';
+import { GlobalConfigOptionsTyped } from './lib/global_config_typed';
 import ErrorCodeEnum from './lib/error_code';
 
 /**
@@ -46,7 +47,7 @@ declare module 'snowflake-sdk' {
     attributesGroupName?: false | null | string;
   }
 
-  export interface ConfigureOptions {
+  export type ConfigureOptions = Partial<GlobalConfigOptionsTyped> & {
     /**
      * Set the logLevel and logFilePath,
      * https://docs.snowflake.com/en/developer-guide/node-js/nodejs-driver-logs.
@@ -95,7 +96,7 @@ declare module 'snowflake-sdk' {
      * The default value is true. If false, the driver will not get the proxy from the environment variable.
      */
     useEnvProxy?: boolean;
-  }
+  };
 
   export type ConnectionOptions = WIP_ConnectionOptions & {
     //Detail information: https://docs.snowflake.com/en/developer-guide/node-js/nodejs-driver-options

--- a/lib/agent/crl_utils.ts
+++ b/lib/agent/crl_utils.ts
@@ -3,6 +3,7 @@ import crypto from 'crypto';
 import ASN1 from 'asn1.js-rfc5280';
 import axios, { AxiosRequestConfig } from 'axios';
 import Logger from '../logger';
+import GlobalConfigTyped from '../global_config_typed';
 
 // TODO:
 // Implement RSASSA-PSS signature verification
@@ -144,6 +145,7 @@ export async function getCrl(url: string, axiosOptions: AxiosRequestConfig = {})
   const downloadStartedAt = Date.now();
   const { data } = await axios.get(url, {
     ...axiosOptions,
+    timeout: GlobalConfigTyped.crlDownloadTimeout,
     responseType: 'arraybuffer',
   });
   logDebug(`Download Completed in ${Date.now() - downloadStartedAt}ms`);

--- a/lib/agent/crl_utils.ts
+++ b/lib/agent/crl_utils.ts
@@ -145,7 +145,7 @@ export async function getCrl(url: string, axiosOptions: AxiosRequestConfig = {})
   const downloadStartedAt = Date.now();
   const { data } = await axios.get(url, {
     ...axiosOptions,
-    timeout: GlobalConfigTyped.crlDownloadTimeout,
+    timeout: GlobalConfigTyped.getValue('crlDownloadTimeout'),
     responseType: 'arraybuffer',
   });
   logDebug(`Download Completed in ${Date.now() - downloadStartedAt}ms`);

--- a/lib/agent/crl_validator.ts
+++ b/lib/agent/crl_validator.ts
@@ -21,9 +21,6 @@ export const CRL_VALIDATOR_INTERNAL = {
 export type CRLValidatorConfig = {
   checkMode: 'DISABLED' | 'ENABLED' | 'ADVISORY';
   allowCertificatesWithoutCrlURL: boolean;
-  inMemoryCache: boolean;
-  onDiskCache: boolean;
-  downloadTimeoutMs: number;
 };
 
 export class CertificateRevokedError extends Error {

--- a/lib/agent/crl_validator.ts
+++ b/lib/agent/crl_validator.ts
@@ -21,6 +21,8 @@ export const CRL_VALIDATOR_INTERNAL = {
 export type CRLValidatorConfig = {
   checkMode: 'DISABLED' | 'ENABLED' | 'ADVISORY';
   allowCertificatesWithoutCrlURL: boolean;
+  inMemoryCache: boolean;
+  onDiskCache: boolean;
 };
 
 export class CertificateRevokedError extends Error {

--- a/lib/connection/connection_config.js
+++ b/lib/connection/connection_config.js
@@ -78,9 +78,6 @@ const DEFAULT_PARAMS = [
   'queryTag',
   'certRevocationCheckMode',
   'crlAllowCertificatesWithoutCrlURL',
-  'crlInMemoryCache',
-  'crlOnDiskCache',
-  'crlDownloadTimeoutMs',
 ];
 
 function consolidateHostAndAccount(options) {
@@ -1147,9 +1144,6 @@ function ConnectionConfig(options, validateCredentials, qaMode, clientInfo) {
   this.crlValidatorConfig = {
     checkMode: options.certRevocationCheckMode ?? 'DISABLED',
     allowCertificatesWithoutCrlURL: options.crlAllowCertificatesWithoutCrlURL ?? false,
-    inMemoryCache: options.crlInMemoryCache ?? true,
-    onDiskCache: options.crlOnDiskCache ?? true,
-    downloadTimeoutMs: options.crlDownloadTimeoutMs ?? 10000,
   };
 
   // create the parameters array

--- a/lib/connection/connection_config.js
+++ b/lib/connection/connection_config.js
@@ -78,6 +78,8 @@ const DEFAULT_PARAMS = [
   'queryTag',
   'certRevocationCheckMode',
   'crlAllowCertificatesWithoutCrlURL',
+  'crlInMemoryCache',
+  'crlOnDiskCache',
 ];
 
 function consolidateHostAndAccount(options) {
@@ -1144,6 +1146,8 @@ function ConnectionConfig(options, validateCredentials, qaMode, clientInfo) {
   this.crlValidatorConfig = {
     checkMode: options.certRevocationCheckMode ?? 'DISABLED',
     allowCertificatesWithoutCrlURL: options.crlAllowCertificatesWithoutCrlURL ?? false,
+    inMemoryCache: options.crlInMemoryCache ?? true,
+    onDiskCache: options.crlOnDiskCache ?? true,
   };
 
   // create the parameters array

--- a/lib/connection/types.ts
+++ b/lib/connection/types.ts
@@ -128,27 +128,6 @@ export interface WIP_ConnectionOptions {
    * @default false
    */
   crlAllowCertificatesWithoutCrlURL?: CRLValidatorConfig['allowCertificatesWithoutCrlURL'];
-
-  /**
-   * When certRevocationCheckMode is enabled, allows to cache CRLs in memory.
-   *
-   * @default true
-   */
-  crlInMemoryCache?: CRLValidatorConfig['inMemoryCache'];
-
-  /**
-   * When certRevocationCheckMode is enabled, allows to cache CRLs on disk.
-   *
-   * @default true
-   */
-  crlOnDiskCache?: CRLValidatorConfig['onDiskCache'];
-
-  /**
-   * When certRevocationCheckMode is enabled, allows to set timeout for CRL download.
-   *
-   * @default 10000
-   */
-  crlDownloadTimeoutMs?: CRLValidatorConfig['downloadTimeoutMs'];
 }
 
 /**

--- a/lib/connection/types.ts
+++ b/lib/connection/types.ts
@@ -128,6 +128,20 @@ export interface WIP_ConnectionOptions {
    * @default false
    */
   crlAllowCertificatesWithoutCrlURL?: CRLValidatorConfig['allowCertificatesWithoutCrlURL'];
+
+  /**
+   * When certRevocationCheckMode is enabled, allows to cache CRLs in memory.
+   *
+   * @default true
+   */
+  crlInMemoryCache?: CRLValidatorConfig['inMemoryCache'];
+
+  /**
+   * When certRevocationCheckMode is enabled, allows to cache CRLs on disk.
+   *
+   * @default true
+   */
+  crlOnDiskCache?: CRLValidatorConfig['onDiskCache'];
 }
 
 /**

--- a/lib/core.js
+++ b/lib/core.js
@@ -9,7 +9,7 @@ const Logger = require('./logger');
 const LoggerCore = require('./logger/core');
 const DataTypes = require('./connection/result/data_types');
 const GlobalConfig = require('./global_config');
-const { setGlobalConfigTypedOptions } = require('./global_config_typed');
+const GlobalConfigTyped = require('./global_config_typed').default;
 const { loadConnectionConfiguration } = require('./configuration/connection_configuration');
 
 /**
@@ -218,7 +218,7 @@ function Core(options) {
         );
       }
 
-      setGlobalConfigTypedOptions(options);
+      GlobalConfigTyped.setOptions(options);
 
       const disableOCSPChecks = options.disableOCSPChecks;
       if (Util.exists(disableOCSPChecks)) {

--- a/lib/core.js
+++ b/lib/core.js
@@ -9,6 +9,7 @@ const Logger = require('./logger');
 const LoggerCore = require('./logger/core');
 const DataTypes = require('./connection/result/data_types');
 const GlobalConfig = require('./global_config');
+const { setGlobalConfigTypedOptions } = require('./global_config_typed');
 const { loadConnectionConfiguration } = require('./configuration/connection_configuration');
 
 /**
@@ -216,6 +217,8 @@ function Core(options) {
           additionalLogToConsole,
         );
       }
+
+      setGlobalConfigTypedOptions(options);
 
       const disableOCSPChecks = options.disableOCSPChecks;
       if (Util.exists(disableOCSPChecks)) {

--- a/lib/global_config_typed.ts
+++ b/lib/global_config_typed.ts
@@ -1,0 +1,69 @@
+import Logger from './logger';
+
+/*
+ * NOTE:
+ * Work In Progress migration of global_config.js to TypeScript.
+ *
+ * Instead of gettter+setter for each config option, we should use a signle object
+ * Instead of manual input validation, we should rely on TypeScript's type system
+ * This will simplify erorr codes, typing, mocking and testing = less code to maintain
+ *
+ * TODO:
+ * When all global_config.js options are migrated:
+ * - rename to global_config.ts
+ * - removed "typed" from variable & function names
+ */
+export interface GlobalConfigOptionsTyped {
+  /**
+   * Enable CRL caching in memory. Cached entries are removed after crlCacheValidityTime.
+   *
+   * @default true
+   */
+  crlInMemoryCache: boolean;
+
+  /**
+   * Enable CRL caching on disk. Cached entries are removed after crlCacheValidityTime.
+   *
+   * Disk read/write failures are ignored.
+   *
+   * @default true
+   */
+  crlOnDiskCache: boolean;
+
+  /**
+   * HTTP request timeout for CRL download.
+   *
+   * @default 10000 (ms)
+   */
+  crlDownloadTimeout: number;
+
+  /**
+   * Time after which cached CRL entries are invalidated.
+   *
+   * @default 86400000 (24 hours in ms)
+   */
+  crlCacheValidityTime: number;
+}
+
+export const GLOBAL_CONFIG_DEFAULTS: GlobalConfigOptionsTyped = {
+  crlInMemoryCache: true,
+  crlOnDiskCache: true,
+  crlDownloadTimeout: 10000,
+  crlCacheValidityTime: 86400000,
+};
+
+const GlobalConfigTyped: GlobalConfigOptionsTyped = {
+  ...GLOBAL_CONFIG_DEFAULTS,
+};
+
+export default GlobalConfigTyped;
+
+export const setGlobalConfigTypedOptions = (options: Partial<GlobalConfigOptionsTyped>) => {
+  const filteredOptions = Object.fromEntries(
+    Object.entries(options).filter(
+      ([key, value]) => key in GLOBAL_CONFIG_DEFAULTS && value !== undefined,
+    ),
+  );
+  Logger().debug('Setting global config typed options: %j', filteredOptions);
+  Object.assign(GlobalConfigTyped, filteredOptions);
+};

--- a/test/unit/agent/crl_validator_test.ts
+++ b/test/unit/agent/crl_validator_test.ts
@@ -15,6 +15,8 @@ describe('validateCrl', () => {
   const validatorConfig: CRLValidatorConfig = {
     checkMode: 'ENABLED',
     allowCertificatesWithoutCrlURL: false,
+    inMemoryCache: false,
+    onDiskCache: false,
   };
   const crlUrl = 'http://example.com/crl.crl';
   const rootKeyPair = createCertificateKeyPair();

--- a/test/unit/agent/crl_validator_test.ts
+++ b/test/unit/agent/crl_validator_test.ts
@@ -15,9 +15,6 @@ describe('validateCrl', () => {
   const validatorConfig: CRLValidatorConfig = {
     checkMode: 'ENABLED',
     allowCertificatesWithoutCrlURL: false,
-    inMemoryCache: false,
-    onDiskCache: false,
-    downloadTimeoutMs: 5000,
   };
   const crlUrl = 'http://example.com/crl.crl';
   const rootKeyPair = createCertificateKeyPair();

--- a/test/unit/global_config.ts
+++ b/test/unit/global_config.ts
@@ -1,28 +1,41 @@
 import assert from 'assert';
 import GlobalConfigTyped, {
   GLOBAL_CONFIG_DEFAULTS,
-  setGlobalConfigTypedOptions,
+  globalConfigSetOptions,
 } from '../../lib/global_config_typed';
 
 describe('GlobalConfig', () => {
-  afterEach(() => {
-    setGlobalConfigTypedOptions(GLOBAL_CONFIG_DEFAULTS);
+  beforeEach(() => {
+    for (const key in globalConfigSetOptions) {
+      delete globalConfigSetOptions[key as keyof typeof globalConfigSetOptions];
+    }
   });
 
-  it('returns GlobalConfig with default values', () => {
-    assert.deepStrictEqual(GlobalConfigTyped, GLOBAL_CONFIG_DEFAULTS);
+  it('getValue returns default value if not configured', () => {
+    assert.strictEqual(
+      GlobalConfigTyped.getValue('crlInMemoryCache'),
+      GLOBAL_CONFIG_DEFAULTS.crlInMemoryCache,
+    );
+  });
+
+  it('getValue returns configured value', () => {
+    GlobalConfigTyped.setOptions({ crlResponseCacheDir: 'test' });
+    assert.strictEqual(GlobalConfigTyped.getValue('crlResponseCacheDir'), 'test');
   });
 
   it('setGlobalConfigTypedOptions sets only valid options and skipps undefined options', () => {
-    setGlobalConfigTypedOptions({
+    GlobalConfigTyped.setOptions({
       crlInMemoryCache: false,
       crlDownloadTimeout: undefined,
       // @ts-expect-error invalid key
       invalidKey: 'invalidValue',
     });
-    assert.deepStrictEqual(GlobalConfigTyped, {
-      ...GLOBAL_CONFIG_DEFAULTS,
-      crlInMemoryCache: false,
-    });
+    assert.strictEqual(GlobalConfigTyped.getValue('crlInMemoryCache'), false);
+    assert.strictEqual(
+      GlobalConfigTyped.getValue('crlDownloadTimeout'),
+      GLOBAL_CONFIG_DEFAULTS.crlDownloadTimeout,
+    );
+    // @ts-expect-error invalid key
+    assert.strictEqual(GlobalConfigTyped.getValue('invalidKey'), undefined);
   });
 });

--- a/test/unit/global_config.ts
+++ b/test/unit/global_config.ts
@@ -1,0 +1,28 @@
+import assert from 'assert';
+import GlobalConfigTyped, {
+  GLOBAL_CONFIG_DEFAULTS,
+  setGlobalConfigTypedOptions,
+} from '../../lib/global_config_typed';
+
+describe('GlobalConfig', () => {
+  afterEach(() => {
+    setGlobalConfigTypedOptions(GLOBAL_CONFIG_DEFAULTS);
+  });
+
+  it('returns GlobalConfig with default values', () => {
+    assert.deepStrictEqual(GlobalConfigTyped, GLOBAL_CONFIG_DEFAULTS);
+  });
+
+  it('setGlobalConfigTypedOptions sets only valid options and skipps undefined options', () => {
+    setGlobalConfigTypedOptions({
+      crlInMemoryCache: false,
+      crlDownloadTimeout: undefined,
+      // @ts-expect-error invalid key
+      invalidKey: 'invalidValue',
+    });
+    assert.deepStrictEqual(GlobalConfigTyped, {
+      ...GLOBAL_CONFIG_DEFAULTS,
+      crlInMemoryCache: false,
+    });
+  });
+});


### PR DESCRIPTION
### Description
Related to CRL caching implemented in pending PR https://github.com/snowflakedb/snowflake-connector-nodejs/pull/1163

* Moved some config options to the global config
* created new GlobalConfig with TypeScript 
* added a NOTE with migration plan

#### Notes on migration plan
Developers are reading our source code, and it's very difficult for them to understand what's going on in our config. There are 5000+ lines of config-related code with undocumented defaults, undocumented env variables, mistakes in value validators, and inconsistent error codes. All of this can be reduced to ~500 lines of code with Typescript + default values map.

Other popular SDKs don't do param validation either and rely on defaults, TS, and runtime errors. 

### Checklist

- [x] Create tests which fail without the change (if possible)
- [x] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [x] Extend the types in index.d.ts file (if necessary)
- [x] Extend the README / documentation and ensure is properly displayed (if necessary)
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message
