### PR TITLE
Fix misleading connection success logs

### DIFF
--- a/lib/connection/connection.js
+++ b/lib/connection/connection.js
@@ -241,7 +241,7 @@ function Connection(context) {
    */
   function connectCallback(self, callback, timer) {
     return function (err) {
-      const connectingDuration = timer ? timer.getDuration() : 'unknown';
+      const connectingDuration = timer.getDuration();
 
       if (err) {
         Logger.getInstance().error(


### PR DESCRIPTION
### Description

The current logging in `connect()` and `connectAsync()` is misleading: it logs "connected successfully" immediately after initiating the request, not after receiving the response.

This caused confusion while debugging a connection issue with a wrong account name - the logs said "connected successfully after 3ms" but the connection was actually hanging until timeout.

**Changes:**

- Move success/failure logging into the actual callback where we know the real result
- Log "connection request initiated" at DEBUG level instead of false success at INFO level  
- Include the actual error message when connection fails

### Checklist

- [ ] Create tests which fail without the change (if possible)
- [x] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [ ] Extend the types in index.d.ts file (if necessary)
- [ ] Extend the README / documentation and ensure is properly displayed (if necessary)
- [ ] Provide JIRA issue id (if possible) or GitHub issue id in commit message