### PR TITLE
SNOW-3362718: mimic 'glob' dot:false behaviour which was the default pre v2.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 Changes:
 
 - Replaced deprecated Node.js `url.parse()` with the WHATWG `URL` constructor (snowflakedb/snowflake-connector-nodejs#1380)
-- Fixed file name pattern wildcard matching behaviour, should be now similar to the dropped 'glob' package's default 'dot:false' behaviour (snowflakedb/snowflake-connector-nodejs#1381)
+- Fixed file name pattern matching to not match dot-prefixed files/directories by default, aligning with standard glob behavior and default of `dot: false`. Was lingering around since v2.3.3. (snowflakedb/snowflake-connector-nodejs#1381)
 
 ## 2.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 Changes:
 
 - Replaced deprecated Node.js `url.parse()` with the WHATWG `URL` constructor (snowflakedb/snowflake-connector-nodejs#1380)
+- Fixed file name pattern wildcard matching behaviour, should be now similar to the dropped 'glob' package's default 'dot:false' behaviour (snowflakedb/snowflake-connector-nodejs#1381)
 
 ## 2.4.0
 

--- a/lib/file_util.js
+++ b/lib/file_util.js
@@ -143,9 +143,11 @@ exports.globToRegex = function (pattern) {
   for (let i = 0; i < pattern.length; i++) {
     const char = pattern[i];
     if (char === '*') {
-      regexPattern += '.*';
+      // Mimic glob's dot:false default: a wildcard at the start of the
+      // pattern must not match a leading dot in the filename.
+      regexPattern += (i === 0) ? '[^.].*' : '.*';
     } else if (char === '?') {
-      regexPattern += '.';
+      regexPattern += (i === 0) ? '[^.]' : '.';
     } else {
       regexPattern += escapeRegex(char);
     }

--- a/lib/file_util.js
+++ b/lib/file_util.js
@@ -1,23 +1,23 @@
-const crypto = require('crypto');
-const fs = require('fs');
-const fsPromises = require('node:fs/promises');
-const path = require('path');
-const zlib = require('zlib');
-const os = require('os');
-const { isWindows, escapeRegex } = require('./util');
-const Logger = require('./logger').default;
+const crypto = require("crypto");
+const fs = require("fs");
+const fsPromises = require("node:fs/promises");
+const path = require("path");
+const zlib = require("zlib");
+const os = require("os");
+const { isWindows, escapeRegex } = require("./util");
+const Logger = require("./logger").default;
 
 const resultStatus = {
-  ERROR: 'ERROR',
-  UPLOADED: 'UPLOADED',
-  DOWNLOADED: 'DOWNLOADED',
-  COLLISION: 'COLLISION',
-  SKIPPED: 'SKIPPED',
-  RENEW_TOKEN: 'RENEW_TOKEN',
-  RENEW_PRESIGNED_URL: 'RENEW_PRESIGNED_URL',
-  NOT_FOUND_FILE: 'NOT_FOUND_FILE',
-  NEED_RETRY: 'NEED_RETRY',
-  NEED_RETRY_WITH_LOWER_CONCURRENCY: 'NEED_RETRY_WITH_LOWER_CONCURRENCY',
+  ERROR: "ERROR",
+  UPLOADED: "UPLOADED",
+  DOWNLOADED: "DOWNLOADED",
+  COLLISION: "COLLISION",
+  SKIPPED: "SKIPPED",
+  RENEW_TOKEN: "RENEW_TOKEN",
+  RENEW_PRESIGNED_URL: "RENEW_PRESIGNED_URL",
+  NOT_FOUND_FILE: "NOT_FOUND_FILE",
+  NEED_RETRY: "NEED_RETRY",
+  NEED_RETRY_WITH_LOWER_CONCURRENCY: "NEED_RETRY_WITH_LOWER_CONCURRENCY",
 };
 
 exports.resultStatus = resultStatus;
@@ -26,7 +26,8 @@ const ownerReadAndWriteFilePermission = 0o600;
 const othersCanReadFilePermission = 0o044;
 const othersCanWriteFilePermission = 0o022;
 const executableFilePermission = 0o111;
-const SKIP_TOKEN_FILE_PERMISSIONS_VERIFICATION_ENV_VAR = 'SKIP_TOKEN_FILE_PERMISSIONS_VERIFICATION';
+const SKIP_TOKEN_FILE_PERMISSIONS_VERIFICATION_ENV_VAR =
+  "SKIP_TOKEN_FILE_PERMISSIONS_VERIFICATION";
 
 // File Header
 function FileHeader(digest, contentLength, encryptionMetadata) {
@@ -57,7 +58,7 @@ function FileUtil() {
   this.compressFileWithGZIP = async function (fileName, tmpDir) {
     // Set file name and path for compressed file
     const baseName = path.basename(fileName);
-    const gzipFileName = path.join(tmpDir, baseName + '_c.gz');
+    const gzipFileName = path.join(tmpDir, baseName + "_c.gz");
 
     await new Promise(function (resolve) {
       // Create gzip object
@@ -67,7 +68,7 @@ function FileUtil() {
       const writer = fs.createWriteStream(gzipFileName);
       // Write and compress file
       const result = reader.pipe(gzip).pipe(writer);
-      result.on('finish', function () {
+      result.on("finish", function () {
         resolve();
       });
     });
@@ -92,7 +93,7 @@ function FileUtil() {
    * @returns {null}
    */
   this.normalizeGzipHeader = async function (gzipFileName) {
-    const fd = fs.openSync(gzipFileName, 'rs+');
+    const fd = fs.openSync(gzipFileName, "rs+");
 
     // Reset the timestamp in gzip header
     // Write at position 4
@@ -117,18 +118,20 @@ function FileUtil() {
     const bufferSize = fileInfo.size;
 
     // Stream the file to avoid buffering it entirely in memory.
-    const hash = crypto.createHash('sha256');
+    const hash = crypto.createHash("sha256");
     await new Promise((resolve, reject) => {
-      const infile = fs.createReadStream(fileName, { highWaterMark: chunkSize });
-      infile.on('data', (chunk) => {
+      const infile = fs.createReadStream(fileName, {
+        highWaterMark: chunkSize,
+      });
+      infile.on("data", (chunk) => {
         hash.update(chunk);
       });
-      infile.on('end', resolve);
-      infile.on('error', reject);
+      infile.on("end", resolve);
+      infile.on("error", reject);
     });
 
     return {
-      digest: hash.digest('base64'),
+      digest: hash.digest("base64"),
       size: bufferSize,
     };
   };
@@ -138,16 +141,16 @@ exports.FileUtil = FileUtil;
 // NOTE:
 // This won't be needed when we'll support Node 22+ which has fs.globSync method
 exports.globToRegex = function (pattern) {
-  let regexPattern = '';
+  let regexPattern = "";
 
   for (let i = 0; i < pattern.length; i++) {
     const char = pattern[i];
-    if (char === '*') {
+    if (char === "*") {
       // Mimic glob's dot:false default: a wildcard at the start of the
       // pattern must not match a leading dot in the filename.
-      regexPattern += (i === 0) ? '[^.].*' : '.*';
-    } else if (char === '?') {
-      regexPattern += (i === 0) ? '[^.]' : '.';
+      regexPattern += i === 0 ? "[^.].*" : ".*";
+    } else if (char === "?") {
+      regexPattern += i === 0 ? "[^.]" : ".";
     } else {
       regexPattern += escapeRegex(char);
     }
@@ -179,7 +182,7 @@ exports.validateNoExtraPermissionsForOthers = function (
   fsPromises = null,
   useSync = false,
 ) {
-  const fsp = fsPromises ? fsPromises : require('fs/promises');
+  const fsp = fsPromises ? fsPromises : require("fs/promises");
   if (isWindows() || shouldSkipTokenFilePermissionsVerification()) {
     return;
   }
@@ -206,7 +209,10 @@ exports.validateNoExtraPermissionsForOthers = function (
     }
 
     //The owner should have read and write permission.
-    if ((permission & ownerReadAndWriteFilePermission) === ownerReadAndWriteFilePermission) {
+    if (
+      (permission & ownerReadAndWriteFilePermission) ===
+      ownerReadAndWriteFilePermission
+    ) {
       Logger().debug(
         `Validated that the owner has read and write permission for file: ${filePath}, Permission: ${permission.toString(8)}`,
       );
@@ -218,7 +224,7 @@ exports.validateNoExtraPermissionsForOthers = function (
 
     const userInfo = os.userInfo();
     if (stats.uid === userInfo.uid) {
-      Logger().debug('Validated file owner');
+      Logger().debug("Validated file owner");
     } else {
       throw new Error(
         `Invalid file owner for file ${filePath}). Make sure the user running the software is the owner of the file, or remove the file and re-run the driver.`,
@@ -228,7 +234,7 @@ exports.validateNoExtraPermissionsForOthers = function (
 
   const handleError = (err) => {
     // When file doesn't exist - return
-    if (err.code === 'ENOENT') {
+    if (err.code === "ENOENT") {
       return;
     }
     throw err;
@@ -258,10 +264,13 @@ exports.validateNoExtraPermissionsForOthersSync = function (filePath) {
  * @returns {Promise<FileHandle>}
  */
 exports.getSecureHandle = async function (filePath, flags, fsPromises) {
-  const fsp = fsPromises ? fsPromises : require('fs/promises');
+  const fsp = fsPromises ? fsPromises : require("fs/promises");
   try {
     const fileHandle = await fsp.open(filePath, flags, 0o600);
-    if (os.platform() === 'win32' || shouldSkipTokenFilePermissionsVerification()) {
+    if (
+      os.platform() === "win32" ||
+      shouldSkipTokenFilePermissionsVerification()
+    ) {
       return fileHandle;
     }
     const stats = await fileHandle.stat();
@@ -281,7 +290,7 @@ exports.getSecureHandle = async function (filePath, flags, fsPromises) {
 
     const userInfo = os.userInfo();
     if (stats.uid === userInfo.uid) {
-      Logger().debug('Validated file owner');
+      Logger().debug("Validated file owner");
     } else {
       throw new Error(
         `Invalid file owner for file ${filePath}). Make sure the system user is the owner of the file otherwise please remove the file and re-run the driver.`,
@@ -290,7 +299,7 @@ exports.getSecureHandle = async function (filePath, flags, fsPromises) {
     return fileHandle;
   } catch (err) {
     //When file doesn't exist - return
-    if (err.code === 'ENOENT') {
+    if (err.code === "ENOENT") {
       return null;
     } else {
       throw err;
@@ -311,8 +320,12 @@ exports.closeHandle = async function (fileHandle) {
  * @param fsPromises
  * @returns {Promise<boolean>} resolves always to true for Windows
  */
-exports.isFileModeCorrect = async function (filePath, expectedMode, fsPromises) {
-  if (os.platform() === 'win32') {
+exports.isFileModeCorrect = async function (
+  filePath,
+  expectedMode,
+  fsPromises,
+) {
+  if (os.platform() === "win32") {
     return true;
   }
   return await fsPromises.stat(filePath).then((stats) => {
@@ -329,8 +342,11 @@ exports.isFileModeCorrect = async function (filePath, expectedMode, fsPromises) 
  * @param fsPromises
  * @returns {Promise<boolean>} resolves always to true for Windows
  */
-exports.isFileNotWritableByGroupOrOthers = async function (configFilePath, fsPromises) {
-  if (os.platform() === 'win32') {
+exports.isFileNotWritableByGroupOrOthers = async function (
+  configFilePath,
+  fsPromises,
+) {
+  if (os.platform() === "win32") {
     return true;
   }
   const stats = await fsPromises.stat(configFilePath);
@@ -346,9 +362,9 @@ exports.isFileNotWritableByGroupOrOthers = async function (configFilePath, fsPro
  */
 exports.generateChecksum = function (text, algorithm, encoding) {
   return crypto
-    .createHash(algorithm || 'sha256')
-    .update(text, 'utf8')
-    .digest(encoding || 'hex')
+    .createHash(algorithm || "sha256")
+    .update(text, "utf8")
+    .digest(encoding || "hex")
     .substring(0, 32);
 };
 
@@ -364,4 +380,5 @@ exports.IsFileExisted = async function (filePath) {
 function shouldSkipTokenFilePermissionsVerification() {
   return !!process.env[SKIP_TOKEN_FILE_PERMISSIONS_VERIFICATION_ENV_VAR];
 }
-exports.shouldSkipTokenFilePermissionsVerification = shouldSkipTokenFilePermissionsVerification;
+exports.shouldSkipTokenFilePermissionsVerification =
+  shouldSkipTokenFilePermissionsVerification;

--- a/lib/file_util.js
+++ b/lib/file_util.js
@@ -145,9 +145,9 @@ exports.globToRegex = function (pattern) {
     if (char === '*') {
       // Mimic glob's dot:false default: a wildcard at the start of the
       // pattern must not match a leading dot in the filename.
-      regexPattern += (i === 0) ? '[^.].*' : '.*';
+      regexPattern += i === 0 ? '[^.].*' : '.*';
     } else if (char === '?') {
-      regexPattern += (i === 0) ? '[^.]' : '.';
+      regexPattern += i === 0 ? '[^.]' : '.';
     } else {
       regexPattern += escapeRegex(char);
     }

--- a/lib/file_util.js
+++ b/lib/file_util.js
@@ -1,23 +1,23 @@
-const crypto = require("crypto");
-const fs = require("fs");
-const fsPromises = require("node:fs/promises");
-const path = require("path");
-const zlib = require("zlib");
-const os = require("os");
-const { isWindows, escapeRegex } = require("./util");
-const Logger = require("./logger").default;
+const crypto = require('crypto');
+const fs = require('fs');
+const fsPromises = require('node:fs/promises');
+const path = require('path');
+const zlib = require('zlib');
+const os = require('os');
+const { isWindows, escapeRegex } = require('./util');
+const Logger = require('./logger').default;
 
 const resultStatus = {
-  ERROR: "ERROR",
-  UPLOADED: "UPLOADED",
-  DOWNLOADED: "DOWNLOADED",
-  COLLISION: "COLLISION",
-  SKIPPED: "SKIPPED",
-  RENEW_TOKEN: "RENEW_TOKEN",
-  RENEW_PRESIGNED_URL: "RENEW_PRESIGNED_URL",
-  NOT_FOUND_FILE: "NOT_FOUND_FILE",
-  NEED_RETRY: "NEED_RETRY",
-  NEED_RETRY_WITH_LOWER_CONCURRENCY: "NEED_RETRY_WITH_LOWER_CONCURRENCY",
+  ERROR: 'ERROR',
+  UPLOADED: 'UPLOADED',
+  DOWNLOADED: 'DOWNLOADED',
+  COLLISION: 'COLLISION',
+  SKIPPED: 'SKIPPED',
+  RENEW_TOKEN: 'RENEW_TOKEN',
+  RENEW_PRESIGNED_URL: 'RENEW_PRESIGNED_URL',
+  NOT_FOUND_FILE: 'NOT_FOUND_FILE',
+  NEED_RETRY: 'NEED_RETRY',
+  NEED_RETRY_WITH_LOWER_CONCURRENCY: 'NEED_RETRY_WITH_LOWER_CONCURRENCY',
 };
 
 exports.resultStatus = resultStatus;
@@ -26,8 +26,7 @@ const ownerReadAndWriteFilePermission = 0o600;
 const othersCanReadFilePermission = 0o044;
 const othersCanWriteFilePermission = 0o022;
 const executableFilePermission = 0o111;
-const SKIP_TOKEN_FILE_PERMISSIONS_VERIFICATION_ENV_VAR =
-  "SKIP_TOKEN_FILE_PERMISSIONS_VERIFICATION";
+const SKIP_TOKEN_FILE_PERMISSIONS_VERIFICATION_ENV_VAR = 'SKIP_TOKEN_FILE_PERMISSIONS_VERIFICATION';
 
 // File Header
 function FileHeader(digest, contentLength, encryptionMetadata) {
@@ -58,7 +57,7 @@ function FileUtil() {
   this.compressFileWithGZIP = async function (fileName, tmpDir) {
     // Set file name and path for compressed file
     const baseName = path.basename(fileName);
-    const gzipFileName = path.join(tmpDir, baseName + "_c.gz");
+    const gzipFileName = path.join(tmpDir, baseName + '_c.gz');
 
     await new Promise(function (resolve) {
       // Create gzip object
@@ -68,7 +67,7 @@ function FileUtil() {
       const writer = fs.createWriteStream(gzipFileName);
       // Write and compress file
       const result = reader.pipe(gzip).pipe(writer);
-      result.on("finish", function () {
+      result.on('finish', function () {
         resolve();
       });
     });
@@ -93,7 +92,7 @@ function FileUtil() {
    * @returns {null}
    */
   this.normalizeGzipHeader = async function (gzipFileName) {
-    const fd = fs.openSync(gzipFileName, "rs+");
+    const fd = fs.openSync(gzipFileName, 'rs+');
 
     // Reset the timestamp in gzip header
     // Write at position 4
@@ -118,20 +117,18 @@ function FileUtil() {
     const bufferSize = fileInfo.size;
 
     // Stream the file to avoid buffering it entirely in memory.
-    const hash = crypto.createHash("sha256");
+    const hash = crypto.createHash('sha256');
     await new Promise((resolve, reject) => {
-      const infile = fs.createReadStream(fileName, {
-        highWaterMark: chunkSize,
-      });
-      infile.on("data", (chunk) => {
+      const infile = fs.createReadStream(fileName, { highWaterMark: chunkSize });
+      infile.on('data', (chunk) => {
         hash.update(chunk);
       });
-      infile.on("end", resolve);
-      infile.on("error", reject);
+      infile.on('end', resolve);
+      infile.on('error', reject);
     });
 
     return {
-      digest: hash.digest("base64"),
+      digest: hash.digest('base64'),
       size: bufferSize,
     };
   };
@@ -141,16 +138,16 @@ exports.FileUtil = FileUtil;
 // NOTE:
 // This won't be needed when we'll support Node 22+ which has fs.globSync method
 exports.globToRegex = function (pattern) {
-  let regexPattern = "";
+  let regexPattern = '';
 
   for (let i = 0; i < pattern.length; i++) {
     const char = pattern[i];
-    if (char === "*") {
+    if (char === '*') {
       // Mimic glob's dot:false default: a wildcard at the start of the
       // pattern must not match a leading dot in the filename.
-      regexPattern += i === 0 ? "[^.].*" : ".*";
-    } else if (char === "?") {
-      regexPattern += i === 0 ? "[^.]" : ".";
+      regexPattern += (i === 0) ? '[^.].*' : '.*';
+    } else if (char === '?') {
+      regexPattern += (i === 0) ? '[^.]' : '.';
     } else {
       regexPattern += escapeRegex(char);
     }
@@ -182,7 +179,7 @@ exports.validateNoExtraPermissionsForOthers = function (
   fsPromises = null,
   useSync = false,
 ) {
-  const fsp = fsPromises ? fsPromises : require("fs/promises");
+  const fsp = fsPromises ? fsPromises : require('fs/promises');
   if (isWindows() || shouldSkipTokenFilePermissionsVerification()) {
     return;
   }
@@ -209,10 +206,7 @@ exports.validateNoExtraPermissionsForOthers = function (
     }
 
     //The owner should have read and write permission.
-    if (
-      (permission & ownerReadAndWriteFilePermission) ===
-      ownerReadAndWriteFilePermission
-    ) {
+    if ((permission & ownerReadAndWriteFilePermission) === ownerReadAndWriteFilePermission) {
       Logger().debug(
         `Validated that the owner has read and write permission for file: ${filePath}, Permission: ${permission.toString(8)}`,
       );
@@ -224,7 +218,7 @@ exports.validateNoExtraPermissionsForOthers = function (
 
     const userInfo = os.userInfo();
     if (stats.uid === userInfo.uid) {
-      Logger().debug("Validated file owner");
+      Logger().debug('Validated file owner');
     } else {
       throw new Error(
         `Invalid file owner for file ${filePath}). Make sure the user running the software is the owner of the file, or remove the file and re-run the driver.`,
@@ -234,7 +228,7 @@ exports.validateNoExtraPermissionsForOthers = function (
 
   const handleError = (err) => {
     // When file doesn't exist - return
-    if (err.code === "ENOENT") {
+    if (err.code === 'ENOENT') {
       return;
     }
     throw err;
@@ -264,13 +258,10 @@ exports.validateNoExtraPermissionsForOthersSync = function (filePath) {
  * @returns {Promise<FileHandle>}
  */
 exports.getSecureHandle = async function (filePath, flags, fsPromises) {
-  const fsp = fsPromises ? fsPromises : require("fs/promises");
+  const fsp = fsPromises ? fsPromises : require('fs/promises');
   try {
     const fileHandle = await fsp.open(filePath, flags, 0o600);
-    if (
-      os.platform() === "win32" ||
-      shouldSkipTokenFilePermissionsVerification()
-    ) {
+    if (os.platform() === 'win32' || shouldSkipTokenFilePermissionsVerification()) {
       return fileHandle;
     }
     const stats = await fileHandle.stat();
@@ -290,7 +281,7 @@ exports.getSecureHandle = async function (filePath, flags, fsPromises) {
 
     const userInfo = os.userInfo();
     if (stats.uid === userInfo.uid) {
-      Logger().debug("Validated file owner");
+      Logger().debug('Validated file owner');
     } else {
       throw new Error(
         `Invalid file owner for file ${filePath}). Make sure the system user is the owner of the file otherwise please remove the file and re-run the driver.`,
@@ -299,7 +290,7 @@ exports.getSecureHandle = async function (filePath, flags, fsPromises) {
     return fileHandle;
   } catch (err) {
     //When file doesn't exist - return
-    if (err.code === "ENOENT") {
+    if (err.code === 'ENOENT') {
       return null;
     } else {
       throw err;
@@ -320,12 +311,8 @@ exports.closeHandle = async function (fileHandle) {
  * @param fsPromises
  * @returns {Promise<boolean>} resolves always to true for Windows
  */
-exports.isFileModeCorrect = async function (
-  filePath,
-  expectedMode,
-  fsPromises,
-) {
-  if (os.platform() === "win32") {
+exports.isFileModeCorrect = async function (filePath, expectedMode, fsPromises) {
+  if (os.platform() === 'win32') {
     return true;
   }
   return await fsPromises.stat(filePath).then((stats) => {
@@ -342,11 +329,8 @@ exports.isFileModeCorrect = async function (
  * @param fsPromises
  * @returns {Promise<boolean>} resolves always to true for Windows
  */
-exports.isFileNotWritableByGroupOrOthers = async function (
-  configFilePath,
-  fsPromises,
-) {
-  if (os.platform() === "win32") {
+exports.isFileNotWritableByGroupOrOthers = async function (configFilePath, fsPromises) {
+  if (os.platform() === 'win32') {
     return true;
   }
   const stats = await fsPromises.stat(configFilePath);
@@ -362,9 +346,9 @@ exports.isFileNotWritableByGroupOrOthers = async function (
  */
 exports.generateChecksum = function (text, algorithm, encoding) {
   return crypto
-    .createHash(algorithm || "sha256")
-    .update(text, "utf8")
-    .digest(encoding || "hex")
+    .createHash(algorithm || 'sha256')
+    .update(text, 'utf8')
+    .digest(encoding || 'hex')
     .substring(0, 32);
 };
 
@@ -380,5 +364,4 @@ exports.IsFileExisted = async function (filePath) {
 function shouldSkipTokenFilePermissionsVerification() {
   return !!process.env[SKIP_TOKEN_FILE_PERMISSIONS_VERIFICATION_ENV_VAR];
 }
-exports.shouldSkipTokenFilePermissionsVerification =
-  shouldSkipTokenFilePermissionsVerification;
+exports.shouldSkipTokenFilePermissionsVerification = shouldSkipTokenFilePermissionsVerification;

--- a/test/unit/file_transfer_agent/file_util_test.js
+++ b/test/unit/file_transfer_agent/file_util_test.js
@@ -35,7 +35,18 @@ describe('FileUtil.getDigestAndSizeForFile()', function () {
 });
 
 describe('globToRegex', function () {
-  const files = ['matched.gzip', 'matched2.gzip', 'matched.txt', 'notmatched.txt'];
+  const files = [
+    'matched.gzip',
+    'matched2.gzip',
+    'matched.txt',
+    'notmatched.txt',
+    '.hidden_file.txt',
+    '.env',
+    '.streamlit',
+    'app.py',
+    'config.toml',
+    'archive.tar.gz',
+  ];
   const testCases = [
     {
       pattern: 'ma*',
@@ -57,9 +68,61 @@ describe('globToRegex', function () {
       pattern: 'm?t?he*',
       expectedMatches: ['matched.gzip', 'matched2.gzip', 'matched.txt'],
     },
+    {
+      pattern: '*.*',
+      expectedMatches: [
+        'matched.gzip',
+        'matched2.gzip',
+        'matched.txt',
+        'notmatched.txt',
+        'app.py',
+        'config.toml',
+        'archive.tar.gz',
+      ],
+    },
+    {
+      pattern: '*',
+      expectedMatches: [
+        'matched.gzip',
+        'matched2.gzip',
+        'matched.txt',
+        'notmatched.txt',
+        'app.py',
+        'config.toml',
+        'archive.tar.gz',
+      ],
+    },
+    {
+      pattern: '?.*',
+      expectedMatches: [],
+    },
+    {
+      pattern: '.*',
+      expectedMatches: ['.hidden_file.txt', '.env', '.streamlit'],
+    },
+    {
+      pattern: '.*.txt',
+      expectedMatches: ['.hidden_file.txt'],
+    },
+    {
+      pattern: '.env',
+      expectedMatches: ['.env'],
+    },
+    {
+      pattern: '*.*.*',
+      expectedMatches: ['archive.tar.gz'],
+    },
+    {
+      pattern: '*.toml',
+      expectedMatches: ['config.toml'],
+    },
+    {
+      pattern: '*.py',
+      expectedMatches: ['app.py'],
+    },
   ];
   for (const { pattern, expectedMatches } of testCases) {
-    it(`${pattern} should match ${expectedMatches.join(', ')}`, () => {
+    it(`"${pattern}" should match [${expectedMatches.join(', ')}]`, () => {
       const regex = globToRegex(pattern);
       const matchedFiles = files.filter((file) => regex.test(file));
       assert.deepStrictEqual(matchedFiles, expectedMatches);


### PR DESCRIPTION
### Description

Prior to v2.3.3 the `glob` dependency was used to match file names for `PUT` etc., and we used it with the [default](https://github.com/isaacs/node-glob/blob/v10.5.0/README.md?plain=1#L411-L412) `dot: false` behaviour:
> All options are optional, boolean, and false by default, unless
> otherwise noted.

We ditched `glob` due to CVE but now we seem to have a subtle issue where previously (see above) the leading dot in filenames (e.g. `.streamlit`) was not matched, thus the `PUT` did not attempt to upload the whole directory. Now it does. 

This change aims to 
* check for first char of the filename to get back to the previous behaviour
* add some tests to prevent it from breaking silently in the future

### Checklist

- [x] Create tests which fail without the change (if possible)
- [x] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [ ] Extend the types in index.d.ts file (if necessary)
- [x] Extend the README / documentation and ensure is properly displayed (if necessary)
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message
