### PR TITLE
SNOW-2143625 add boolean and null to Bind typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Improved debug logs when dowloading query result chunks (snowflakedb/snowflake-connector-nodejs#1142)
 - Fixed missing error handling in `getResultsFromQueryId()` (snowflakedb/snowflake-connector-nodejs#1173)
 - Fixed invalid transformation of `null` values to `""` when using stage binds (snowflakedb/snowflake-connector-nodejs#1166)
+- Extended typing of Bind (issue #1093)
 
 ## Prior Releases
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Improved debug logs when dowloading query result chunks (snowflakedb/snowflake-connector-nodejs#1142)
 - Fixed missing error handling in `getResultsFromQueryId()` (snowflakedb/snowflake-connector-nodejs#1173)
 - Fixed invalid transformation of `null` values to `""` when using stage binds (snowflakedb/snowflake-connector-nodejs#1166)
-- Extended typing of Bind (issue #1093)
+- Extended typing of Bind (snowflakedb/snowflake-connector-nodejs#1176)
 
 ## Prior Releases
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,7 +8,7 @@ import ErrorCodeEnum from './lib/error_code';
  */
 declare module 'snowflake-sdk' {
   export type CustomParser = (rawColumnValue: string) => any;
-  export type Bind = string | number;
+  export type Bind = string | number | boolean | null;
   export type InsertBinds = Bind[][];
   export type Binds = Bind[] | InsertBinds;
   export type StatementCallback = (


### PR DESCRIPTION
### Description

Addresses #1093 

Since we check if the bind variables' array is JSON.stringifiable ([ref](https://github.com/snowflakedb/snowflake-connector-nodejs/blob/v2.2.0/lib/connection/statement.js#L363-L369)) and doesn't return `undefined`, in principle then the typing should also reflect it and list the objects which are supposed to be correctly stringifiable (have `toJSON()` method) 

We already had a complaint about this, see above Issue. So extending the Bind typing accordingly.

### Checklist

- [ ] Create tests which fail without the change (if possible)
- [ ] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [x] Extend the types in index.d.ts file (if necessary)
- [x] Extend the README / documentation and ensure is properly displayed (if necessary)
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message
