### PR TITLE
SNOW-3055677 Implement SESSION_ID_AS_STRING capability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## Upcoming Release
 
-Internal changes:
-
-- The login-request now requests `sessionId` as a string to avoid precision loss (snowflakedb/snowflake-connector-nodejs#1384)
-
 Changes:
 
 - Replaced deprecated Node.js `url.parse()` with the WHATWG `URL` constructor (snowflakedb/snowflake-connector-nodejs#1380)
@@ -14,6 +10,10 @@ Changes:
 Bugfixes:
 
 - Fixed file name pattern matching to not match dot-prefixed files/directories by default, aligning with standard glob behavior and default of `dot: false`. Was lingering around since v2.3.3. (snowflakedb/snowflake-connector-nodejs#1381)
+
+Internal:
+
+- The login-request now requests `sessionId` as a string to avoid precision loss (snowflakedb/snowflake-connector-nodejs#1384)
 
 ## 2.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Internal changes:
 
-- The login-request now requests `sessionId` as a string to avoid precision loss
+- The login-request now requests `sessionId` as a string to avoid precision loss (snowflakedb/snowflake-connector-nodejs#1384)
 
 Changes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Upcoming Release
 
+Internal changes:
+
+- The login-request now requests `sessionId` as a string to avoid precision loss
+
 Changes:
 
 - Replaced deprecated Node.js `url.parse()` with the WHATWG `URL` constructor (snowflakedb/snowflake-connector-nodejs#1380)

--- a/lib/queryContextCache.js
+++ b/lib/queryContextCache.js
@@ -20,7 +20,7 @@ function QueryContextElement(id, timestamp, priority, context) {
 
 /**
  * @param {Number} capacity Maximum capacity of the cache.
- * @param {Number} sessionId Session for which the cache is created.
+ * @param {string} sessionId Session for which the cache is created.
  */
 function QueryContextCache(capacity, sessionId) {
   Logger.getInstance().debug(

--- a/lib/services/sf.js
+++ b/lib/services/sf.js
@@ -179,7 +179,7 @@ function SnowflakeService(connectionConfig, httpClient, config) {
 
   /**
    * Set the session id for the current SnowflakeService
-   * @type {function(string|number): void}
+   * @type {function(string): void}
    */
   this.setSessionId = function (sessionId) {
     this.sessionId = sessionId;
@@ -187,7 +187,7 @@ function SnowflakeService(connectionConfig, httpClient, config) {
 
   /**
    * Get the session id.
-   * @returns {number}
+   * @returns {string}
    */
   this.getSessionId = function () {
     return this.sessionId;
@@ -1086,6 +1086,9 @@ StateConnecting.prototype.continue = function () {
   const clientInfo = {
     CLIENT_APP_ID: this.connectionConfig.getClientType(),
     CLIENT_APP_VERSION: this.connectionConfig.getClientVersion(),
+    CLIENT_CAPABILITIES: {
+      SESSION_ID_AS_STRING: true,
+    },
     CLIENT_ENVIRONMENT: {
       APPLICATION_PATH: getApplicationPath(),
       CERT_REVOCATION_CHECK_MODE: this.connectionConfig.crlValidatorConfig.checkMode,

--- a/test/unit/mock/mock_http_client.js
+++ b/test/unit/mock/mock_http_client.js
@@ -150,12 +150,13 @@ function serializeRequest(request) {
   // { url: 'foo', method: 'GET' } even though they are semantically equivalent
   // requests, i.e. they should produce the same output
   const clonedRequest = createSortedClone(request);
+
+  // Ignore these fields, in future we should migrate this entire thing to
+  // wiremock for better matchers
   delete clonedRequest.useSnowflakeRetryMiddleware;
-  delete clonedRequest.json.data.CLIENT_CAPABILITIES;
-  // Ignore CLIENT_ENVIRONMENT for now,
-  // in future we should migrate this entire thing to wiremock for better matchers
-  if (clonedRequest.json && clonedRequest.json.data && clonedRequest.json.data.CLIENT_ENVIRONMENT) {
-    clonedRequest.json.data.CLIENT_ENVIRONMENT = {};
+  if (clonedRequest.json && clonedRequest.json.data) {
+    delete clonedRequest.json.data.CLIENT_CAPABILITIES;
+    delete clonedRequest.json.data.CLIENT_ENVIRONMENT;
   }
   return JSON.stringify(clonedRequest);
 }

--- a/test/unit/mock/mock_http_client.js
+++ b/test/unit/mock/mock_http_client.js
@@ -151,6 +151,7 @@ function serializeRequest(request) {
   // requests, i.e. they should produce the same output
   const clonedRequest = createSortedClone(request);
   delete clonedRequest.useSnowflakeRetryMiddleware;
+  delete clonedRequest.json.data.CLIENT_CAPABILITIES;
   // Ignore CLIENT_ENVIRONMENT for now,
   // in future we should migrate this entire thing to wiremock for better matchers
   if (clonedRequest.json && clonedRequest.json.data && clonedRequest.json.data.CLIENT_ENVIRONMENT) {


### PR DESCRIPTION
### Description

Send `SESSION_ID_AS_STRING: true` in `CLIENT_CAPABILITIES` during login so the server returns `sessionId` as a string, avoiding precision loss with large numeric IDs. Updates JSDoc type annotations in `sf.js` and `queryContextCache.js` to reflect the new string type.

No tests are included because `sessionId` is only used in log messages — there is no functional behavior change to assert on.

### Checklist

- [x] Create tests which fail without the change (if possible)
- [x] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [x] Extend the types in index.d.ts file (if necessary)
- [x] Extend the README / documentation and ensure is properly displayed (if necessary)
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message