### PR TITLE
fix: add bn.js override to deduplicate v4/v5 versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
     "asn1.js": "^5.4.1"
   },
   "overrides": {
-    "semver": "^7.5.2"
+    "semver": "^7.5.2",
+    "bn.js": "^5.2.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Problem

`asn1.js@5.4.1` declares `bn.js@^4.0.0` while the project directly depends on `bn.js@^5.2.1`, causing two versions (4.12.3 and 5.2.3) to be installed simultaneously. This leads to `instanceof` mismatches when `bn.js` v5 instances created in `cert_util.js` are passed into `asn1.js` internals that use `bn.js` v4.

## Solution

Add `"bn.js": "^5.2.1"` to the npm `overrides` field to force all transitive dependencies to use a single version.

## Safety verification

- Compared all prototype methods between bn.js v4.12.3 and v5.2.3 — **fully backward compatible**
- All APIs used by `asn1.js` (`toArray`, `copy`, `negative`, `length`, `toString`) behave identically in both versions
- No public API was removed in v5; only internal methods were renamed (`strip` → `_strip`) and new methods added
