### PR TITLE
NO-SNOW fix mac builds

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -56,7 +56,7 @@ jobs:
           node-version: ${{ matrix.nodeVersion }}
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.7'
+          python-version: '3.12'
       - name: Download Build Artifacts
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
### Description

macos-13 is deprecated

### Checklist

- [x] Create tests which fail without the change (if possible)
- [x] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [x] Extend the types in index.d.ts file (if necessary)
- [x] Extend the README / documentation and ensure is properly displayed (if necessary)
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message
