### PR TITLE
SNOW-1703685: Stream PUT digest + uploads to reduce memory (#922)

### DIFF
--- a/lib/file_transfer_agent/azure_util.js
+++ b/lib/file_transfer_agent/azure_util.js
@@ -157,7 +157,7 @@ function AzureUtil(connectionConfig) {
    * @returns {null}
    */
   this.uploadFile = async function (dataFile, meta, encryptionMetadata, maxConcurrency) {
-    const fileStream = fs.readFileSync(dataFile);
+    const fileStream = fs.createReadStream(dataFile);
     await this.uploadFileStream(fileStream, meta, encryptionMetadata, maxConcurrency);
   };
 
@@ -170,7 +170,7 @@ function AzureUtil(connectionConfig) {
    *
    * @returns {null}
    */
-  this.uploadFileStream = async function (fileStream, meta, encryptionMetadata) {
+  this.uploadFileStream = async function (fileStream, meta, encryptionMetadata, maxConcurrency) {
     const azureMetadata = {
       sfcdigest: meta['SHA256_DIGEST'],
     };
@@ -204,13 +204,22 @@ function AzureUtil(connectionConfig) {
     const blockBlobClient = containerClient.getBlockBlobClient(blobName);
 
     try {
-      await blockBlobClient.upload(fileStream, fileStream.length, {
+      const uploadOptions = {
         metadata: azureMetadata,
         blobHTTPHeaders: {
           blobContentEncoding: 'UTF-8',
           blobContentType: 'application/octet-stream',
         },
-      });
+      };
+
+      if (Buffer.isBuffer(fileStream)) {
+        await blockBlobClient.upload(fileStream, fileStream.length, uploadOptions);
+      } else {
+        const bufferSize = 4 * 1024 * 1024; // 4 MiB
+        const concurrency =
+          Number.isInteger(maxConcurrency) && maxConcurrency > 0 ? maxConcurrency : 1;
+        await blockBlobClient.uploadStream(fileStream, bufferSize, concurrency, uploadOptions);
+      }
     } catch (err) {
       if (err['statusCode'] === 403 && detectAzureTokenExpireError(err)) {
         meta['lastError'] = err;

--- a/lib/file_transfer_agent/gcs_util.js
+++ b/lib/file_transfer_agent/gcs_util.js
@@ -6,6 +6,7 @@ const ProxyUtil = require('../proxy_util');
 const Util = require('../util');
 const { lstrip } = require('../util');
 const Logger = require('../logger').default;
+const { pipeline } = require('stream');
 
 const GCS_METADATA_PREFIX = 'x-goog-meta-';
 const SFC_DIGEST = 'sfc-digest';
@@ -220,7 +221,8 @@ function GCSUtil(connectionConfig, httpClient) {
    * @returns {null}
    */
   this.uploadFile = async function (dataFile, meta, encryptionMetadata, maxConcurrency) {
-    const fileStream = fs.readFileSync(dataFile);
+    meta['uploadFileSize'] = fs.statSync(dataFile).size;
+    const fileStream = fs.createReadStream(dataFile);
     await this.uploadFileStream(fileStream, meta, encryptionMetadata, maxConcurrency);
   };
 
@@ -290,21 +292,37 @@ function GCSUtil(connectionConfig, httpClient) {
     try {
       if (this.shouldUseJsonApi(meta)) {
         const gcsLocation = this.extractBucketNameAndPath(meta['stageInfo']['location']);
-
-        await meta['client'].gcsClient
+        const gcsFile = meta['client'].gcsClient
           .bucket(gcsLocation.bucketName)
-          .file(gcsLocation.path + meta['dstFileName'])
-          .save(fileStream, {
+          .file(gcsLocation.path + meta['dstFileName']);
+
+        const jsonApiMetadata = {
+          metadata: {
+            [ENCRYPTIONDATAPROP]: gcsHeaders[GCS_METADATA_ENCRYPTIONDATAPROP],
+            [MATDESC_KEY]: gcsHeaders[GCS_METADATA_MATDESC_KEY],
+            [SFC_DIGEST]: gcsHeaders[GCS_METADATA_SFC_DIGEST],
+          },
+        };
+
+        if (Buffer.isBuffer(fileStream)) {
+          await gcsFile.save(fileStream, { resumable: false, metadata: jsonApiMetadata });
+        } else {
+          const writeStream = gcsFile.createWriteStream({
             resumable: false,
-            metadata: {
-              metadata: {
-                [ENCRYPTIONDATAPROP]: gcsHeaders[GCS_METADATA_ENCRYPTIONDATAPROP],
-                [MATDESC_KEY]: gcsHeaders[GCS_METADATA_MATDESC_KEY],
-                [SFC_DIGEST]: gcsHeaders[GCS_METADATA_SFC_DIGEST],
-              },
-            },
+            metadata: jsonApiMetadata,
           });
+
+          await new Promise((resolve, reject) => {
+            pipeline(fileStream, writeStream, (err) => (err ? reject(err) : resolve()));
+          });
+        }
       } else {
+        // Keep Content-Length behavior for non-buffer uploads (e.g. presigned URL).
+        if (Buffer.isBuffer(fileStream)) {
+          gcsHeaders['Content-Length'] = fileStream.length;
+        } else if (meta && typeof meta['uploadFileSize'] === 'number') {
+          gcsHeaders['Content-Length'] = meta['uploadFileSize'];
+        }
         // Set maxBodyLength to allow large file uploading
         await axios.put(uploadUrl, fileStream, { maxBodyLength: Infinity, headers: gcsHeaders });
       }

--- a/lib/file_transfer_agent/s3_util.js
+++ b/lib/file_transfer_agent/s3_util.js
@@ -155,7 +155,7 @@ function S3Util(connectionConfig, s3, filestream) {
    * @param {Object} encryptionMetadata
    */
   this.uploadFile = async function (dataFile, meta, encryptionMetadata) {
-    const fileStream = fs.readFileSync(dataFile);
+    const fileStream = fs.createReadStream(dataFile);
     await this.uploadFileStream(fileStream, meta, encryptionMetadata);
   };
 

--- a/lib/file_util.js
+++ b/lib/file_util.js
@@ -116,23 +116,17 @@ function FileUtil() {
     const fileInfo = fs.statSync(fileName);
     const bufferSize = fileInfo.size;
 
-    let buffer = [];
-    await new Promise(function (resolve) {
+    const hash = crypto.createHash('sha256');
+    await new Promise((resolve, reject) => {
       // Create reader stream and set maximum chunk size
       const infile = fs.createReadStream(fileName, { highWaterMark: chunkSize });
-      infile.on('data', function (chunk) {
-        buffer.push(chunk);
-      });
-      infile.on('close', function () {
-        buffer = Buffer.concat(buffer);
-        resolve();
-      });
+      infile.on('data', (chunk) => hash.update(chunk));
+      infile.on('end', resolve);
+      infile.on('error', reject);
     });
 
-    const hash = crypto.createHash('sha256').update(buffer).digest('base64');
-
     return {
-      digest: hash,
+      digest: hash.digest('base64'),
       size: bufferSize,
     };
   };

--- a/test/unit/file_transfer_agent/azure_test.js
+++ b/test/unit/file_transfer_agent/azure_test.js
@@ -2,6 +2,7 @@ const assert = require('assert');
 const AZURE = require('@azure/storage-blob');
 const fs = require('fs');
 const sinon = require('sinon');
+const { Readable } = require('stream');
 const SnowflakeAzureUtil = require('./../../../lib/file_transfer_agent/azure_util');
 const resultStatus = require('../../../lib/file_util').resultStatus;
 
@@ -56,10 +57,11 @@ describe('Azure client', function () {
         }),
         getBlockBlobClient: () => ({
           upload: uploadStub,
+          uploadStream: uploadStub,
         }),
       }),
     });
-    sinonSandbox.stub(fs, 'readFileSync').returnsArg(0);
+    sinonSandbox.stub(fs, 'createReadStream').callsFake(() => Readable.from([Buffer.from('mock')]));
     Azure = new SnowflakeAzureUtil(noProxyConnectionConfig);
   });
 

--- a/test/unit/file_transfer_agent/file_util_test.js
+++ b/test/unit/file_transfer_agent/file_util_test.js
@@ -252,6 +252,42 @@ if (os.platform() !== 'win32') {
   });
 }
 
+describe('FileUtil.getDigestAndSizeForFile()', function () {
+  const fileUtil = new FileUtil();
+  let testFilePath;
+
+  afterEach(async function () {
+    if (testFilePath) {
+      await fsPromises.rm(testFilePath, { force: true });
+      testFilePath = null;
+    }
+  });
+
+  it('should return sha256 digest (base64) and file size', async function () {
+    const content = Buffer.from('snowflake-nodejs-digest-test');
+    testFilePath = path.join(os.tmpdir(), `digest_test_${crypto.randomUUID()}`);
+    await fsPromises.writeFile(testFilePath, content);
+
+    const expectedDigest = crypto.createHash('sha256').update(content).digest('base64');
+    const result = await fileUtil.getDigestAndSizeForFile(testFilePath);
+
+    assert.strictEqual(result.digest, expectedDigest);
+    assert.strictEqual(result.size, content.length);
+  });
+
+  it('should handle empty files', async function () {
+    const content = Buffer.alloc(0);
+    testFilePath = path.join(os.tmpdir(), `digest_test_${crypto.randomUUID()}`);
+    await fsPromises.writeFile(testFilePath, content);
+
+    const expectedDigest = crypto.createHash('sha256').update(content).digest('base64');
+    const result = await fileUtil.getDigestAndSizeForFile(testFilePath);
+
+    assert.strictEqual(result.digest, expectedDigest);
+    assert.strictEqual(result.size, 0);
+  });
+});
+
 describe('FileUtil.normalizeGzipHeader()', function () {
   let fileUtil;
   let tempDir;

--- a/test/unit/file_transfer_agent/gcs_test.js
+++ b/test/unit/file_transfer_agent/gcs_test.js
@@ -1,6 +1,7 @@
 const assert = require('assert');
 const sinon = require('sinon');
 const fs = require('fs');
+const { Readable, Writable } = require('stream');
 const SnowflakeGCSUtil = require('./../../../lib/file_transfer_agent/gcs_util');
 const resultStatus = require('../../../lib/file_util').resultStatus;
 
@@ -39,7 +40,8 @@ describe('GCS client', function () {
 
   beforeEach(() => {
     sinonSandbox = sinon.createSandbox();
-    sinonSandbox.stub(fs, 'readFileSync').returnsArg(0);
+    sinonSandbox.stub(fs, 'createReadStream').callsFake(() => Readable.from([Buffer.from('mock')]));
+    sinonSandbox.stub(fs, 'statSync').returns({ size: 4 });
     meta = {
       stageInfo: {
         location: mockLocation + '/' + mockTable + '/' + mockPath + '/',
@@ -354,11 +356,14 @@ describe('GCS client', function () {
     const gcsClient = {
       bucket: () => ({
         file: () => ({
-          save: () => {
-            const err = new Error();
-            err.code = 401;
-            throw err;
-          },
+          createWriteStream: () =>
+            new Writable({
+              write(_chunk, _encoding, callback) {
+                const err = new Error();
+                err.code = 401;
+                callback(err);
+              },
+            }),
         }),
       }),
     };

--- a/test/unit/file_transfer_agent/s3_test.js
+++ b/test/unit/file_transfer_agent/s3_test.js
@@ -71,8 +71,9 @@ describe('S3 client', function () {
       },
     });
     mock('filesystem', {
-      readFileSync: async function (data) {
-        return data;
+      createReadStream: function () {
+        const { Readable } = require('stream');
+        return Readable.from([Buffer.from('mock')]);
       },
     });
     s3 = require('s3');
@@ -289,8 +290,9 @@ describe('S3 client', function () {
       },
     });
     mock('filesystem', {
-      readFileSync: async function (data) {
-        return data;
+      createReadStream: function () {
+        const { Readable } = require('stream');
+        return Readable.from([Buffer.from('mock')]);
       },
     });
     s3 = require('s3');
@@ -321,8 +323,9 @@ describe('S3 client', function () {
       },
     });
     mock('filesystem', {
-      readFileSync: async function (data) {
-        return data;
+      createReadStream: function () {
+        const { Readable } = require('stream');
+        return Readable.from([Buffer.from('mock')]);
       },
     });
     s3 = require('s3');
@@ -353,8 +356,9 @@ describe('S3 client', function () {
       },
     });
     mock('filesystem', {
-      readFileSync: async function (data) {
-        return data;
+      createReadStream: function () {
+        const { Readable } = require('stream');
+        return Readable.from([Buffer.from('mock')]);
       },
     });
     s3 = require('s3');


### PR DESCRIPTION
### Description

This PR reduces Node driver memory usage during `PUT` file uploads (especially large compressed files) by eliminating full-file buffering in two places:

- **SHA-256 digest calculation**: `FileUtil.getDigestAndSizeForFile()` now hashes incrementally while streaming the file (no `Buffer.concat` of the entire file).
- **Remote storage uploads (S3/GCS/Azure)**: `uploadFile()` now streams the (possibly encrypted/compressed) file from disk via `createReadStream` instead of reading it fully into memory.

This addresses the behavior described in GitHub issue **#922**.

### Checklist

- [x] Create tests which fail without the change (if possible)
- [ ] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [ ] Extend the types in index.d.ts file (if necessary)
- [ ] Extend the README / documentation and ensure is properly displayed (if necessary)
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message
