### PR TITLE
NO-SNOW Fix reauthenticate() for AuthOauthAuthorizationCode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Bugfixes:
 
 - Destroy S3 clients after use in `s3_util.js` (`getFileHeader`, `uploadFileStream`, `nativeDownloadFile`) to prevent keepAlive socket accumulation and memory leak on long-lived pods (snowflakedb/snowflake-connector-nodejs#1403)
 - Fixed `deserializeConnection()` not deriving `accessUrl`/`host` from `account`, causing it to fail with a missing `accessUrl` error when only `account` was provided (snowflakedb/snowflake-connector-nodejs#1406)
-- Fixed `OAUTH_AUTHORIZATION_CODE` opening a browser window on every failed server response (regression from snowflakedb/snowflake-connector-nodejs#1394, causing a browser-popup loop (snowflakedb/snowflake-connector-nodejs#1409)
+- Fixed `OAUTH_AUTHORIZATION_CODE` opening a browser window on every failed server response (regression from snowflakedb/snowflake-connector-nodejs#1394), causing a browser-popup loop (snowflakedb/snowflake-connector-nodejs#1409)
 
 ## 2.4.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Bugfixes:
 
 - Destroy S3 clients after use in `s3_util.js` (`getFileHeader`, `uploadFileStream`, `nativeDownloadFile`) to prevent keepAlive socket accumulation and memory leak on long-lived pods (snowflakedb/snowflake-connector-nodejs#1403)
 - Fixed `deserializeConnection()` not deriving `accessUrl`/`host` from `account`, causing it to fail with a missing `accessUrl` error when only `account` was provided (snowflakedb/snowflake-connector-nodejs#1406)
+- Fixed `OAUTH_AUTHORIZATION_CODE` opening a browser window on every failed server response (regression from snowflakedb/snowflake-connector-nodejs#1394, causing a browser-popup loop (snowflakedb/snowflake-connector-nodejs#1409)
 
 ## 2.4.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Bugfixes:
 
 - Destroy S3 clients after use in `s3_util.js` (`getFileHeader`, `uploadFileStream`, `nativeDownloadFile`) to prevent keepAlive socket accumulation and memory leak on long-lived pods (snowflakedb/snowflake-connector-nodejs#1403)
 - Fixed `deserializeConnection()` not deriving `accessUrl`/`host` from `account`, causing it to fail with a missing `accessUrl` error when only `account` was provided (snowflakedb/snowflake-connector-nodejs#1406)
-- Fixed `OAUTH_AUTHORIZATION_CODE` opening a browser window on every failed server response (regression from snowflakedb/snowflake-connector-nodejs#1394), causing a browser-popup loop (snowflakedb/snowflake-connector-nodejs#1409)
+- Fixed `OAUTH_AUTHORIZATION_CODE` browser-popup loop caused by reauthentication opening a new browser window on every failed server response (regression from snowflakedb/snowflake-connector-nodejs#1394) (snowflakedb/snowflake-connector-nodejs#1409)
 
 ## 2.4.1
 

--- a/lib/authentication/auth_oauth_authorization_code.js
+++ b/lib/authentication/auth_oauth_authorization_code.js
@@ -84,9 +84,14 @@ function AuthOauthAuthorizationCode(connectionConfig, httpClient) {
     );
   };
 
-  this.reauthenticate = async function (body) {
+  // Wipes the cached access token. Called by the connection-failure dispatch
+  // in `sf.js` for every GS `success: false` response so we never resend a
+  // stale access token, regardless of whether a full reauthenticate follows.
+  this.clearAccessTokenCache = async function () {
     await removeFromCache(accessTokenKey);
+  };
 
+  this.reauthenticate = async function (body) {
     const refreshToken = await readCache(refreshTokenKey);
 
     if (refreshToken) {

--- a/lib/services/sf.js
+++ b/lib/services/sf.js
@@ -658,10 +658,24 @@ function StateAbstract(options) {
           if (body && !body.success) {
             const data = body.data;
 
-            if (
-              (body.code === GSErrors.code.ID_TOKEN_INVALID && auth instanceof AuthIDToken) ||
-              auth instanceof AuthOauthAuthorizationCode
-            ) {
+            // NOTE: this dispatch is intentionally hard-coded per auth class
+            // and is not pretty - we accept the spaghetti here because the
+            // whole driver will be replaced by the Universal Driver rewrite.
+            // For AuthOauthAuthorizationCode we always clear the cached access
+            // token on any failed response (so a stale token can't be reused),
+            // but only reauthenticate (which may open a browser window) when
+            // GS specifically reports the OAuth token as expired/invalid.
+            let needsReauth = false;
+            if (auth instanceof AuthIDToken) {
+              needsReauth = body.code === GSErrors.code.ID_TOKEN_INVALID;
+            } else if (auth instanceof AuthOauthAuthorizationCode) {
+              await auth.clearAccessTokenCache();
+              needsReauth =
+                body.code === GSErrors.code.OAUTH_TOKEN_EXPIRED ||
+                body.code === GSErrors.code.OAUTH_TOKEN_INVALID;
+            }
+
+            if (needsReauth) {
               Logger.getInstance().debug(
                 'Authentication rejected by GS (code=%s). Reauthenticating.',
                 body.code,

--- a/test/integration/wiremock/testOauthRefreshToken.js
+++ b/test/integration/wiremock/testOauthRefreshToken.js
@@ -151,6 +151,22 @@ describe('Oauth Refresh token for Autorization Code', function () {
     assert.strictEqual(refreshTokenInCache, 'new_refresh_token');
   });
 
+  it('Surfaces error but clears access token cache on success=false with a non-oauth failure code', async function () {
+    await authUtil.writeToCache(accessTokenKey, 'invalid_token');
+    await authUtil.writeToCache(refreshTokenKey, 'cached_refresh_token');
+    await addWireMockMappingsFromFile(
+      wireMock,
+      'wiremock/mappings/oauth/token_cache_and_refresh/surfaces_error_on_non_oauth_failure_code.json',
+    );
+    await authTest.createConnection(connectionOptionAuthorizationCode);
+    await authTest.connectAsync();
+    authTest.verifyErrorWasThrown('Authentication failed.');
+    const accessTokenInCache = await authUtil.readCache(accessTokenKey);
+    const refreshTokenInCache = await authUtil.readCache(refreshTokenKey);
+    assert.strictEqual(accessTokenInCache, null);
+    assert.strictEqual(refreshTokenInCache, 'cached_refresh_token');
+  });
+
   it('Restart authentication when error during refreshing token', async function () {
     await authUtil.writeToCache(accessTokenKey, 'expired_token');
     await authUtil.writeToCache(refreshTokenKey, 'first_refresh_token');

--- a/wiremock/mappings/oauth/token_cache_and_refresh/reauthenticate_on_invalid_oauth_token.json
+++ b/wiremock/mappings/oauth/token_cache_and_refresh/reauthenticate_on_invalid_oauth_token.json
@@ -29,7 +29,7 @@
             "authnMethod": "OAUTH",
             "signInOptions": {}
           },
-          "code": "123456",
+          "code": "390303",
           "message": "Authentication failed.",
           "success": false,
           "headers": null

--- a/wiremock/mappings/oauth/token_cache_and_refresh/surfaces_error_on_non_oauth_failure_code.json
+++ b/wiremock/mappings/oauth/token_cache_and_refresh/surfaces_error_on_non_oauth_failure_code.json
@@ -1,0 +1,40 @@
+{
+  "mappings": [
+    {
+      "scenarioName": "Surface error on non-oauth failure code",
+      "requiredScenarioState": "Started",
+      "newScenarioState": "Login rejected",
+      "request": {
+        "urlPathPattern": "/session/v1/login-request.*",
+        "method": "POST",
+        "bodyPatterns": [
+          {
+            "equalToJson": {
+              "data": {
+                "TOKEN": "invalid_token"
+              }
+            },
+            "ignoreExtraElements": true
+          }
+        ]
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "jsonBody": {
+          "data": {
+            "nextAction": "RETRY_LOGIN",
+            "authnMethod": "OAUTH",
+            "signInOptions": {}
+          },
+          "code": "123456",
+          "message": "Authentication failed.",
+          "success": false,
+          "headers": null
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
### Description

Fix `OAUTH_AUTHORIZATION_CODE` opening a browser window on every failed GS response, which could cause an endless browser-popup loop. Reauthentication is now gated on GS codes `390303` (`OAUTH_TOKEN_INVALID`) and `390318` (`OAUTH_TOKEN_EXPIRED`); the access-token cache is still cleared on any `success: false` response so a stale token can't be reused. Regression introduced in #1394.

### Checklist

- [x] Create tests which fail without the change (if possible)
- [x] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [x] Extend the types in index.d.ts file (if necessary)
- [x] Extend the README / documentation and ensure is properly displayed (if necessary)
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message