### PR TITLE
SNOW-2684159: Add NodeJS 24 (LTS) support

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -49,7 +49,7 @@ jobs:
       fail-fast: false
       matrix:
         cloud: ['AWS', 'AZURE', 'GCP']
-        nodeVersion: ['18.x','20.x', '22.x', '24.x']
+        nodeVersion: ['18.x', '20.x', '22.x', '24.x']
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
### Description

Closes #1201

NodeJS 24 is now LTS as of October 28, 2025. This PR updates the test matrix to only test against NodeJS 18, 20, 22, and 24.

The docs at https://docs.snowflake.com/en/developer-guide/node-js/nodejs-driver will also need to be updated to represent only actively supported Node versions.

### Checklist

- [x] Create tests which fail without the change (if possible)
- [x] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [x] Extend the types in index.d.ts file (if necessary)
- [x] Extend the README / documentation and ensure is properly displayed (if necessary)
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message
