### PR TITLE
NO-SNOW  Fixed platform-detection probe not aborting within 200ms on Bun

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Upcoming Release
 
+Bugfixes:
+
+- Fixed platform-detection probe not aborting within 200ms on Bun (snowflakedb/snowflake-connector-nodejs#1412)
+
 ## 2.4.2
 
 Bugfixes:

--- a/lib/telemetry/platform_detection.ts
+++ b/lib/telemetry/platform_detection.ts
@@ -159,14 +159,14 @@ type HttpRequestResult = {
   body: string;
 };
 
-const IS_BUN = typeof process !== 'undefined' && !!process.versions?.bun;
 function httpRequest(
   url: string,
   signal: AbortSignal,
   headers?: Record<string, string>,
   method: string = 'GET',
 ): Promise<HttpRequestResult> {
-  return IS_BUN
+  const isBun = typeof process !== 'undefined' && !!process.versions?.bun;
+  return isBun
     ? httpRequestFetch(url, signal, headers, method)
     : httpRequestNode(url, signal, headers, method);
 }

--- a/lib/telemetry/platform_detection.ts
+++ b/lib/telemetry/platform_detection.ts
@@ -146,19 +146,52 @@ function envPresent(...envVars: string[]): boolean {
 }
 
 /*
- * We intentionally avoid using fetch() here, since aborting fetch requests
- * can sometimes leave sockets open and prevent the Node.js process from exiting (tested on 22).
+ * Runtime-dispatched HTTP helper.
+ *
+ * - On Node.js, we use node:http: aborting an in-flight fetch in Node can
+ *   leave undici's socket alive, delaying process exit until the request fails (tested on 22 & 24).
+ * - On Bun, we use fetch: Bun's node:http does not handle AbortSignal properly
+ *   during the connect phase. See: https://github.com/oven-sh/bun/issues/31167
  */
+type HttpRequestResult = {
+  ok: boolean;
+  headers: http.IncomingHttpHeaders;
+  body: string;
+};
+
+const IS_BUN = typeof process !== 'undefined' && !!process.versions?.bun;
 function httpRequest(
   url: string,
   signal: AbortSignal,
   headers?: Record<string, string>,
   method: string = 'GET',
-): Promise<{
-  ok: boolean;
-  headers: http.IncomingHttpHeaders;
-  body: string;
-}> {
+): Promise<HttpRequestResult> {
+  return IS_BUN
+    ? httpRequestFetch(url, signal, headers, method)
+    : httpRequestNode(url, signal, headers, method);
+}
+
+async function httpRequestFetch(
+  url: string,
+  signal: AbortSignal,
+  headers: Record<string, string> | undefined,
+  method: string,
+): Promise<HttpRequestResult> {
+  const res = await fetch(url, { method, headers, signal });
+  const body = await res.text();
+  const resHeaders: http.IncomingHttpHeaders = {};
+  res.headers.forEach((value, key) => {
+    resHeaders[key] = value;
+  });
+  return { ok: res.ok, headers: resHeaders, body };
+}
+
+function httpRequestNode(
+  url: string,
+  signal: AbortSignal,
+  headers: Record<string, string> | undefined,
+  method: string,
+): Promise<HttpRequestResult> {
   return new Promise((resolve, reject) => {
     const req = http.request(url, { method, signal, headers }, (res) => {
       let body = '';


### PR DESCRIPTION
### Description

Fixes a bug where the platform-detection telemetry probe could block far beyond its intended 200ms timeout when the connector runs on Bun.

**Root cause:** `httpRequest()` in `lib/telemetry/platform_detection.ts` used `node:http` with an `AbortSignal`. On Bun, `node:http` does not honor `AbortSignal` during the connect phase (see [oven-sh/bun#31167](https://github.com/oven-sh/bun/issues/31167)), so probes to unreachable cloud-metadata endpoints (e.g. `169.254.169.254`) would hang well past the 200ms budget — delaying the first query on connect.

We can't simply switch everything to `fetch` either: on Node.js, aborting an in-flight `fetch` can leave undici's socket alive and delay process exit (tested on Node 22 & 24), which is why `node:http` was chosen originally.

**Fix:** Dispatch the HTTP helper by runtime.

- On **Node.js**, keep using `node:http` (avoids the undici socket-leak / delayed-exit issue).
- On **Bun**, use `fetch` (correctly aborts on `AbortSignal`).

Runtime is detected via `!!process.versions?.bun`. Both code paths return the same `HttpRequestResult` shape, so callers are unchanged.

No public API or behavior change on Node.js; Bun users now see platform detection respect the 200ms timeout.

### Checklist

- [x] Create tests which fail without the change (if possible)
- [x] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [x] Extend the types in index.d.ts file (if necessary) — N/A, internal change
- [x] Extend the README / documentation and ensure is properly displayed (if necessary) — N/A
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message — `NO-SNOW` used per existing commit