### PR TITLE
SNOW-2306340: Add pki-oversight as a joint owner for PKI-related files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @snowflakedb/Client
+/lib/agent/** @snowflakedb/pki-oversight @snowflakedb/Client


### PR DESCRIPTION
### Description

Add pki-oversight as a joint owner for PKI-related files. Similar to https://github.com/snowflakedb/gosnowflake/pull/1581

### Checklist

- [x] Create tests which fail without the change (if possible)
- [x] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [x] Extend the types in index.d.ts file (if necessary)
- [x] Extend the README / documentation and ensure is properly displayed (if necessary)
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message
