### PR TITLE
NO-SNOW Fix slow & flaky tests

### DIFF
--- a/test/integration/ocsp_mock/testConnectionOcspMock.js
+++ b/test/integration/ocsp_mock/testConnectionOcspMock.js
@@ -1,25 +1,34 @@
-const snowflake = require('./../../../lib/snowflake');
 const async = require('async');
 const assert = require('assert');
+const sinon = require('sinon');
 const connOption = require('../connectionOptions');
 const Errors = require('../../../lib/errors');
-const ErrorCodes = Errors.codes;
+const snowflake = require('./../../../lib/snowflake');
 const HttpsMockAgent = require('./https_ocsp_mock_agent');
 const Logger = require('../../../lib/logger');
+const Util = require('../../../lib/util');
 
-function cloneConnOption(connOption) {
-  const ret = {};
-  for (const k in connOption) {
-    ret[k] = connOption[k];
-  }
-  return ret;
-}
+const ErrorCodes = Errors.codes;
 
 describe('Connection test with OCSP Mock', function () {
-  this.timeout(300000);
+  before(() => {
+    // NOTE:
+    // Mock backoff to 100ms for fast retries
+    sinon
+      .stub(Util, 'getJitteredSleepTime')
+      .callsFake((_numRetries, _currentSleepTime, totalElapsedTime) => {
+        const sleep = 0.1; // 100ms
+        const newTotalElapsedTime = totalElapsedTime + sleep;
+        return { sleep, totalElapsedTime: newTotalElapsedTime };
+      });
+  });
 
-  const valid = cloneConnOption(connOption.valid);
+  after(() => sinon.restore());
 
+  const valid = {
+    ...connOption.valid,
+    sfRetryMaxLoginRetries: 2,
+  };
   const isHttps = valid.accessUrl.startsWith('https');
 
   function connect(errcode, connection, callback) {

--- a/test/integration/testLargeResultSet.js
+++ b/test/integration/testLargeResultSet.js
@@ -259,7 +259,7 @@ describe('SNOW-743920:Large result set with ~35 chunks', function () {
         } else {
           stmt
             .streamRows()
-            .on('error', () => done(err))
+            .on('error', done)
             .on('data', (row) => rows.push(row))
             .on('end', () => {
               try {

--- a/test/integration/testOcsp.js
+++ b/test/integration/testOcsp.js
@@ -25,13 +25,9 @@ describe('OCSP validation', function () {
     async.series(
       [
         function (callback) {
-          connection.connect(function (err) {
-            assert.ok(!err, JSON.stringify(err));
-            callback();
-          });
+          connection.connect(callback);
         },
         function (callback) {
-          let numErrors = 0;
           let numStmtsExecuted = 0;
           const numStmtsTotal = 20;
 
@@ -42,12 +38,11 @@ describe('OCSP validation', function () {
               sqlText: 'select 1;',
               complete: function (err) {
                 if (err) {
-                  numErrors++;
+                  callback(err);
                 }
 
                 numStmtsExecuted++;
-                if (numStmtsExecuted === numStmtsTotal - 1) {
-                  assert.strictEqual(numErrors, 0);
+                if (numStmtsExecuted === numStmtsTotal) {
                   callback();
                 }
               },
@@ -71,13 +66,9 @@ describe('OCSP validation', function () {
     async.series(
       [
         function (callback) {
-          connection.connect(function (err) {
-            assert.ok(!err, JSON.stringify(err));
-            callback();
-          });
+          connection.connect(callback);
         },
         function (callback) {
-          let numErrors = 0;
           let numStmtsExecuted = 0;
           const numStmtsTotal = 5;
 
@@ -89,13 +80,12 @@ describe('OCSP validation', function () {
                 sqlText: 'select 1;',
                 complete: function (err) {
                   if (err) {
-                    numErrors++;
+                    callback(err);
                   }
 
                   numStmtsExecuted++;
-                  if (numStmtsExecuted === numStmtsTotal - 1) {
+                  if (numStmtsExecuted === numStmtsTotal) {
                     delete process.env['SF_OCSP_TEST_CACHE_MAXAGE'];
-                    assert.strictEqual(numErrors, 0);
                     callback();
                   }
                 },


### PR DESCRIPTION
### Description

* `test/integration/ocsp_mock/testConnectionOcspMock.js` -> ridiculously slow with 2 tests taking 6 minutes to complete because of `/login-request` retries. Solved by reducing retry attempts to 2 and mocking the backoff strategy to 100ms repeats
* `test/integration/testHTAP.js` 
  * fixed error printing
  * actual error seems to indicate that 2 processes use the same dbname - fixed with uuids
  * `this.retries(3)` replaced with timeout as test is often on the edge of default execution time
 * `test/integration/testLargeResultSet.js` -> printing wrong error on stream error
 * `test/integration/testOcsp.js` -> wrong loop logic that ends the test while 1 query is still in progress

### Checklist

- [x] Create tests which fail without the change (if possible)
- [x] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [x] Extend the types in index.d.ts file (if necessary)
- [x] Extend the README / documentation and ensure is properly displayed (if necessary)
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message
