### PR TITLE
NO-SNOW fix s3 test

### DIFF
--- a/test/unit/file_transfer_agent/s3_test.js
+++ b/test/unit/file_transfer_agent/s3_test.js
@@ -347,12 +347,12 @@ describe('S3 client', function () {
     meta['client'] = AWS.createClient(meta['stageInfo']);
 
     const clientConfig = await meta['client'].config.requestHandler.configProvider;
-    const cleintHttpAgent = await clientConfig.httpAgentProvider();
-    assert.equal(cleintHttpAgent.options.host, proxyOptions.host);
-    assert.equal(cleintHttpAgent.options.hostname, 'snowflake.com');
-    assert.equal(cleintHttpAgent.options.user, proxyOptions.user);
-    assert.equal(cleintHttpAgent.options.password, proxyOptions.password);
-    assert.equal(cleintHttpAgent.options.port, proxyOptions.port);
+    const clientHttpAgent = await clientConfig.httpAgentProvider();
+    assert.equal(clientHttpAgent.options.host, proxyOptions.host);
+    assert.equal(clientHttpAgent.options.hostname, 'snowflake.com');
+    assert.equal(clientHttpAgent.options.user, proxyOptions.user);
+    assert.equal(clientHttpAgent.options.password, proxyOptions.password);
+    assert.equal(clientHttpAgent.options.port, proxyOptions.port);
 
     assert.equal(clientConfig.httpsAgent.options.host, proxyOptions.host);
     assert.equal(clientConfig.httpsAgent.options.hostname, 'snowflake.com');


### PR DESCRIPTION
### Description

AWS S3 SDK changed internal api resulting in our unit test failing. We don't call `configProvider.httpClient` directly, so the change doesn't affect anything except the unit test

### Checklist

- [x] Create tests which fail without the change (if possible)
- [x] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [x] Extend the types in index.d.ts file (if necessary)
- [x] Extend the README / documentation and ensure is properly displayed (if necessary)
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message
