### PR TITLE
Add OAuth authorization code to login retry handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Exported `normalizeConnectionOptions()` utility to convert snake_case connection keys to camelCase, with key aliases and acronym overrides (snowflakedb/snowflake-connector-nodejs#1304)
 - Fixed `getDefaultCacheDir()` crashing in environments where no user home directory is configured by falling back to `os.tmpdir()` (snowflakedb/snowflake-connector-nodejs#1312)
 - Fixed a bug where host specified in `NO_PROXY` in the `.domain.com` wildcard format were not correctly matching the destination host (snowflakedb/snowflake-connector-nodejs#1309)
+- Fixed OAuth Authorization Code login retries not refreshing the access token, causing unnecessary browser re-authentication when the token expired during active use
 
 ## 2.3.4
 

--- a/lib/services/sf.js
+++ b/lib/services/sf.js
@@ -1246,6 +1246,11 @@ StateConnecting.prototype.continue = function () {
           } else if (auth instanceof AuthKeypair) {
             Logger.getInstance().debug('AuthKeyPair authentication requires token refresh.');
             await auth.reauthenticate(context.options.json);
+          } else if (auth instanceof AuthOauthAuthorizationCode) {
+            Logger.getInstance().debug(
+              'OAuth authorization code authentication requires token refresh.',
+            );
+            await auth.reauthenticate(context.options.json);
           }
           setTimeout(sendRequest, sleep * 1000);
           return;


### PR DESCRIPTION
The login retry handler in sf.js called reauthenticate() for AuthOkta and AuthKeypair but not AuthOauthAuthorizationCode. When an OAuth access token expired during a login request, the retry resent the same expired token instead of refreshing it, causing the request to fail and fall through to a browser re-auth prompt.
