### PR TITLE
Fix TypeError when query response omits rowset in Result.createChunks

### DIFF
--- a/lib/connection/result/result.js
+++ b/lib/connection/result/result.js
@@ -274,6 +274,7 @@ function createChunks(
   // if we don't have any chunks, or if some records were returned inline,
   // fabricate a config object for the first chunk
   chunkCfgs = chunkCfgs || [];
+  rowset = rowset || [];
   if (!chunkCfgs || rowset.length > 0) {
     chunkCfgs.unshift({
       rowCount: rowset.length,

--- a/test/unit/connection/result/result_test.js
+++ b/test/unit/connection/result/result_test.js
@@ -1,5 +1,6 @@
 const Util = require('./../../../../lib/util');
 const assert = require('assert');
+const Result = require('./../../../../lib/connection/result/result');
 
 const ResultTestCommon = require('./result_test_common');
 
@@ -148,5 +149,17 @@ describe('Result', function () {
       0,
       5,
     );
+  });
+
+  it('does not throw when rowset is missing', function () {
+    const responseWithoutRowset = JSON.parse(JSON.stringify(response));
+    delete responseWithoutRowset.data.rowset;
+    responseWithoutRowset.data.returned = 0;
+    responseWithoutRowset.data.total = 0;
+    responseWithoutRowset.data.chunks = [];
+
+    assert.doesNotThrow(function () {
+      new Result(ResultTestCommon.createResultOptions(responseWithoutRowset));
+    });
   });
 });


### PR DESCRIPTION
### Description

  Fixes a crash in result processing when query responses omit data.rowset.

  Result.createChunks() accessed rowset.length without guarding for undefined, which can throw:
  TypeError: undefined is not an object (evaluating 'rowset.length').

### Root Cause

  In lib/connection/result/result.js, createChunks() normalized chunkCfgs but not rowset, then dereferenced rowset.length.

### Changes

  - Added defensive normalization in createChunks():
      - rowset = rowset || [];
  - Added regression test in test/unit/connection/result/result_test.js:
      - does not throw when rowset is missing
      - removes response.data.rowset, sets chunks = [], and verifies new Result(...) does not throw.

### Impact

  - Prevents runtime crashes when rowset is absent in response payloads.
  - Backward-compatible for existing result parsing paths.

### Validation

  - npm run test:single -- test/unit/connection/result/result_test.js
      - 20 passing


### Checklist

- [ ] Create tests which fail without the change (if possible)
- [ ] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [ ] Extend the types in index.d.ts file (if necessary)
- [ ] Extend the README / documentation and ensure is properly displayed (if necessary)
- [ ] Provide JIRA issue id (if possible) or GitHub issue id in commit message
