### PR TITLE
SNOW-3170447 bugfixes for noProxy

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -122,7 +122,7 @@ declare module 'snowflake-sdk' {
      * Specifies a list of hosts that the driver should connect to directly, bypassing the proxy server.
      *
      * - Use a pipe symbol (`|`) to separate multiple hosts.
-     * - Use `*` or `?` as glob patterns (e.g., `*sub.amazonaws.com`).
+     * - Use `*` as a wildcard (e.g., `*sub.amazonaws.com`).
      * - A leading dot (e.g., `.amazonaws.com`) matches any subdomain.
      *
      * @example

--- a/lib/file_util.js
+++ b/lib/file_util.js
@@ -4,7 +4,7 @@ const fsPromises = require('node:fs/promises');
 const path = require('path');
 const zlib = require('zlib');
 const os = require('os');
-const { isWindows, globToRegex } = require('./util');
+const { isWindows, escapeRegex } = require('./util');
 const Logger = require('./logger').default;
 
 const resultStatus = {
@@ -135,8 +135,27 @@ function FileUtil() {
 }
 exports.FileUtil = FileUtil;
 
+// NOTE:
+// This won't be needed when we'll support Node 22+ which has fs.globSync method
+exports.globToRegex = function (pattern) {
+  let regexPattern = '';
+
+  for (let i = 0; i < pattern.length; i++) {
+    const char = pattern[i];
+    if (char === '*') {
+      regexPattern += '.*';
+    } else if (char === '?') {
+      regexPattern += '.';
+    } else {
+      regexPattern += escapeRegex(char);
+    }
+  }
+
+  return new RegExp(`^${regexPattern}$`);
+};
+
 exports.getMatchingFilePaths = function (dir, fileName) {
-  const fileNameRegex = globToRegex(fileName);
+  const fileNameRegex = exports.globToRegex(fileName);
   try {
     const files = fs.readdirSync(dir);
     const matchedFiles = files.filter((file) => fileNameRegex.test(file));

--- a/lib/proxy_util.js
+++ b/lib/proxy_util.js
@@ -347,14 +347,20 @@ exports.isByPassProxy = function (proxy, destination) {
   if (proxy && proxy.noProxy) {
     const bypassList = proxy.noProxy.split('|');
     return bypassList.find((noProxy) => {
-      let host = noProxy.trim();
+      const host = noProxy.trim();
       if (destination instanceof RegExp) {
         return destination.test(host);
       }
-      if (host.startsWith('.')) {
-        host = '*' + host;
+      let regexPattern = '';
+      for (let i = 0; i < host.length; i++) {
+        const char = host[i];
+        if (char === '*' || (char === '.' && i === 0)) {
+          regexPattern += '.*';
+        } else {
+          regexPattern += Util.escapeRegex(char);
+        }
       }
-      const noProxyRegex = Util.globToRegex(host);
+      const noProxyRegex = new RegExp(`^${regexPattern}$`);
       return noProxyRegex.test(destination);
     });
   }

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -659,22 +659,6 @@ export function sleep(sleepTimeMs: number) {
   return new Promise((resolve) => setTimeout(resolve, sleepTimeMs));
 }
 
-// NOTE:
-// This won't be needed when we'll support Node 22+ which has fs.globSync method
-export function globToRegex(pattern: string) {
-  let regexPattern = '';
-
-  for (let i = 0; i < pattern.length; i++) {
-    const char = pattern[i];
-    if (char === '*') {
-      regexPattern += '.*';
-    } else if (char === '?') {
-      regexPattern += '.';
-    } else {
-      // Escape special regex characters
-      regexPattern += char.replace(/[.+^${}()|[\]\\]/g, '\\$&');
-    }
-  }
-
-  return new RegExp(`^${regexPattern}$`);
+export function escapeRegex(str: string) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }

--- a/test/unit/file_transfer_agent/file_util_test.js
+++ b/test/unit/file_transfer_agent/file_util_test.js
@@ -4,6 +4,7 @@ const os = require('os');
 const fsPromises = require('fs').promises;
 const crypto = require('crypto');
 const {
+  globToRegex,
   getMatchingFilePaths,
   isFileNotWritableByGroupOrOthers,
   validateOnlyUserReadWritePermissionAndOwner,
@@ -28,6 +29,39 @@ describe('FileUtil.getDigestAndSizeForFile()', function () {
       await fsPromises.rm(tmpFilePath, { force: true });
     }
   });
+});
+
+describe('globToRegex', function () {
+  const files = ['matched.gzip', 'matched2.gzip', 'matched.txt', 'notmatched.txt'];
+  const testCases = [
+    {
+      pattern: 'ma*',
+      expectedMatches: ['matched.gzip', 'matched2.gzip', 'matched.txt'],
+    },
+    {
+      pattern: 'matche*.gzip',
+      expectedMatches: ['matched.gzip', 'matched2.gzip'],
+    },
+    {
+      pattern: 'matched.gzip*',
+      expectedMatches: ['matched.gzip'],
+    },
+    {
+      pattern: 'matche?.gzip',
+      expectedMatches: ['matched.gzip'],
+    },
+    {
+      pattern: 'm?t?he*',
+      expectedMatches: ['matched.gzip', 'matched2.gzip', 'matched.txt'],
+    },
+  ];
+  for (const { pattern, expectedMatches } of testCases) {
+    it(`${pattern} should match ${expectedMatches.join(', ')}`, () => {
+      const regex = globToRegex(pattern);
+      const matchedFiles = files.filter((file) => regex.test(file));
+      assert.deepStrictEqual(matchedFiles, expectedMatches);
+    });
+  }
 });
 
 describe('matching files by wildcard', function () {

--- a/test/unit/util_test.js
+++ b/test/unit/util_test.js
@@ -1090,36 +1090,3 @@ describe('Util', function () {
     });
   });
 });
-
-describe('globToRegex', function () {
-  const files = ['matched.gzip', 'matched2.gzip', 'matched.txt', 'notmatched.txt'];
-  const testCases = [
-    {
-      pattern: 'ma*',
-      expectedMatches: ['matched.gzip', 'matched2.gzip', 'matched.txt'],
-    },
-    {
-      pattern: 'matche*.gzip',
-      expectedMatches: ['matched.gzip', 'matched2.gzip'],
-    },
-    {
-      pattern: 'matched.gzip*',
-      expectedMatches: ['matched.gzip'],
-    },
-    {
-      pattern: 'matche?.gzip',
-      expectedMatches: ['matched.gzip'],
-    },
-    {
-      pattern: 'm?t?he*',
-      expectedMatches: ['matched.gzip', 'matched2.gzip', 'matched.txt'],
-    },
-  ];
-  for (const { pattern, expectedMatches } of testCases) {
-    it(`${pattern} should match ${expectedMatches.join(', ')}`, () => {
-      const regex = Util.globToRegex(pattern);
-      const matchedFiles = files.filter((file) => regex.test(file));
-      assert.deepStrictEqual(matchedFiles, expectedMatches);
-    });
-  }
-});


### PR DESCRIPTION
### Description

Follow up after https://github.com/snowflakedb/snowflake-connector-nodejs/pull/1309, as additional bugs were found

- Fix 2 bugs in `noProxy` / `NO_PROXY` pattern matching in `isByPassProxy`:
  - `.` in host patterns (e.g. `snowflakecomputing.com`) was treated as a regex wildcard instead of a literal dot, causing `snowflakecomputingccom` to incorrectly match
  - Partial `noProxy` entries (e.g. `snowflake`) incorrectly matched longer destinations (e.g. `snowflakecomputing.com`) because the regex was not anchored at the end
  - Added unit tests covering 2 bugs
- Extract `escapeRegex` helper into `lib/util.ts`, used by both `proxy_util.js` and `file_util.js`
- Improve `noProxy` JSDoc in `index.d.ts` with structured description and example


### Checklist

- [x] Create tests which fail without the change (if possible)
- [x] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [x] Extend the types in index.d.ts file (if necessary)
- [x] Extend the README / documentation and ensure is properly displayed (if necessary)
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message