### PR TITLE
NO-SNOW Improve connection serialization docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 Bugfixes:
 
 - Destroy S3 clients after use in `s3_util.js` (`getFileHeader`, `uploadFileStream`, `nativeDownloadFile`) to prevent keepAlive socket accumulation and memory leak on long-lived pods (snowflakedb/snowflake-connector-nodejs#1403)
+- Fixed `deserializeConnection()` not deriving `accessUrl`/`host` from `account`, causing it to fail with a missing `accessUrl` error when only `account` was provided (snowflakedb/snowflake-connector-nodejs#1406)
 
 ## 2.4.1
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -314,8 +314,36 @@ declare module 'snowflake-sdk' {
      */
     isAnError(): boolean;
 
-    /*
-     * Returns a serialized version of this connection.
+    /**
+     * Returns a JSON-serialized string of the connection state (master/session
+     * tokens and their expiration timestamps). Useful when the same authenticated
+     * session needs to be shared across multiple clients/processes — pair with
+     * {@link deserializeConnection} on the receiving side.
+     *
+     * WARNING: The format of the serialized string is not stable and may change
+     * without notice. We do not guarantee that a serialized string can be shared
+     * across different driver versions; the only guarantee is that a string
+     * produced by {@link serialize} can be passed to {@link deserializeConnection}
+     * on the same driver version.
+     *
+     * The Snowflake backend also alters many behaviors based on driver type and version;
+     * sharing a session with a different driver type or substantially different version
+     * may lead to unexpected bugs.
+     *
+     * @example
+     * // Shape of the returned JSON string (token values redacted):
+     * {
+     *   "services": {
+     *     "sf": {
+     *       "tokenInfo": {
+     *         "masterToken": "...",
+     *         "masterTokenExpirationTime": 1778832267622,
+     *         "sessionToken": "...",
+     *         "sessionTokenExpirationTime": 1778749466622
+     *       }
+     *     }
+     *   }
+     * }
      */
     serialize(): string;
   }
@@ -658,17 +686,30 @@ declare module 'snowflake-sdk' {
   export function normalizeConnectionOptions(options: Record<string, unknown>): ConnectionOptions;
 
   /**
-   * Deserializes a serialized connection.
+   * Functional equivalent of {@link Connection.serialize} — returns the same
+   * JSON-serialized string for the given connection. Use whichever form is
+   * more convenient at the call site.
+   *
+   * See {@link Connection.serialize} for the payload shape and the
+   * unstable-API warning.
+   */
+  export function serializeConnection(connection: Connection): string;
+
+  /**
+   * Rehydrates a connection from the string produced by
+   * {@link serializeConnection} (or {@link Connection.serialize}). The returned
+   * connection reuses the embedded session/master tokens, so it can issue
+   * queries without going through the login flow again — this is the typical
+   * way to share an authenticated session across processes/clients.
+   *
+   * `options` should describe the same Snowflake account the original
+   * connection targeted (e.g. `accessUrl`, `account`); credentials are not
+   * required because the session is already established.
    */
   export function deserializeConnection(
     options: ConnectionOptions,
     serializedConnection: string,
   ): Connection;
-
-  /**
-   * Serializes a given connection.
-   */
-  export function serializeConnection(connection: Connection): string;
 
   /**
    * Configures this instance of the Snowflake core module.

--- a/lib/connection/connection_config.js
+++ b/lib/connection/connection_config.js
@@ -310,6 +310,12 @@ function ConnectionConfig(options, validateCredentials, qaMode, clientInfo) {
 
   consolidateHostAndAccount(options);
 
+  // check for missing account
+  Errors.checkArgumentExists(
+    Util.exists(options.account),
+    ErrorCodes.ERR_CONN_CREATE_MISSING_ACCOUNT,
+  );
+
   // check for missing accessUrl
   Errors.checkArgumentExists(
     Util.exists(options.accessUrl),
@@ -320,12 +326,6 @@ function ConnectionConfig(options, validateCredentials, qaMode, clientInfo) {
   Errors.checkArgumentValid(
     Util.isString(options.accessUrl),
     ErrorCodes.ERR_CONN_CREATE_INVALID_ACCESS_URL,
-  );
-
-  // check for missing account
-  Errors.checkArgumentExists(
-    Util.exists(options.account),
-    ErrorCodes.ERR_CONN_CREATE_MISSING_ACCOUNT,
   );
 
   const proxyHost = options.proxyHost;

--- a/lib/connection/connection_config.js
+++ b/lib/connection/connection_config.js
@@ -155,17 +155,6 @@ function consolidateHostAndAccount(options) {
   }
   options.account = realAccount;
   options.region = realRegion;
-
-  // check for missing accessURL
-  Errors.checkArgumentExists(
-    Util.exists(options.account),
-    ErrorCodes.ERR_CONN_CREATE_MISSING_ACCOUNT,
-  );
-  // check for missing account
-  Errors.checkArgumentExists(
-    Util.exists(options.accessUrl),
-    ErrorCodes.ERR_CONN_CREATE_MISSING_ACCESS_URL,
-  );
 }
 
 /**
@@ -317,9 +306,9 @@ function ConnectionConfig(options, validateCredentials, qaMode, clientInfo) {
         ErrorCodes.ERR_CONN_CREATE_INVALID_OUATH_CLIENT_SECRET,
       );
     }
-
-    consolidateHostAndAccount(options);
   }
+
+  consolidateHostAndAccount(options);
 
   // check for missing accessUrl
   Errors.checkArgumentExists(
@@ -331,6 +320,12 @@ function ConnectionConfig(options, validateCredentials, qaMode, clientInfo) {
   Errors.checkArgumentValid(
     Util.isString(options.accessUrl),
     ErrorCodes.ERR_CONN_CREATE_INVALID_ACCESS_URL,
+  );
+
+  // check for missing account
+  Errors.checkArgumentExists(
+    Util.exists(options.account),
+    ErrorCodes.ERR_CONN_CREATE_MISSING_ACCOUNT,
   );
 
   const proxyHost = options.proxyHost;

--- a/test/integration/testSerializeConnection.ts
+++ b/test/integration/testSerializeConnection.ts
@@ -35,7 +35,7 @@ describe('Connection serialize / deserialize', function () {
 
   it('snowflake.deserializeConnection() rehydrates into a usable Connection', async () => {
     const connection2 = snowflake.deserializeConnection(
-      connOptions,
+      { account: connOptions.account, host: connOptions.host, accessUrl: connOptions.accessUrl },
       snowflake.serializeConnection(connection),
     );
     try {

--- a/test/integration/testSerializeConnection.ts
+++ b/test/integration/testSerializeConnection.ts
@@ -1,6 +1,6 @@
 import assert from 'assert';
 import * as testUtil from './testUtil';
-import { valid as connOption } from './connectionOptions';
+import { valid as connOptions } from './connectionOptions';
 
 const snowflake = require('../../lib/snowflake').default;
 
@@ -35,7 +35,7 @@ describe('Connection serialize / deserialize', function () {
 
   it('snowflake.deserializeConnection() rehydrates into a usable Connection', async () => {
     const connection2 = snowflake.deserializeConnection(
-      connOption,
+      connOptions,
       snowflake.serializeConnection(connection),
     );
     try {

--- a/test/integration/testSerializeConnection.ts
+++ b/test/integration/testSerializeConnection.ts
@@ -1,0 +1,47 @@
+import assert from 'assert';
+import * as testUtil from './testUtil';
+import { valid as connOption } from './connectionOptions';
+
+const snowflake = require('../../lib/snowflake').default;
+
+describe('Connection serialize / deserialize', function () {
+  let connection: any;
+
+  before(async () => {
+    connection = testUtil.createConnection();
+    await testUtil.connectAsync(connection);
+  });
+
+  after(async () => {
+    await testUtil.destroyConnectionAsync(connection);
+  });
+
+  it('connection.serialize() returns a JSON string with services.sf.tokenInfo', () => {
+    const serialized = connection.serialize();
+    assert.strictEqual(typeof serialized, 'string');
+    assert.ok(serialized.length > 0);
+
+    const tokenInfo = JSON.parse(serialized)?.services?.sf?.tokenInfo;
+    assert.ok(tokenInfo, 'expected services.sf.tokenInfo in serialized payload');
+    assert.strictEqual(typeof tokenInfo.masterToken, 'string');
+    assert.strictEqual(typeof tokenInfo.sessionToken, 'string');
+    assert.strictEqual(typeof tokenInfo.masterTokenExpirationTime, 'number');
+    assert.strictEqual(typeof tokenInfo.sessionTokenExpirationTime, 'number');
+  });
+
+  it('snowflake.serializeConnection() returns the same string as connection.serialize()', () => {
+    assert.strictEqual(snowflake.serializeConnection(connection), connection.serialize());
+  });
+
+  it('snowflake.deserializeConnection() rehydrates into a usable Connection', async () => {
+    const connection2 = snowflake.deserializeConnection(
+      connOption,
+      snowflake.serializeConnection(connection),
+    );
+    try {
+      assert.strictEqual(connection2.isUp(), true);
+    } finally {
+      await testUtil.destroyConnectionAsync(connection2);
+    }
+  });
+});


### PR DESCRIPTION
### Description

Improves connection serialization support — both via documentation and a small bugfix in `ConnectionConfig` — and adds integration test coverage for the serialize/deserialize round trip.

**`index.d.ts` — documentation**

- Documented `Connection.serialize()`, `serializeConnection()`, and `deserializeConnection()` with their intended use case (sharing an authenticated session across processes/clients), an example of the JSON payload shape (`services.sf.tokenInfo` with master/session tokens and expirations), and an explicit unstable-format warning (no cross-version / cross-driver guarantees).
- Reordered `serializeConnection` / `deserializeConnection` so the function used first at the call site is declared first.

**`lib/connection/connection_config.js` — bugfix**

- `consolidateHostAndAccount()` (which derives `accessUrl`/`host` from `account` and vice versa) was only invoked when `validateCredentials` was true. `deserializeConnection()` constructs a `ConnectionConfig` with `validateCredentials = false`, so passing only `account` resulted in `ERR_CONN_CREATE_MISSING_ACCESS_URL`. Moved the call out of the `validateCredentials` branch so consolidation always runs.
- Removed the duplicate `accessUrl` / `account` existence checks that lived inside `consolidateHostAndAccount()` — they are already enforced (and now correctly ordered) at the top level of `ConnectionConfig`.

**`test/integration/testSerializeConnection.ts` — new integration test**

- `connection.serialize()` returns a JSON string containing `services.sf.tokenInfo` with the expected token + expiration fields.
- `snowflake.serializeConnection(conn)` matches `conn.serialize()`.
- `snowflake.deserializeConnection()` rehydrates a usable connection (passing only `account` / `host` / `accessUrl`, exercising the bugfix above) and `isUp()` returns `true`.

### Checklist

- [x] Create tests which fail without the change (if possible)
- [x] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [x] Extend the types in index.d.ts file (if necessary)
- [x] Extend the README / documentation and ensure is properly displayed (if necessary)
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message