### PR TITLE
SNOW-2117146 Add CRL_REVOCATION_CHECK_MODE to CLIENT_ENVIRONMENT

### DIFF
--- a/lib/authentication/authentication.js
+++ b/lib/authentication/authentication.js
@@ -13,12 +13,14 @@ const AuthWorkloadIdentity = require('./auth_workload_identity').default;
 
 /**
  * TODO: Refactor
- * - StateConnecting.continue in sf.js adds almost every param from this function (overwrites them)
+ * - StateConnecting.continue in sf.js and ConnectionConfig adds almost every param
+ *   from this function (overwrites them)
  * - AUTHENTICATOR is implemented in almost every auth provider
  *
  * Refactor Plan:
+ * - Have a single place to build CLIENT_ENVIRONMENT: ConnectionConfig or sf.js
  * - Have a single place to build common params by either:
- *  - Remeving this method
+ *  - Removing this method
  *  - Moving logic from StateConnecting.continue to this method.
  *    Options should be simplified to accept only ConnectionConfig
  * - Rename auth.updateBody to auth.buildData (as it only builds keys under body.data)

--- a/lib/services/sf.js
+++ b/lib/services/sf.js
@@ -1099,6 +1099,7 @@ StateConnecting.prototype.continue = function () {
   const clientEnvironment = this.connectionConfig.getClientEnvironment();
   if (Util.isObject(clientEnvironment)) {
     clientInfo.CLIENT_ENVIRONMENT = {
+      CRL_REVOCATION_CHECK_MODE: this.connectionConfig.crlValidatorConfig.checkMode,
       ...json.data.CLIENT_ENVIRONMENT,
       ...clientEnvironment,
     };

--- a/test/integration/testCrl.ts
+++ b/test/integration/testCrl.ts
@@ -1,5 +1,6 @@
 import assert from 'assert';
 import sinon from 'sinon';
+import axios from 'axios';
 import os from 'os';
 import { WIP_ConnectionOptions } from '../../lib/connection/types';
 import * as connectionOptions from './connectionOptions';
@@ -27,9 +28,15 @@ describe('connection with CRL validation', () => {
   });
 
   it.skip('allows connection for valid certificate', async () => {
+    const axiosRequestSpy = sinon.spy(axios, 'request');
     const validateCrlSpy = sinon.spy(CRL_VALIDATOR_INTERNAL, 'validateCrl');
     await assert.doesNotReject(testCrlConnection());
     assert.strictEqual(validateCrlSpy.callCount, 1);
+    const loginRequestData = axiosRequestSpy.getCall(0).args[0].data as any;
+    assert.strictEqual(
+      loginRequestData.data.CLIENT_ENVIRONMENT.CRL_REVOCATION_CHECK_MODE,
+      'ENABLED',
+    );
   });
 
   if (os.platform() === 'linux' && !process.env.SHOULD_SKIP_PROXY_TESTS) {


### PR DESCRIPTION
### Description

Adds `CRL_REVOCATION_CHECK_MODE ` to login request `CLIENT_ENVIRONMENT`

### Checklist

- [x] Create tests which fail without the change (if possible)
- [x] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [x] Extend the types in index.d.ts file (if necessary)
- [x] Extend the README / documentation and ensure is properly displayed (if necessary)
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message
