### PR TITLE
SNOW-3440013 Pin @aws-sdk dependencies

### DIFF
--- a/.cursor/rules/aws-sdk-pinning.mdc
+++ b/.cursor/rules/aws-sdk-pinning.mdc
@@ -1,0 +1,36 @@
+---
+description: "Enforce tilde-pinning for all @aws-sdk/* dependencies in package.json"
+globs: package.json
+alwaysApply: false
+---
+### Code Rules
+
+All `@aws-sdk/*` entries in `package.json` MUST use the tilde (`~`) range so only patch versions float. This applies to both `dependencies` and `devDependencies`, and to any new `@aws-sdk/*` entry added in the future.
+
+Currently covered entries (must match `package.json`):
+
+- `dependencies`:
+  - `@aws-sdk/client-s3`
+  - `@aws-sdk/client-sts`
+  - `@aws-sdk/credential-provider-node`
+  - `@aws-sdk/ec2-metadata-service`
+- `devDependencies`:
+  - `@aws-sdk/types`
+
+❌ `"@aws-sdk/client-s3": "^3.1038.0"`
+❌ `"@aws-sdk/client-s3": "3.1038.0"` (exact pin — too strict, blocks patch fixes)
+✅ `"@aws-sdk/client-s3": "~3.1038.0"`
+
+### Reasoning
+
+AWS does not guarantee that `@aws-sdk/*` minor releases avoid breaking changes for the Node.js versions the driver still supports (Node 18). As of January 2026, the AWS SDK for JavaScript has dropped Node 18 from its tested matrix and will start emitting deprecation warnings / publishing engine constraints incompatible with Node 18 — see [AWS SDK for JavaScript aligns with Node.js release schedule](https://aws.amazon.com/blogs/developer/aws-sdk-for-javascript-aligns-with-node-js-release-schedule/) and the [Node.js and ECMAScript version support policy](https://github.com/aws/aws-sdk-js-v3#nodejs-and-ecmascript-version-support-policy). Past minor releases have already shipped CJS-incompatible code that broke our consumers — see (snowflakedb/snowflake-connector-nodejs#1395).
+
+The Snowflake Node.js driver still supports Node 18, so tilde-pinning lets us pick up patch-level security and bug fixes while preventing silent minor bumps from dropping Node 18 compatibility or otherwise breaking the driver.
+
+### When bumping
+
+Bumping `@aws-sdk/*` is a manual process:
+
+1. Bump each entry in `package.json` to the latest available minor (still using the `~` range) and run `npm install` locally. Do NOT commit `package-lock.json` — it is gitignored.
+2. Run the full test suite on Node 18 to validate the new minor still works on our minimum supported Node version. The AWS SDK no longer runs tests on Node 18, so this validation is on us.
+3. Only after Node 18 validation passes, submit the bump PR.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Changes:
 - Replaced deprecated Node.js `url.parse()` with the WHATWG `URL` constructor (snowflakedb/snowflake-connector-nodejs#1380)
 - Bumped axios to `1.15.1` to address deprecated `url.parse()` warning in Node.js 22+ ([axios/axios#10625](https://github.com/axios/axios/pull/10625)) and to address a set of security issues, including CVE-2025-62718 (snowflakedb/snowflake-connector-nodejs#1387) and (snowflakedb/snowflake-connector-nodejs#1391)
 - Reduced peak memory usage when streaming large result sets by reordering chunk lifecycle to free the previous chunk before parsing the next one (snowflakedb/snowflake-connector-nodejs#1382)
+- Pinned all `@aws-sdk/*` dependencies to their latest minor (patch floats only). AWS does not guarantee that minor releases avoid breaking changes for the Node.js versions we still support (Node 18+); see (snowflakedb/snowflake-connector-nodejs#1395) (snowflakedb/snowflake-connector-nodejs#1396)
 
 Bugfixes:
 

--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
   },
   "dependencies": {
     "@aws-crypto/sha256-js": "^5.2.0",
-    "@aws-sdk/client-s3": "^3.1016.0",
-    "@aws-sdk/client-sts": "^3.1016.0",
-    "@aws-sdk/credential-provider-node": "^3.972.25",
-    "@aws-sdk/ec2-metadata-service": "^3.1016.0",
+    "@aws-sdk/client-s3": "~3.1038.0",
+    "@aws-sdk/client-sts": "~3.1038.0",
+    "@aws-sdk/credential-provider-node": "~3.972.37",
+    "@aws-sdk/ec2-metadata-service": "~3.1038.0",
     "@azure/identity": "^4.10.1",
     "@azure/storage-blob": "12.26.x",
     "@smithy/node-http-handler": "^4.4.9",
@@ -41,7 +41,7 @@
     "winston": "^3.1.0"
   },
   "devDependencies": {
-    "@aws-sdk/types": "^3.973.1",
+    "@aws-sdk/types": "~3.973.8",
     "@napi-rs/cli": "^3.2.0",
     "@types/mocha": "^10.0.10",
     "@types/node": "^22.15.18",


### PR DESCRIPTION
### Description

Pin all `@aws-sdk/*` direct dependencies in `package.json` to their latest minor using `~` (patch floats only):

- `dependencies`:
  - `@aws-sdk/client-s3`: `^3.1016.0` → `~3.1038.0`
  - `@aws-sdk/client-sts`: `^3.1016.0` → `~3.1038.0`
  - `@aws-sdk/credential-provider-node`: `^3.972.25` → `~3.972.37`
  - `@aws-sdk/ec2-metadata-service`: `^3.1016.0` → `~3.1038.0`
- `devDependencies`:
  - `@aws-sdk/types`: `^3.973.1` → `~3.973.8`

#### Why

AWS does not guarantee that `@aws-sdk/*` minor releases avoid breaking changes for the Node.js versions the driver still supports (Node 18+). As of January 2026, the AWS SDK for JavaScript [aligned with the Node.js release schedule](https://aws.amazon.com/blogs/developer/aws-sdk-for-javascript-aligns-with-node-js-release-schedule/) and [dropped Node 18 from its tested matrix](https://github.com/aws/aws-sdk-js-v3#nodejs-and-ecmascript-version-support-policy). A recent example is `@aws-sdk/xml-builder@3.972.20`, which broke CJS consumers and surfaced as #1395 for our users.

Tilde-pinning lets us pick up patch-level security and bug fixes while preventing silent minor bumps from dropping Node 18 compatibility or otherwise breaking the driver. Bumps will now go through a manual review + Node 18 test run before landing.

This PR also adds a Cursor rule (`.cursor/rules/aws-sdk-pinning.mdc`, auto-attached to `package.json`) that documents the pinning policy and the manual bump workflow.

Closes #1395.

### Checklist

- [x] Create tests which fail without the change (if possible) — N/A (dependency pinning)
- [x] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [x] Extend the types in index.d.ts file (if necessary) — N/A
- [x] Extend the README / documentation and ensure is properly displayed (if necessary) — N/A (CHANGELOG and Cursor rule updated instead)
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message