### PR TITLE
SNOW-1997074 Ensure new retry middleware handles redirects properly

### DIFF
--- a/test/integration/wiremock/testRequestRetry.ts
+++ b/test/integration/wiremock/testRequestRetry.ts
@@ -199,4 +199,16 @@ describe('Request Retries', () => {
       );
     });
   }
+
+  it('retries original request when redirect target fails', async () => {
+    await addWireMockMappingsFromFile(
+      wiremock,
+      'wiremock/mappings/request_retries/query_request_redirect_fail.json',
+    );
+    await testUtil.connectAsync(connection);
+    await testUtil.executeCmdAsyncWithAdditionalParameters(connection, 'SELECT 1', {
+      asyncExec: true,
+    });
+    assert.strictEqual(getAxiosRequestsCount('/queries/v1/query-request'), 4);
+  });
 });

--- a/wiremock/mappings/request_retries/query_request_redirect_fail.json
+++ b/wiremock/mappings/request_retries/query_request_redirect_fail.json
@@ -1,0 +1,51 @@
+{
+  "mappings": [
+    {
+      "priority": 1,
+      "request": {
+        "urlPathPattern": "/queries/v1/query-request*",
+        "method": "POST",
+        "queryParameters": {
+          "retryCount": {
+            "equalTo": "3"
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "jsonBody": {
+          "code": "333333",
+          "data": {
+            "queryId": "01baf79b-0108-1a60-0000-01110354a6ce"
+          },
+          "message": null,
+          "success": true
+        }
+      }
+    },
+    {
+      "request": {
+        "urlPathPattern": "/queries/v1/query-request.*",
+        "method": "POST"
+      },
+      "response": {
+        "status": 307,
+        "headers": {
+          "Location": "/temp-redirect-1"
+        }
+      }
+    },
+    {
+      "request": {
+        "urlPathPattern": "/temp-redirect-1",
+        "method": "POST"
+      },
+      "response": {
+        "fixedDelayMilliseconds": 5000
+      }
+    }
+  ]
+}


### PR DESCRIPTION
### Description

Added a test to ensure that retry middleware follows redirects and retries the original request if the redirect target fails.

IMO, 1 test checking a single request with a 307 redirect is enough, as we should expect the underlying HTTP library to handle any kind of HTTP redirects in the same way.

### Checklist

- [x] Create tests which fail without the change (if possible)
- [x] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [x] Extend the types in index.d.ts file (if necessary)
- [x] Extend the README / documentation and ensure is properly displayed (if necessary)
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message
