### PR TITLE
NO-SNOW destroy S3 clients after use to prevent keepAlive socket leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Changes:
 
 Bugfixes:
 
+- Destroy S3 clients after use in `s3_util.js` (`getFileHeader`, `uploadFileStream`, `nativeDownloadFile`) to prevent keepAlive socket accumulation and memory leak on long-lived pods
 - Fixed file name pattern matching to not match dot-prefixed files/directories by default, aligning with standard glob behavior and default of `dot: false`. Was lingering around since v2.3.3. (snowflakedb/snowflake-connector-nodejs#1381)
 - Fixed `OAUTH_AUTHORIZATION_CODE` cache not evicting entries on server `390303` errors (snowflakedb/snowflake-connector-nodejs#1392, snowflakedb/snowflake-connector-nodejs#1394)
 

--- a/lib/file_transfer_agent/s3_util.js
+++ b/lib/file_transfer_agent/s3_util.js
@@ -104,47 +104,51 @@ function S3Util(connectionConfig, s3, filestream) {
   this.getFileHeader = async function (meta, filename) {
     const stageInfo = meta['stageInfo'];
     const client = this.createClient(stageInfo);
-    const s3location = extractBucketNameAndPath(stageInfo['location']);
-
-    const params = {
-      Bucket: s3location.bucketName,
-      Key: s3location.s3path + filename,
-    };
-
-    let akey;
-
     try {
-      await client.getObject(params).then(function (data) {
-        akey = data;
-      });
-    } catch (err) {
-      if (err['Code'] === EXPIRED_TOKEN) {
-        meta['resultStatus'] = resultStatus.RENEW_TOKEN;
-        return null;
-      } else if (err['Code'] === NO_SUCH_KEY) {
-        meta['resultStatus'] = resultStatus.NOT_FOUND_FILE;
-        return FileHeader(null, null, null);
-      } else if (err['Code'] === '400') {
-        meta['resultStatus'] = resultStatus.RENEW_TOKEN;
-        return null;
-      } else {
-        meta['resultStatus'] = resultStatus.ERROR;
-        return null;
+      const s3location = extractBucketNameAndPath(stageInfo['location']);
+
+      const params = {
+        Bucket: s3location.bucketName,
+        Key: s3location.s3path + filename,
+      };
+
+      let akey;
+
+      try {
+        await client.getObject(params).then(function (data) {
+          akey = data;
+        });
+      } catch (err) {
+        if (err['Code'] === EXPIRED_TOKEN) {
+          meta['resultStatus'] = resultStatus.RENEW_TOKEN;
+          return null;
+        } else if (err['Code'] === NO_SUCH_KEY) {
+          meta['resultStatus'] = resultStatus.NOT_FOUND_FILE;
+          return FileHeader(null, null, null);
+        } else if (err['Code'] === '400') {
+          meta['resultStatus'] = resultStatus.RENEW_TOKEN;
+          return null;
+        } else {
+          meta['resultStatus'] = resultStatus.ERROR;
+          return null;
+        }
       }
+
+      meta['resultStatus'] = resultStatus.UPLOADED;
+
+      let encryptionMetadata;
+      if (akey && akey.Metadata[AMZ_KEY]) {
+        encryptionMetadata = EncryptionMetadata(
+          akey.Metadata[AMZ_KEY],
+          akey.Metadata[AMZ_IV],
+          akey.Metadata[AMZ_MATDESC],
+        );
+      }
+
+      return FileHeader(akey.Metadata[SFC_DIGEST], akey.ContentLength, encryptionMetadata);
+    } finally {
+      client.destroy();
     }
-
-    meta['resultStatus'] = resultStatus.UPLOADED;
-
-    let encryptionMetadata;
-    if (akey && akey.Metadata[AMZ_KEY]) {
-      encryptionMetadata = EncryptionMetadata(
-        akey.Metadata[AMZ_KEY],
-        akey.Metadata[AMZ_IV],
-        akey.Metadata[AMZ_MATDESC],
-      );
-    }
-
-    return FileHeader(akey.Metadata[SFC_DIGEST], akey.ContentLength, encryptionMetadata);
   };
 
   /**
@@ -180,35 +184,38 @@ function S3Util(connectionConfig, s3, filestream) {
 
     const stageInfo = meta['stageInfo'];
     const client = this.createClient(stageInfo);
-
-    const s3location = extractBucketNameAndPath(meta['stageInfo']['location']);
-
-    const params = {
-      Bucket: s3location.bucketName,
-      Body: fileStream,
-      Key: s3location.s3path + meta['dstFileName'],
-      Metadata: s3Metadata,
-    };
-
-    // call S3 to upload file to specified bucket
     try {
-      await client.putObject(params);
-    } catch (err) {
-      if (err['Code'] === EXPIRED_TOKEN) {
-        meta['resultStatus'] = resultStatus.RENEW_TOKEN;
-      } else {
-        meta['lastError'] = err;
-        if (err['Code'] === ERRORNO_WSAECONNABORTED.toString()) {
-          meta['resultStatus'] = resultStatus.NEED_RETRY_WITH_LOWER_CONCURRENCY;
-        } else {
-          meta['resultStatus'] = resultStatus.NEED_RETRY;
-        }
-      }
-      return;
-    }
+      const s3location = extractBucketNameAndPath(meta['stageInfo']['location']);
 
-    meta['dstFileSize'] = meta['uploadSize'];
-    meta['resultStatus'] = resultStatus.UPLOADED;
+      const params = {
+        Bucket: s3location.bucketName,
+        Body: fileStream,
+        Key: s3location.s3path + meta['dstFileName'],
+        Metadata: s3Metadata,
+      };
+
+      // call S3 to upload file to specified bucket
+      try {
+        await client.putObject(params);
+      } catch (err) {
+        if (err['Code'] === EXPIRED_TOKEN) {
+          meta['resultStatus'] = resultStatus.RENEW_TOKEN;
+        } else {
+          meta['lastError'] = err;
+          if (err['Code'] === ERRORNO_WSAECONNABORTED.toString()) {
+            meta['resultStatus'] = resultStatus.NEED_RETRY_WITH_LOWER_CONCURRENCY;
+          } else {
+            meta['resultStatus'] = resultStatus.NEED_RETRY;
+          }
+        }
+        return;
+      }
+
+      meta['dstFileSize'] = meta['uploadSize'];
+      meta['resultStatus'] = resultStatus.UPLOADED;
+    } finally {
+      client.destroy();
+    }
   };
 
   /**
@@ -221,51 +228,54 @@ function S3Util(connectionConfig, s3, filestream) {
   this.nativeDownloadFile = async function (meta, fullDstPath) {
     const stageInfo = meta['stageInfo'];
     const client = this.createClient(stageInfo);
-
-    const s3location = extractBucketNameAndPath(meta['stageInfo']['location']);
-
-    const params = {
-      Bucket: s3location.bucketName,
-      Key: s3location.s3path + meta['dstFileName'],
-    };
-
-    // call S3 to download file to specified bucket
     try {
-      Logger().debug(
-        `Send Get Request to the Bucket: ${params.Bucket}, GET request: ${params.Key}`,
-      );
-      await client
-        .getObject(params)
-        .then((data) => {
-          Logger().debug(
-            `Http Status for the GET request: ${params.Key} : ${data.$metadata.httpStatusCode}`,
-          );
-          return data.Body.transformToByteArray();
-        })
-        .then((data) => {
-          return new Promise((resolve, reject) => {
-            fs.writeFile(fullDstPath, data, 'binary', (err) => {
-              if (err) {
-                reject(err);
-              }
-              resolve();
+      const s3location = extractBucketNameAndPath(meta['stageInfo']['location']);
+
+      const params = {
+        Bucket: s3location.bucketName,
+        Key: s3location.s3path + meta['dstFileName'],
+      };
+
+      // call S3 to download file to specified bucket
+      try {
+        Logger().debug(
+          `Send Get Request to the Bucket: ${params.Bucket}, GET request: ${params.Key}`,
+        );
+        await client
+          .getObject(params)
+          .then((data) => {
+            Logger().debug(
+              `Http Status for the GET request: ${params.Key} : ${data.$metadata.httpStatusCode}`,
+            );
+            return data.Body.transformToByteArray();
+          })
+          .then((data) => {
+            return new Promise((resolve, reject) => {
+              fs.writeFile(fullDstPath, data, 'binary', (err) => {
+                if (err) {
+                  reject(err);
+                }
+                resolve();
+              });
             });
           });
-        });
-    } catch (err) {
-      if (err['Code'] === EXPIRED_TOKEN) {
-        meta['resultStatus'] = resultStatus.RENEW_TOKEN;
-      } else {
-        meta['lastError'] = err;
-        if (err['Code'] === ERRORNO_WSAECONNABORTED.toString()) {
-          meta['resultStatus'] = resultStatus.NEED_RETRY_WITH_LOWER_CONCURRENCY;
+      } catch (err) {
+        if (err['Code'] === EXPIRED_TOKEN) {
+          meta['resultStatus'] = resultStatus.RENEW_TOKEN;
         } else {
-          meta['resultStatus'] = resultStatus.NEED_RETRY;
+          meta['lastError'] = err;
+          if (err['Code'] === ERRORNO_WSAECONNABORTED.toString()) {
+            meta['resultStatus'] = resultStatus.NEED_RETRY_WITH_LOWER_CONCURRENCY;
+          } else {
+            meta['resultStatus'] = resultStatus.NEED_RETRY;
+          }
         }
+        return;
       }
-      return;
+      meta['resultStatus'] = resultStatus.DOWNLOADED;
+    } finally {
+      client.destroy();
     }
-    meta['resultStatus'] = resultStatus.DOWNLOADED;
   };
 }
 

--- a/test/unit/file_transfer_agent/s3_test.js
+++ b/test/unit/file_transfer_agent/s3_test.js
@@ -7,6 +7,62 @@ const extractBucketNameAndPath =
 
 const resultStatus = require('../../../lib/file_util').resultStatus;
 
+// Reusable S3 method behaviours.
+const resolveEmptyMetadata = () => Promise.resolve({ Metadata: '' });
+const resolveDownload = () =>
+  Promise.resolve({
+    $metadata: { httpStatusCode: 200 },
+    Body: {
+      transformToByteArray: () => Promise.resolve(Buffer.from('mock')),
+    },
+  });
+const throwWithCode = (code) => () => {
+  const err = new Error();
+  err.Code = code;
+  throw err;
+};
+
+// Registers a mock `s3` module and returns the freshly-required handle.
+// Only the fields explicitly passed are attached to the constructed S3 instance,
+// so each test can opt into exactly the surface it exercises.
+function mockS3({ getObject, putObject, captureConfig = false, onDestroy } = {}) {
+  mock('s3', {
+    S3: function (config) {
+      function S3() {
+        if (captureConfig) {
+          this.config = config;
+        }
+        if (getObject) {
+          this.getObject = getObject;
+        }
+        if (putObject) {
+          this.putObject = putObject;
+        }
+      }
+      S3.prototype.destroy = onDestroy || function () {};
+      return new S3();
+    },
+  });
+  return require('s3');
+}
+
+// Registers a mock `filesystem` module with sensible defaults; tests can override `writeFile`.
+function mockFilesystem({ writeFile } = {}) {
+  const impl = {
+    createReadStream: function () {
+      return Readable.from([Buffer.from('mock')]);
+    },
+    readFileSync: async function (data) {
+      return data;
+    },
+  };
+  if (writeFile) {
+    impl.writeFile = writeFile;
+  }
+  mock('filesystem', impl);
+  return require('filesystem');
+}
+
 describe('S3 client', function () {
   const mockDataFile = 'mockDataFile';
   const mockLocation = 'mockLocation';
@@ -41,34 +97,12 @@ describe('S3 client', function () {
   };
 
   before(function () {
-    mock('s3', {
-      S3: function (config) {
-        function S3() {
-          this.getObject = function () {
-            return Promise.resolve({
-              Metadata: '',
-            });
-          };
-          this.config = config;
-          this.putObject = function () {
-            return Promise.resolve();
-          };
-        }
-        S3.prototype.destroy = function () {};
-        return new S3();
-      },
+    s3 = mockS3({
+      getObject: resolveEmptyMetadata,
+      putObject: () => Promise.resolve(),
+      captureConfig: true,
     });
-    mock('filesystem', {
-      createReadStream: function () {
-        return Readable.from([Buffer.from('mock')]);
-      },
-      readFileSync: async function (data) {
-        return data;
-      },
-    });
-    s3 = require('s3');
-    filesystem = require('filesystem');
-
+    filesystem = mockFilesystem();
     AWS = new SnowflakeS3Util(noProxyConnectionConfig, s3, filesystem);
   });
 
@@ -150,82 +184,28 @@ describe('S3 client', function () {
   });
 
   it('get file header - fail expired token', async function () {
-    mock('s3', {
-      S3: function () {
-        function S3() {
-          this.getObject = function () {
-            const err = new Error();
-            err.Code = 'ExpiredToken';
-            throw err;
-          };
-        }
-        S3.prototype.destroy = function () {};
-        return new S3();
-      },
-    });
-    s3 = require('s3');
+    s3 = mockS3({ getObject: throwWithCode('ExpiredToken') });
     const AWS = new SnowflakeS3Util(noProxyConnectionConfig, s3);
     await AWS.getFileHeader(meta, dataFile);
     assert.strictEqual(meta['resultStatus'], resultStatus.RENEW_TOKEN);
   });
 
   it('get file header - fail no such key', async function () {
-    mock('s3', {
-      S3: function () {
-        function S3() {
-          this.getObject = function () {
-            const err = new Error();
-            err.Code = 'NoSuchKey';
-            throw err;
-          };
-        }
-
-        S3.prototype.destroy = function () {};
-        return new S3();
-      },
-    });
-    s3 = require('s3');
-
+    s3 = mockS3({ getObject: throwWithCode('NoSuchKey') });
     const AWS = new SnowflakeS3Util(noProxyConnectionConfig, s3);
     await AWS.getFileHeader(meta, dataFile);
     assert.strictEqual(meta['resultStatus'], resultStatus.NOT_FOUND_FILE);
   });
 
   it('get file header - fail HTTP 400', async function () {
-    mock('s3', {
-      S3: function () {
-        function S3() {
-          this.getObject = function () {
-            const err = new Error();
-            err.Code = '400';
-            throw err;
-          };
-        }
-        S3.prototype.destroy = function () {};
-        return new S3();
-      },
-    });
-    s3 = require('s3');
+    s3 = mockS3({ getObject: throwWithCode('400') });
     const AWS = new SnowflakeS3Util(noProxyConnectionConfig, s3, filesystem);
     await AWS.getFileHeader(meta, dataFile);
     assert.strictEqual(meta['resultStatus'], resultStatus.RENEW_TOKEN);
   });
 
   it('get file header - fail unknown', async function () {
-    mock('s3', {
-      S3: function () {
-        function S3() {
-          this.getObject = function () {
-            const err = new Error();
-            err.Code = 'unknown';
-            throw err;
-          };
-        }
-        S3.prototype.destroy = function () {};
-        return new S3();
-      },
-    });
-    s3 = require('s3');
+    s3 = mockS3({ getObject: throwWithCode('unknown') });
     const AWS = new SnowflakeS3Util(noProxyConnectionConfig, s3, filesystem);
     await AWS.getFileHeader(meta, dataFile);
     assert.strictEqual(meta['resultStatus'], resultStatus.ERROR);
@@ -238,20 +218,12 @@ describe('S3 client', function () {
 
   it('getFileHeader destroys client after success', async function () {
     let destroyed = false;
-    mock('s3', {
-      S3: function () {
-        function S3() {
-          this.getObject = function () {
-            return Promise.resolve({ Metadata: '' });
-          };
-        }
-        S3.prototype.destroy = function () {
-          destroyed = true;
-        };
-        return new S3();
+    s3 = mockS3({
+      getObject: resolveEmptyMetadata,
+      onDestroy: () => {
+        destroyed = true;
       },
     });
-    s3 = require('s3');
     const client = new SnowflakeS3Util(noProxyConnectionConfig, s3, filesystem);
     await client.getFileHeader(meta, dataFile);
     assert.strictEqual(destroyed, true);
@@ -259,22 +231,12 @@ describe('S3 client', function () {
 
   it('getFileHeader destroys client after error', async function () {
     let destroyed = false;
-    mock('s3', {
-      S3: function () {
-        function S3() {
-          this.getObject = function () {
-            const err = new Error();
-            err.Code = 'ExpiredToken';
-            throw err;
-          };
-        }
-        S3.prototype.destroy = function () {
-          destroyed = true;
-        };
-        return new S3();
+    s3 = mockS3({
+      getObject: throwWithCode('ExpiredToken'),
+      onDestroy: () => {
+        destroyed = true;
       },
     });
-    s3 = require('s3');
     const client = new SnowflakeS3Util(noProxyConnectionConfig, s3);
     await client.getFileHeader(meta, dataFile);
     assert.strictEqual(destroyed, true);
@@ -282,20 +244,12 @@ describe('S3 client', function () {
 
   it('uploadFile destroys client after success', async function () {
     let destroyed = false;
-    mock('s3', {
-      S3: function () {
-        function S3() {
-          this.putObject = function () {
-            return Promise.resolve();
-          };
-        }
-        S3.prototype.destroy = function () {
-          destroyed = true;
-        };
-        return new S3();
+    s3 = mockS3({
+      putObject: () => Promise.resolve(),
+      onDestroy: () => {
+        destroyed = true;
       },
     });
-    s3 = require('s3');
     const client = new SnowflakeS3Util(noProxyConnectionConfig, s3, filesystem);
     await client.uploadFile(dataFile, meta, encryptionMetadata);
     assert.strictEqual(destroyed, true);
@@ -303,22 +257,12 @@ describe('S3 client', function () {
 
   it('uploadFile destroys client after error', async function () {
     let destroyed = false;
-    mock('s3', {
-      S3: function () {
-        function S3() {
-          this.putObject = function () {
-            const err = new Error();
-            err.Code = 'ExpiredToken';
-            throw err;
-          };
-        }
-        S3.prototype.destroy = function () {
-          destroyed = true;
-        };
-        return new S3();
+    s3 = mockS3({
+      putObject: throwWithCode('ExpiredToken'),
+      onDestroy: () => {
+        destroyed = true;
       },
     });
-    s3 = require('s3');
     const client = new SnowflakeS3Util(noProxyConnectionConfig, s3, filesystem);
     await client.uploadFile(dataFile, meta, encryptionMetadata);
     assert.strictEqual(destroyed, true);
@@ -326,36 +270,15 @@ describe('S3 client', function () {
 
   it('nativeDownloadFile destroys client after success', async function () {
     let destroyed = false;
-    mock('s3', {
-      S3: function () {
-        function S3() {
-          this.getObject = function () {
-            return Promise.resolve({
-              $metadata: { httpStatusCode: 200 },
-              Body: {
-                transformToByteArray: function () {
-                  return Promise.resolve(Buffer.from('mock'));
-                },
-              },
-            });
-          };
-        }
-        S3.prototype.destroy = function () {
-          destroyed = true;
-        };
-        return new S3();
+    s3 = mockS3({
+      getObject: resolveDownload,
+      onDestroy: () => {
+        destroyed = true;
       },
     });
-    mock('filesystem', {
-      createReadStream: function () {
-        return Readable.from([Buffer.from('mock')]);
-      },
-      writeFile: function (path, data, encoding, cb) {
-        cb(null);
-      },
+    filesystem = mockFilesystem({
+      writeFile: (path, data, encoding, cb) => cb(null),
     });
-    s3 = require('s3');
-    filesystem = require('filesystem');
     const client = new SnowflakeS3Util(noProxyConnectionConfig, s3, filesystem);
     await client.nativeDownloadFile(meta, '/tmp/mock');
     assert.strictEqual(destroyed, true);
@@ -363,125 +286,45 @@ describe('S3 client', function () {
 
   it('nativeDownloadFile destroys client after error', async function () {
     let destroyed = false;
-    mock('s3', {
-      S3: function () {
-        function S3() {
-          this.getObject = function () {
-            const err = new Error();
-            err.Code = 'ExpiredToken';
-            throw err;
-          };
-        }
-        S3.prototype.destroy = function () {
-          destroyed = true;
-        };
-        return new S3();
+    s3 = mockS3({
+      getObject: throwWithCode('ExpiredToken'),
+      onDestroy: () => {
+        destroyed = true;
       },
     });
-    s3 = require('s3');
     const client = new SnowflakeS3Util(noProxyConnectionConfig, s3);
     await client.nativeDownloadFile(meta, '/tmp/mock');
     assert.strictEqual(destroyed, true);
   });
 
   it('upload - fail expired token', async function () {
-    mock('s3', {
-      S3: function () {
-        function S3() {
-          this.putObject = function () {
-            const err = new Error();
-            err.Code = 'ExpiredToken';
-            throw err;
-          };
-        }
-        S3.prototype.destroy = function () {};
-        return new S3();
-      },
-    });
-    mock('filesystem', {
-      createReadStream: function () {
-        return Readable.from([Buffer.from('mock')]);
-      },
-      readFileSync: async function (data) {
-        return data;
-      },
-    });
-    s3 = require('s3');
-    filesystem = require('filesystem');
+    s3 = mockS3({ putObject: throwWithCode('ExpiredToken') });
+    filesystem = mockFilesystem();
     const AWS = new SnowflakeS3Util(noProxyConnectionConfig, s3, filesystem);
     await AWS.uploadFile(dataFile, meta, encryptionMetadata);
     assert.strictEqual(meta['resultStatus'], resultStatus.RENEW_TOKEN);
   });
 
   it('upload - fail wsaeconnaborted', async function () {
-    mock('s3', {
-      S3: function () {
-        function S3() {
-          this.putObject = function () {
-            const err = new Error();
-            err.Code = '10053';
-            throw err;
-          };
-        }
-        S3.prototype.destroy = function () {};
-        return new S3();
-      },
-    });
-    mock('filesystem', {
-      createReadStream: function () {
-        return Readable.from([Buffer.from('mock')]);
-      },
-      readFileSync: async function (data) {
-        return data;
-      },
-    });
-    s3 = require('s3');
-    filesystem = require('filesystem');
+    s3 = mockS3({ putObject: throwWithCode('10053') });
+    filesystem = mockFilesystem();
     const AWS = new SnowflakeS3Util(noProxyConnectionConfig, s3, filesystem);
     await AWS.uploadFile(dataFile, meta, encryptionMetadata);
     assert.strictEqual(meta['resultStatus'], resultStatus.NEED_RETRY_WITH_LOWER_CONCURRENCY);
   });
 
   it('upload - fail HTTP 400', async function () {
-    mock('s3', {
-      S3: function () {
-        function S3() {
-          this.putObject = function () {
-            const err = new Error();
-            err.Code = '400';
-            throw err;
-          };
-        }
-        S3.prototype.destroy = function () {};
-        return new S3();
-      },
-    });
-    mock('filesystem', {
-      createReadStream: function () {
-        return Readable.from([Buffer.from('mock')]);
-      },
-      readFileSync: async function (data) {
-        return data;
-      },
-    });
-    s3 = require('s3');
-    filesystem = require('filesystem');
+    s3 = mockS3({ putObject: throwWithCode('400') });
+    filesystem = mockFilesystem();
     const AWS = new SnowflakeS3Util(noProxyConnectionConfig, s3, filesystem);
     await AWS.uploadFile(dataFile, meta, encryptionMetadata);
     assert.strictEqual(meta['resultStatus'], resultStatus.NEED_RETRY);
   });
 
   it('proxy configured', async function () {
-    mock('s3', {
-      S3: function (config) {
-        function S3() {
-          this.config = config;
-          this.putObject = function () {};
-        }
-
-        S3.prototype.destroy = function () {};
-        return new S3();
-      },
+    s3 = mockS3({
+      putObject: () => {},
+      captureConfig: true,
     });
     const proxyOptions = {
       host: '127.0.0.1',
@@ -499,7 +342,6 @@ describe('S3 client', function () {
         checkMode: 'DISABLED',
       },
     };
-    s3 = require('s3');
     const AWS = new SnowflakeS3Util(proxyConnectionConfig, s3);
     meta['client'] = AWS.createClient(meta['stageInfo']);
 

--- a/test/unit/file_transfer_agent/s3_test.js
+++ b/test/unit/file_transfer_agent/s3_test.js
@@ -54,6 +54,7 @@ describe('S3 client', function () {
             return Promise.resolve();
           };
         }
+        S3.prototype.destroy = function () {};
         return new S3();
       },
     });
@@ -158,6 +159,7 @@ describe('S3 client', function () {
             throw err;
           };
         }
+        S3.prototype.destroy = function () {};
         return new S3();
       },
     });
@@ -178,6 +180,7 @@ describe('S3 client', function () {
           };
         }
 
+        S3.prototype.destroy = function () {};
         return new S3();
       },
     });
@@ -198,6 +201,7 @@ describe('S3 client', function () {
             throw err;
           };
         }
+        S3.prototype.destroy = function () {};
         return new S3();
       },
     });
@@ -217,6 +221,7 @@ describe('S3 client', function () {
             throw err;
           };
         }
+        S3.prototype.destroy = function () {};
         return new S3();
       },
     });
@@ -231,6 +236,154 @@ describe('S3 client', function () {
     assert.strictEqual(meta['resultStatus'], resultStatus.UPLOADED);
   });
 
+  it('getFileHeader destroys client after success', async function () {
+    let destroyed = false;
+    mock('s3', {
+      S3: function () {
+        function S3() {
+          this.getObject = function () {
+            return Promise.resolve({ Metadata: '' });
+          };
+        }
+        S3.prototype.destroy = function () {
+          destroyed = true;
+        };
+        return new S3();
+      },
+    });
+    s3 = require('s3');
+    const client = new SnowflakeS3Util(noProxyConnectionConfig, s3, filesystem);
+    await client.getFileHeader(meta, dataFile);
+    assert.strictEqual(destroyed, true);
+  });
+
+  it('getFileHeader destroys client after error', async function () {
+    let destroyed = false;
+    mock('s3', {
+      S3: function () {
+        function S3() {
+          this.getObject = function () {
+            const err = new Error();
+            err.Code = 'ExpiredToken';
+            throw err;
+          };
+        }
+        S3.prototype.destroy = function () {
+          destroyed = true;
+        };
+        return new S3();
+      },
+    });
+    s3 = require('s3');
+    const client = new SnowflakeS3Util(noProxyConnectionConfig, s3);
+    await client.getFileHeader(meta, dataFile);
+    assert.strictEqual(destroyed, true);
+  });
+
+  it('uploadFile destroys client after success', async function () {
+    let destroyed = false;
+    mock('s3', {
+      S3: function () {
+        function S3() {
+          this.putObject = function () {
+            return Promise.resolve();
+          };
+        }
+        S3.prototype.destroy = function () {
+          destroyed = true;
+        };
+        return new S3();
+      },
+    });
+    s3 = require('s3');
+    const client = new SnowflakeS3Util(noProxyConnectionConfig, s3, filesystem);
+    await client.uploadFile(dataFile, meta, encryptionMetadata);
+    assert.strictEqual(destroyed, true);
+  });
+
+  it('uploadFile destroys client after error', async function () {
+    let destroyed = false;
+    mock('s3', {
+      S3: function () {
+        function S3() {
+          this.putObject = function () {
+            const err = new Error();
+            err.Code = 'ExpiredToken';
+            throw err;
+          };
+        }
+        S3.prototype.destroy = function () {
+          destroyed = true;
+        };
+        return new S3();
+      },
+    });
+    s3 = require('s3');
+    const client = new SnowflakeS3Util(noProxyConnectionConfig, s3, filesystem);
+    await client.uploadFile(dataFile, meta, encryptionMetadata);
+    assert.strictEqual(destroyed, true);
+  });
+
+  it('nativeDownloadFile destroys client after success', async function () {
+    let destroyed = false;
+    mock('s3', {
+      S3: function () {
+        function S3() {
+          this.getObject = function () {
+            return Promise.resolve({
+              $metadata: { httpStatusCode: 200 },
+              Body: {
+                transformToByteArray: function () {
+                  return Promise.resolve(Buffer.from('mock'));
+                },
+              },
+            });
+          };
+        }
+        S3.prototype.destroy = function () {
+          destroyed = true;
+        };
+        return new S3();
+      },
+    });
+    mock('filesystem', {
+      createReadStream: function () {
+        return Readable.from([Buffer.from('mock')]);
+      },
+      writeFile: function (path, data, encoding, cb) {
+        cb(null);
+      },
+    });
+    s3 = require('s3');
+    filesystem = require('filesystem');
+    const client = new SnowflakeS3Util(noProxyConnectionConfig, s3, filesystem);
+    await client.nativeDownloadFile(meta, '/tmp/mock');
+    assert.strictEqual(destroyed, true);
+  });
+
+  it('nativeDownloadFile destroys client after error', async function () {
+    let destroyed = false;
+    mock('s3', {
+      S3: function () {
+        function S3() {
+          this.getObject = function () {
+            const err = new Error();
+            err.Code = 'ExpiredToken';
+            throw err;
+          };
+        }
+        S3.prototype.destroy = function () {
+          destroyed = true;
+        };
+        return new S3();
+      },
+    });
+    s3 = require('s3');
+    const client = new SnowflakeS3Util(noProxyConnectionConfig, s3);
+    await client.nativeDownloadFile(meta, '/tmp/mock');
+    assert.strictEqual(destroyed, true);
+  });
+
   it('upload - fail expired token', async function () {
     mock('s3', {
       S3: function () {
@@ -241,6 +394,7 @@ describe('S3 client', function () {
             throw err;
           };
         }
+        S3.prototype.destroy = function () {};
         return new S3();
       },
     });
@@ -269,6 +423,7 @@ describe('S3 client', function () {
             throw err;
           };
         }
+        S3.prototype.destroy = function () {};
         return new S3();
       },
     });
@@ -297,6 +452,7 @@ describe('S3 client', function () {
             throw err;
           };
         }
+        S3.prototype.destroy = function () {};
         return new S3();
       },
     });
@@ -323,6 +479,7 @@ describe('S3 client', function () {
           this.putObject = function () {};
         }
 
+        S3.prototype.destroy = function () {};
         return new S3();
       },
     });


### PR DESCRIPTION
### Description

`s3_util.js` creates a new S3 client via `createClient()` in `getFileHeader`, `uploadFileStream`, and `nativeDownloadFile` but never calls `client.destroy()`. Each client holds an HTTPS agent with `keepAlive: true` sockets that accumulate indefinitely, causing monotonic RSS growth and eventual OOMKill on long-lived pods.

This PR wraps each function body in `try { ... } finally { client.destroy() }` to release the HTTPS agent, TLS sockets, and TCP connections immediately after use.

**Design note:** A previous fix (#735) was reverted in #747. That approach changed client lifecycle ownership by reading from `meta['client']` and destroying at the orchestrator level. This PR keeps each function self-contained — `createClient()` and `destroy()` in the same scope, no changes to `file_transfer_agent.js` or `remote_storage_util.js`.

Related: #734

### Checklist

- [x] Create tests which fail without the change (if possible)
- [x] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [ ] Extend the types in index.d.ts file (if necessary) — N/A
- [ ] Extend the README / documentation and ensure is properly displayed (if necessary) — N/A
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message