### PR TITLE
Reduce peak memory when streaming large result sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changes:
 
 - Replaced deprecated Node.js `url.parse()` with the WHATWG `URL` constructor (snowflakedb/snowflake-connector-nodejs#1380)
 - Fixed file name pattern matching to not match dot-prefixed files/directories by default, aligning with standard glob behavior and default of `dot: false`. Was lingering around since v2.3.3. (snowflakedb/snowflake-connector-nodejs#1381)
+- Reduced peak memory usage when streaming large result sets by reordering chunk lifecycle to free the previous chunk before parsing the next one (snowflakedb/snowflake-connector-nodejs#790)
 
 ## 2.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,15 @@
 # Changelog
 
-##
+## Upcoming Release
 
 Changes:
 
 - Replaced deprecated Node.js `url.parse()` with the WHATWG `URL` constructor (snowflakedb/snowflake-connector-nodejs#1380)
+- Reduced peak memory usage when streaming large result sets by reordering chunk lifecycle to free the previous chunk before parsing the next one (snowflakedb/snowflake-connector-nodejs#1382)
+
+Bugfixes:
+
 - Fixed file name pattern matching to not match dot-prefixed files/directories by default, aligning with standard glob behavior and default of `dot: false`. Was lingering around since v2.3.3. (snowflakedb/snowflake-connector-nodejs#1381)
-- Reduced peak memory usage when streaming large result sets by reordering chunk lifecycle to free the previous chunk before parsing the next one (snowflakedb/snowflake-connector-nodejs#790)
 
 ## 2.4.0
 

--- a/lib/connection/result/row_stream.js
+++ b/lib/connection/result/row_stream.js
@@ -150,7 +150,9 @@ function RowStream(statement, context, options) {
 
         // push() data to readable stream until highWaterMark threshold is reached or all rows are pushed
         while (rowIndex < rowBuffer.length) {
-          row = rowBuffer[rowIndex++];
+          row = rowBuffer[rowIndex];
+          rowBuffer[rowIndex] = null;
+          rowIndex++;
 
           // if buffer has reached the threshold based on the highWaterMark value then
           // push() will return false and pause sending data to the buffer until the data is read from the buffer
@@ -183,6 +185,12 @@ function RowStream(statement, context, options) {
     resultStream.removeListener('data', onResultStreamData);
     resultStream.removeListener('close', onResultStreamClose);
 
+    // Free previous chunk before getRows() triggers JSON.parse on the new one
+    if (previousChunk && previousChunk !== chunk) {
+      previousChunk.clearRows();
+    }
+    previousChunk = chunk;
+
     // get all the rows in the chunk that overlap with the requested window,
     // and use the resulting array as the new row buffer
     const chunkStart = chunk.getStartIndex();
@@ -196,12 +204,6 @@ function RowStream(statement, context, options) {
 
     // process the row buffer
     processRowBuffer();
-
-    if (previousChunk && previousChunk !== chunk) {
-      previousChunk.clearRows();
-    }
-
-    previousChunk = chunk;
   };
 
   /**

--- a/test/unit/connection/result/row_stream_test.ts
+++ b/test/unit/connection/result/row_stream_test.ts
@@ -77,35 +77,32 @@ describe('RowStream', function () {
       highWaterMark = 1000,
     ) {
       const callLog: string[] = [];
+
+      let totalRows = 0;
       const chunks = chunkDefs.map((def, i) => {
-        const startIndex = chunkDefs.slice(0, i).reduce((s, d) => s + d.rows.length, 0);
-        return createMockChunk(i, startIndex, def.rows, callLog);
+        const chunk = createMockChunk(i, totalRows, def.rows, callLog);
+        totalRows += def.rows.length;
+        return chunk;
       });
 
-      const totalRows = chunkDefs.reduce((s, d) => s + d.rows.length, 0);
-      const columns = [{ getId: () => 0, getName: () => 'col', getType: () => 'TEXT' }];
-
-      const config = new ConnectionConfig({
-        ...mandatoryConnectionOptions,
-        rowStreamHighWaterMark: highWaterMark,
-      });
-
-      const result = {
-        getReturnedRows: () => totalRows,
-        findOverlappingChunks: () => chunks,
+      const statement = {
+        getColumns: () => [{ getId: () => 0, getName: () => 'col', getType: () => 'TEXT' }],
       };
-
       const context = {
-        connectionConfig: config,
-        result,
+        connectionConfig: new ConnectionConfig({
+          ...mandatoryConnectionOptions,
+          rowStreamHighWaterMark: highWaterMark,
+        }),
+        result: {
+          getReturnedRows: () => totalRows,
+          findOverlappingChunks: () => chunks,
+        },
         isFetchingResult: false,
         rowMode: undefined,
         fetchAsString: undefined,
       };
 
-      const statement = { getColumns: () => columns };
       const stream = new RowStream(statement, context) as unknown as Readable;
-
       return { stream, callLog, chunks };
     }
 

--- a/test/unit/connection/result/row_stream_test.ts
+++ b/test/unit/connection/result/row_stream_test.ts
@@ -1,4 +1,5 @@
 import assert from 'assert';
+import { EventEmitter } from 'events';
 import { Readable } from 'stream';
 import RowStream from '../../../../lib/connection/result/row_stream';
 import ConnectionConfig from '../../../../lib/connection/connection_config';
@@ -29,5 +30,138 @@ describe('RowStream', function () {
     });
     const stream = createRowStream(config);
     assert.strictEqual(stream.readableHighWaterMark, 25);
+  });
+
+  describe('chunk memory management', function () {
+    // Minimal mock row with the extract function RowStream expects
+    function mockRow(value: string) {
+      return { getColumnValue: () => value, getColumnValueAsString: () => value };
+    }
+
+    function createMockChunk(
+      id: number,
+      startIndex: number,
+      rows: ReturnType<typeof mockRow>[],
+      callLog: string[],
+    ) {
+      const emitter = new EventEmitter();
+      let loading = false;
+
+      const chunk = Object.assign(emitter, {
+        _url: 'https://s3.snowflake.com/chunk',
+        getStartIndex: () => startIndex,
+        getEndIndex: () => startIndex + rows.length - 1,
+        getRows: () => {
+          callLog.push(`chunk${id}:getRows`);
+          return rows;
+        },
+        clearRows: () => {
+          callLog.push(`chunk${id}:clearRows`);
+        },
+        getId: () => id,
+        isLoading: () => loading,
+        load: function () {
+          loading = true;
+          process.nextTick(() => {
+            loading = false;
+            emitter.emit('loadcomplete', null, chunk);
+          });
+        },
+      });
+
+      return chunk;
+    }
+
+    function createStreamWithChunks(
+      chunkDefs: { rows: ReturnType<typeof mockRow>[] }[],
+      highWaterMark = 1000,
+    ) {
+      const callLog: string[] = [];
+      const chunks = chunkDefs.map((def, i) => {
+        const startIndex = chunkDefs.slice(0, i).reduce((s, d) => s + d.rows.length, 0);
+        return createMockChunk(i, startIndex, def.rows, callLog);
+      });
+
+      const totalRows = chunkDefs.reduce((s, d) => s + d.rows.length, 0);
+      const columns = [{ getId: () => 0, getName: () => 'col', getType: () => 'TEXT' }];
+
+      const config = new ConnectionConfig({
+        ...mandatoryConnectionOptions,
+        rowStreamHighWaterMark: highWaterMark,
+      });
+
+      const result = {
+        getReturnedRows: () => totalRows,
+        findOverlappingChunks: () => chunks,
+      };
+
+      const context = {
+        connectionConfig: config,
+        result,
+        isFetchingResult: false,
+        rowMode: undefined,
+        fetchAsString: undefined,
+      };
+
+      const statement = { getColumns: () => columns };
+      const stream = new RowStream(statement, context) as unknown as Readable;
+
+      return { stream, callLog, chunks };
+    }
+
+    it('clears previous chunk rows before parsing the new chunk', function (done) {
+      const { stream, callLog } = createStreamWithChunks([
+        { rows: [mockRow('a'), mockRow('b')] },
+        { rows: [mockRow('c'), mockRow('d')] },
+      ]);
+
+      const received: string[] = [];
+      stream.on('data', (row: Record<string, string>) => received.push(row.col));
+      stream.on('end', () => {
+        // chunk0:getRows must come first (initial chunk)
+        // chunk0:clearRows must come BEFORE chunk1:getRows
+        const getRows0 = callLog.indexOf('chunk0:getRows');
+        const clearRows0 = callLog.indexOf('chunk0:clearRows');
+        const getRows1 = callLog.indexOf('chunk1:getRows');
+
+        assert.ok(getRows0 >= 0, 'chunk0:getRows should be called');
+        assert.ok(clearRows0 >= 0, 'chunk0:clearRows should be called');
+        assert.ok(getRows1 >= 0, 'chunk1:getRows should be called');
+        assert.ok(
+          clearRows0 < getRows1,
+          `clearRows on chunk 0 (index ${clearRows0}) should be called before ` +
+            `getRows on chunk 1 (index ${getRows1}), callLog: ${callLog.join(', ')}`,
+        );
+
+        assert.deepStrictEqual(received, ['a', 'b', 'c', 'd']);
+
+        // last chunk should also be cleaned up during close()
+        assert.ok(callLog.includes('chunk1:clearRows'), 'last chunk should be cleared on close');
+        done();
+      });
+      stream.on('error', done);
+    });
+
+    it('delivers all rows correctly under backpressure (highWaterMark=1)', function (done) {
+      const { stream, callLog } = createStreamWithChunks(
+        [
+          { rows: [mockRow('a'), mockRow('b'), mockRow('c'), mockRow('d')] },
+          { rows: [mockRow('e'), mockRow('f')] },
+        ],
+        1,
+      );
+
+      const received: string[] = [];
+      stream.on('data', (row: Record<string, string>) => received.push(row.col));
+      stream.on('end', () => {
+        assert.deepStrictEqual(received, ['a', 'b', 'c', 'd', 'e', 'f']);
+        assert.ok(
+          callLog.indexOf('chunk0:clearRows') < callLog.indexOf('chunk1:getRows'),
+          'clearRows ordering must hold under backpressure',
+        );
+        done();
+      });
+      stream.on('error', done);
+    });
   });
 });


### PR DESCRIPTION
### Description

When streaming large result sets via `streamRows()`, the previous chunk's `_rows` array is freed only after `getRows()` on the next chunk - meaning the old rows coexist with the new chunk's `JSON.parse` allocation and any prefetched `_rowsetAsString` buffers, raising the transient memory peak unnecessarily.

**Changes:**

1. Move `previousChunk.clearRows()` before `chunk.getRows()` in `onResultStreamData` - frees the previous chunk's rows before the next chunk's parse allocates.
2. Null consumed `rowBuffer` entries in the `processRowBuffer` while loop - allows GC to reclaim row objects incrementally rather than retaining the entire buffer.

These are minor SDK-side optimizations that reduce transient peak memory during chunk transitions. For environments streaming very large exports, consumers can additionally tune:

- `resultPrefetch: 1` - reduces prefetched chunks from 2 to 1, lowering baseline memory from buffered `_rowsetAsString` payloads
- `rowStreamHighWaterMark` (v2.3.5) - controls row-level Readable buffering
- `CLIENT_RESULT_CHUNK_SIZE` session parameter - controls server-side chunk sizing (currently requires server-side enablement, not yet GA)
- Streaming JSON parsing and Arrow format support would yield the largest gains but require significant SDK changes

Related: #790

### Checklist

- [x] Create tests which fail without the change (if possible)
- [x] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [ ] ~~Extend the types in index.d.ts file (if necessary)~~ - N/A, no public API change
- [ ] ~~Extend the README / documentation~~ - N/A
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message