### PR TITLE
SNOW-3428739 Retire uuid dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Internal:
 - Extended login-request `PLATFORM` telemetry to detect cloud VMs, managed identities, and GitHub Actions in addition to serverless environments (snowflakedb/snowflake-connector-nodejs#1386)
 - The login-request now requests `sessionId` as a string to avoid precision loss (snowflakedb/snowflake-connector-nodejs#1384)
 - Removed dead browser-related code and `browser-request` dependency (snowflakedb/snowflake-connector-nodejs#1387)
-- Dropped `uuid` dependency in favor of Node's built-in `crypto.randomUUID()` (snowflakedb/snowflake-connector-nodejs#TODO)
+- Dropped `uuid` dependency in favor of Node's built-in `crypto.randomUUID()` (snowflakedb/snowflake-connector-nodejs#1397)
 
 ## 2.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Internal:
 - Extended login-request `PLATFORM` telemetry to detect cloud VMs, managed identities, and GitHub Actions in addition to serverless environments (snowflakedb/snowflake-connector-nodejs#1386)
 - The login-request now requests `sessionId` as a string to avoid precision loss (snowflakedb/snowflake-connector-nodejs#1384)
 - Removed dead browser-related code and `browser-request` dependency (snowflakedb/snowflake-connector-nodejs#1387)
+- Dropped `uuid` dependency in favor of Node's built-in `crypto.randomUUID()` (snowflakedb/snowflake-connector-nodejs#TODO)
 
 ## 2.4.0
 

--- a/lib/connection/connection.js
+++ b/lib/connection/connection.js
@@ -1,4 +1,4 @@
-const { v4: uuidv4 } = require('uuid');
+const { randomUUID } = require('crypto');
 const Url = require('url');
 const QueryString = require('querystring');
 const QueryStatus = require('../constants/query_status');
@@ -36,7 +36,7 @@ function Connection(context) {
   const connectionConfig = context.getConnectionConfig();
 
   // generate an id for the connection
-  const id = uuidv4();
+  const id = randomUUID();
   Logger.getInstance().trace('Generated connection id: %s', id);
 
   Logger.getInstance().info(
@@ -167,7 +167,7 @@ function Connection(context) {
 
   this.heartbeat = (callback) => {
     Logger.getInstance().trace('Issuing heartbeat call');
-    const requestId = uuidv4();
+    const requestId = randomUUID();
 
     services.sf.request({
       method: 'POST',

--- a/lib/connection/statement.js
+++ b/lib/connection/statement.js
@@ -1,4 +1,4 @@
-const { v4: uuidv4 } = require('uuid');
+const { randomUUID } = require('crypto');
 
 const Url = require('url');
 const QueryString = require('querystring');
@@ -451,7 +451,7 @@ function createContextPreExec(statementOptions, services, connectionConfig) {
     statementContext.resubmitRequest = true;
   } else {
     // use a random uuid for the statement request id
-    statementContext.requestId = uuidv4();
+    statementContext.requestId = randomUUID();
   }
 
   return statementContext;
@@ -963,7 +963,7 @@ function StageBindingStatementPreExec(statementOptions, context, services, conne
    */
   this.StageBindingRequest = async function (options, context, services, connectionConfig) {
     try {
-      const bindUploaderRequestId = uuidv4();
+      const bindUploaderRequestId = randomUUID();
       const bind = new Bind.BindUploader(
         options,
         services,

--- a/lib/services/sf.js
+++ b/lib/services/sf.js
@@ -40,7 +40,7 @@
                - destroy()    - Disconnected
  */
 
-const { v4: uuidv4 } = require('uuid');
+const { randomUUID } = require('crypto');
 const EventEmitter = require('events').EventEmitter;
 const Util = require('../util');
 const Errors = require('../errors');
@@ -759,7 +759,7 @@ function StateAbstract(options) {
   function addGuidToParams(params) {
     // In case of repeated requests for the same request ID,
     // the Global UID is added for better traceability.
-    const guid = uuidv4();
+    const guid = randomUUID();
     params[sfParams.paramsNames.SF_REQUEST_GUID] = guid;
   }
 
@@ -1327,7 +1327,7 @@ function buildLoginUrl(connectionConfig) {
   const queryStringObject = {};
   if (!connectionConfig.isQaMode()) {
     // No requestId is attached to login-request in test mode.
-    queryStringObject.requestId = uuidv4();
+    queryStringObject.requestId = randomUUID();
   }
   for (let index = 0, length = queryParams.length; index < length; index++) {
     const queryParam = queryParams[index];
@@ -1448,7 +1448,7 @@ StateConnected.prototype.request = function (options) {
  * @inheritDoc
  */
 StateConnected.prototype.destroy = function (options) {
-  const requestID = uuidv4();
+  const requestID = randomUUID();
 
   // send out a session token request to terminate the current connection
   this.createSessionTokenRequest({

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "open": "^7.3.1",
     "simple-lru-cache": "^0.0.2",
     "toml": "^3.0.0",
-    "uuid": "^8.3.2",
     "winston": "^3.1.0"
   },
   "devDependencies": {

--- a/test/integration/testConnection.js
+++ b/test/integration/testConnection.js
@@ -9,7 +9,7 @@ const Core = require('./../../lib/core');
 const { stdout } = require('test-console');
 const { assertLogMessage } = require('./testUtil');
 const { configureLogger } = require('../configureLogger');
-const { v4: uuidv4 } = require('uuid');
+const { randomUUID } = require('crypto');
 
 describe('Connection test', function () {
   it('return tokens in qaMode', function () {
@@ -105,8 +105,8 @@ describe('Connection test', function () {
   });
 
   it('Failed connection returns sanitized error', function (done) {
-    const randomId = uuidv4();
-    const randomId2 = uuidv4();
+    const randomId = randomUUID();
+    const randomId2 = randomUUID();
     const connection = snowflake.createConnection({
       account: 'some-account',
       username: randomId,


### PR DESCRIPTION
### Description

Adresses issue #1393.

Replaces the third-party `uuid` package with Node's built-in `crypto.randomUUID()` across the codebase. The driver requires Node `>=18` (see `package.json`), and `crypto.randomUUID()` has been available since Node 14.17 / 15.6, so it is universally available in our supported runtimes.

The codebase already used `crypto.randomUUID()` in `lib/file_transfer_agent/encrypt_util.js` and several test files; this PR finishes the migration and removes the dependency. Both APIs produce RFC 4122 v4 UUIDs in the same canonical 36-char lowercase hyphenated form, so there is no behavioral change for callers (request IDs, statement IDs, GUIDs) and no public API impact.

### Checklist

- [x] Create tests which fail without the change (if possible) — N/A, pure internal refactor with no observable behavior change; existing tests cover the affected code paths.
- [x] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [x] Extend the types in index.d.ts file (if necessary) — N/A, no public API change.
- [x] Extend the README / documentation and ensure is properly displayed (if necessary) — N/A.
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message