### PR TITLE
NO-SNOW Improve cache invalidation in AuthOauthAuthorizationCode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Changes:
 Bugfixes:
 
 - Fixed file name pattern matching to not match dot-prefixed files/directories by default, aligning with standard glob behavior and default of `dot: false`. Was lingering around since v2.3.3. (snowflakedb/snowflake-connector-nodejs#1381)
-- Fixed `OAUTH_AUTHORIZATION_CODE` cache not evicting entries on server `390303` errors (snowflakedb/snowflake-connector-nodejs#1392)
+- Fixed `OAUTH_AUTHORIZATION_CODE` cache not evicting entries on server `390303` errors (snowflakedb/snowflake-connector-nodejs#1392, snowflakedb/snowflake-connector-nodejs#1394)
 
 Internal:
 

--- a/lib/services/sf.js
+++ b/lib/services/sf.js
@@ -660,11 +660,12 @@ function StateAbstract(options) {
 
             if (
               (body.code === GSErrors.code.ID_TOKEN_INVALID && auth instanceof AuthIDToken) ||
-              ((body.code === GSErrors.code.OAUTH_TOKEN_EXPIRED ||
-                body.code === GSErrors.code.OAUTH_TOKEN_INVALID) &&
-                auth instanceof AuthOauthAuthorizationCode)
+              auth instanceof AuthOauthAuthorizationCode
             ) {
-              Logger.getInstance().debug('ID Token being used has expired. Reauthenticating');
+              Logger.getInstance().debug(
+                'Authentication rejected by GS (code=%s). Reauthenticating.',
+                body.code,
+              );
               await auth.reauthenticate(requestOptions.json);
               return httpClient.request(realRequestOptions);
             }

--- a/test/integration/wiremock/testOauthRefreshToken.js
+++ b/test/integration/wiremock/testOauthRefreshToken.js
@@ -135,7 +135,7 @@ describe('Oauth Refresh token for Autorization Code', function () {
     assert.strictEqual(refreshTokenInCache, 'new_refresh_token');
   });
 
-  it('Reauthenticates with refreshed token when cached access token is invalid', async function () {
+  it('Reauthenticates with refresh token when cached access token returns success=false from the server', async function () {
     await authUtil.writeToCache(accessTokenKey, 'invalid_token');
     await authUtil.writeToCache(refreshTokenKey, 'cached_refresh_token');
     await addWireMockMappingsFromFile(

--- a/wiremock/mappings/oauth/token_cache_and_refresh/reauthenticate_on_invalid_oauth_token.json
+++ b/wiremock/mappings/oauth/token_cache_and_refresh/reauthenticate_on_invalid_oauth_token.json
@@ -29,8 +29,8 @@
             "authnMethod": "OAUTH",
             "signInOptions": {}
           },
-          "code": "390303",
-          "message": "OAuth access token is invalid.",
+          "code": "123456",
+          "message": "Authentication failed.",
           "success": false,
           "headers": null
         }


### PR DESCRIPTION
### Description

Align OAuth access-token cache invalidation in `lib/services/sf.js` with the [Go driver's behavior](https://github.com/snowflakedb/gosnowflake/blob/c30b5a9677e61ea0d96f0367eb962bcd795c045e/auth.go#L334-L345).

Previously, the Node.js connector only triggered `auth.reauthenticate()` for two specific GS error codes (`OAUTH_TOKEN_INVALID` 390303 and `OAUTH_TOKEN_EXPIRED` 390318) when using OAuth Authorization Code authentication. The Go driver instead invalidates the cached OAuth access token on **any** `success: false` auth response when the authenticator is an OAuth native flow.

This change makes the Node.js driver consistent: any failed auth response now triggers cache invalidation + reauthenticate when the authenticator is `AuthOauthAuthorizationCode`. The `AuthIDToken` branch is unchanged.

**Changes:**
- `lib/services/sf.js`: simplified the reauthenticate condition to fire on any failure for `AuthOauthAuthorizationCode`; the debug log now includes the actual error code.
- `wiremock/mappings/oauth/token_cache_and_refresh/reauthenticate_on_invalid_oauth_token.json`: replaced the response code `"390303"` with an arbitrary code `"123456"` (not present in `lib/constants/gs_errors.ts`) so the test exercises the new broader behavior.
- `test/integration/wiremock/testOauthRefreshToken.js`: renamed the existing test to `'Reauthenticates with refresh token when cached access token returns success=false from the server'`.

### Checklist

- [x] Create tests which fail without the change (if possible)
- [x] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [x] Extend the types in index.d.ts file (if necessary)
- [x] Extend the README / documentation and ensure is properly displayed (if necessary)
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message