### PR TITLE
Cloud provider specific dependencies made as optional peer dependencies

### DIFF
--- a/lib/authentication/auth_workload_identity/attestation_aws.ts
+++ b/lib/authentication/auth_workload_identity/attestation_aws.ts
@@ -1,15 +1,8 @@
 import Logger from '../../logger';
 
 export async function getAwsCredentials(region: string, impersonationPath: string[] = []) {
-  // @ts-ignore
-  const defaultProvider = await import('@aws-sdk/credential-provider-node').then(
-    (i) => i.defaultProvider,
-  );
-  // @ts-ignore
-  const { STSClient, AssumeRoleCommand } = await import('@aws-sdk/client-sts').then((i) => ({
-    STSClient: i.STSClient,
-    AssumeRoleCommand: i.AssumeRoleCommand,
-  }));
+  const { defaultProvider } = await import('@aws-sdk/credential-provider-node');
+  const { STSClient, AssumeRoleCommand } = await import('@aws-sdk/client-sts');
 
   Logger().debug('Getting AWS credentials from default provider');
   let credentials = await defaultProvider()();
@@ -40,10 +33,7 @@ export async function getAwsCredentials(region: string, impersonationPath: strin
 }
 
 export async function getAwsRegion() {
-  // @ts-ignore
-  const MetadataService = await import('@aws-sdk/ec2-metadata-service').then(
-    (i) => i.MetadataService,
-  );
+  const { MetadataService } = await import('@aws-sdk/ec2-metadata-service');
 
   if (process.env.AWS_REGION) {
     Logger().debug('Getting AWS region from AWS_REGION');
@@ -60,12 +50,9 @@ export function getStsHostname(region: string) {
 }
 
 export async function getAwsAttestationToken(impersonationPath?: string[]) {
-  // @ts-ignore
-  const HttpRequest = await import('@smithy/protocol-http').then((i) => i.HttpRequest);
-  // @ts-ignore
-  const SignatureV4 = await import('@smithy/signature-v4').then((i) => i.SignatureV4);
-  // @ts-ignore
-  const Sha256 = await import('@aws-crypto/sha256-js').then((i) => i.Sha256);
+  const { HttpRequest } = await import('@smithy/protocol-http');
+  const { SignatureV4 } = await import('@smithy/signature-v4');
+  const { Sha256 } = await import('@aws-crypto/sha256-js');
 
   const region = await getAwsRegion();
   const credentials = await getAwsCredentials(region, impersonationPath);

--- a/lib/authentication/auth_workload_identity/attestation_azure.ts
+++ b/lib/authentication/auth_workload_identity/attestation_azure.ts
@@ -8,10 +8,7 @@ export async function getAzureAttestationToken(
     entraIdResource?: string;
   } = {},
 ) {
-  // @ts-ignore
-  const DefaultAzureCredential = await import('@azure/identity').then(
-    (e) => e.DefaultAzureCredential,
-  );
+  const { DefaultAzureCredential } = await import('@azure/identity');
   const credential = new DefaultAzureCredential({
     managedIdentityClientId: options.managedIdentityClientId,
   });

--- a/lib/authentication/auth_workload_identity/attestation_gcp.ts
+++ b/lib/authentication/auth_workload_identity/attestation_gcp.ts
@@ -4,10 +4,7 @@ export const SNOWFLAKE_AUDIENCE = 'snowflakecomputing.com';
 
 export async function getGcpAttestationToken(impersonationPath?: string[]) {
   //@ts-ignore
-  const { GoogleAuth, Impersonated } = await import('google-auth-library').then((i) => ({
-    GoogleAuth: i.GoogleAuth,
-    Impersonated: i.Impersonated,
-  }));
+  const { GoogleAuth, Impersonated } = await import('google-auth-library');
   const auth = new GoogleAuth();
 
   if (impersonationPath) {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,18 @@
     "ts-node": "^10.9.2",
     "typescript": "^5.8.3",
     "wiremock": "^3.10.0",
-    "wiremock-rest-client": "^1.11.0"
+    "wiremock-rest-client": "^1.11.0",
+    "@aws-crypto/sha256-js": "^5.2.0",
+    "@aws-sdk/client-s3": "^3.726.0",
+    "@aws-sdk/client-sts": "^3.899.0",
+    "@aws-sdk/credential-provider-node": "^3.823.0",
+    "@aws-sdk/ec2-metadata-service": "^3.826.0",
+    "@smithy/node-http-handler": "^4.0.1",
+    "@smithy/protocol-http": "^5.1.3",
+    "@smithy/signature-v4": "^5.2.1",
+    "@azure/identity": "^4.13.0",
+    "@azure/storage-blob": "^12.11.0",
+    "@google-cloud/storage": "^7.7.0"
   },
   "peerDependencies": {
     "asn1.js": "^5.4.1",
@@ -60,6 +71,7 @@
     "@smithy/node-http-handler": "^4.0.1",
     "@smithy/protocol-http": "^5.1.3",
     "@smithy/signature-v4": "^5.2.1",
+    "@azure/identity": "^4.13.0",
     "@azure/storage-blob": "^12.11.0",
     "@google-cloud/storage": "^7.7.0"
   },
@@ -68,6 +80,9 @@
       "optional": true
     },
     "@aws-sdk/client-s3": {
+      "optional": true
+    },
+    "@azure/identity": {
       "optional": true
     },
     "@azure/storage-blob": {

--- a/test/unit/authentication/auth_workload_identity/attestation_azure_test.ts
+++ b/test/unit/authentication/auth_workload_identity/attestation_azure_test.ts
@@ -1,6 +1,5 @@
 import sinon from 'sinon';
 import assert from 'assert';
-// @ts-ignore
 import * as AzureIdentity from '@azure/identity';
 import {
   getAzureAttestationToken,

--- a/test/unit/authentication/auth_workload_identity/auth_workload_identity_test.ts
+++ b/test/unit/authentication/auth_workload_identity/auth_workload_identity_test.ts
@@ -1,7 +1,6 @@
 import sinon from 'sinon';
 import rewiremock from 'rewiremock/node';
 import assert from 'assert';
-// @ts-ignore
 import * as AzureIdentity from '@azure/identity';
 import * as AttestationAzureModule from '../../../../lib/authentication/auth_workload_identity/attestation_azure';
 import { GoogleAuth } from 'google-auth-library';


### PR DESCRIPTION
### Description

Dependencies concerning specific cloud providers used in `attestation_aws.ts`, `attestation_azure.ts` and `attestation_gcp.ts` files made as optional `peerDependencies` and `devDependencies` (the latter is only to provide correct typings for Typescript during development). The static imports which required mentioned deps are turned into dynamic ones and are done on-demand (when any functions from these attestation functions require them). 

Thanks to that none of these deps need to be installed by default and only when a target app needs it - then only these `peerDependencies` which concern specific cloud provider must be installed additionally.

### Checklist

- [ ] Create tests which fail without the change (if possible)
- [ ] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [ ] Extend the types in index.d.ts file (if necessary)
- [ ] Extend the README / documentation and ensure is properly displayed (if necessary)
- [ ] Provide JIRA issue id (if possible) or GitHub issue id in commit message
