### PR TITLE
NO-SNOW Run smoke test for Bun

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -175,7 +175,7 @@ jobs:
 
   test-bun:
     needs: build
-    name: Bun smoke test on Linux
+    name: Bun smoke test on Ubuntu (AWS)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -173,6 +173,31 @@ jobs:
           token: ${{ secrets.CODE_COV_UPLOAD_TOKEN }}
           fail_ci_if_error: true
 
+  test-bun:
+    needs: build
+    name: Bun smoke test on Linux
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.x'
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - name: Download Build Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: artifacts
+          path: artifacts
+      - name: Bun smoke test
+        shell: bash
+        env:
+          PARAMETERS_SECRET: ${{ secrets.PARAMETERS_SECRET }}
+          NODEJS_PRIVATE_KEY_SECRET: ${{ secrets.NODEJS_PRIVATE_KEY_SECRET }}
+          CLOUD_PROVIDER: AWS
+        run: ./ci/test_bun.sh
+
   test-rockylinux9:
     needs: build
     name: ${{ matrix.cloud }} Node.js ${{ matrix.nodeVersion }} on Rocky Linux 9

--- a/ci/container/test_npm_package_bun.ts
+++ b/ci/container/test_npm_package_bun.ts
@@ -1,0 +1,97 @@
+/* oxlint-disable no-console */
+// NOTE:
+// Smoke test executed by Bun against the packed `snowflake-sdk` tarball.
+//
+// We do not run the full mocha test suite on Bun because our unit tests rely on
+// import-mocking libraries (`rewiremock`, `mock-require`) that are not compatible
+// with Bun's module loader. Instead, this single smoke test exercises the most
+// important end-to-end path on Bun:
+//   - import the published package shape (`snowflake-sdk`)
+//   - establish a real connection using the same credentials mocha uses
+//   - run `select 1` and verify the result
+//
+// Connection options are re-derived from `SNOWFLAKE_TEST_*` env vars (the same
+// ones consumed by `test/integration/connectionOptions.js`) rather than imported
+// from that file, so this script has no dependency on the repo source tree and
+// runs against the installed package.
+
+import snowflake from 'snowflake-sdk';
+import assert from 'node:assert/strict';
+
+const protocol = process.env.SNOWFLAKE_TEST_PROTOCOL ?? 'https';
+const account = process.env.SNOWFLAKE_TEST_ACCOUNT;
+if (!account) {
+  throw new Error('SNOWFLAKE_TEST_ACCOUNT is not set');
+}
+const host = process.env.SNOWFLAKE_TEST_HOST ?? `${account}.snowflakecomputing.com`;
+const port = process.env.SNOWFLAKE_TEST_PORT ?? '443';
+const accessUrl = `${protocol}://${host}:${port}`;
+
+const privateKeyPath = process.env.SNOWFLAKE_TEST_PRIVATE_KEY_FILE;
+const keypairOptions = privateKeyPath
+  ? {
+      privateKeyPath,
+      authenticator: process.env.SNOWFLAKE_TEST_AUTHENTICATOR ?? 'SNOWFLAKE_JWT',
+    }
+  : {};
+
+const connection = snowflake.createConnection({
+  accessUrl,
+  username: process.env.SNOWFLAKE_TEST_USER,
+  password: process.env.SNOWFLAKE_TEST_PASSWORD,
+  account,
+  warehouse: process.env.SNOWFLAKE_TEST_WAREHOUSE,
+  database: process.env.SNOWFLAKE_TEST_DATABASE,
+  schema: process.env.SNOWFLAKE_TEST_SCHEMA,
+  role: process.env.SNOWFLAKE_TEST_ROLE,
+  host,
+  ...keypairOptions,
+});
+
+const setupConnection = (): Promise<void> =>
+  new Promise((resolve, reject) => {
+    connection.connect((err) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve();
+      }
+    });
+  });
+
+const executeQuery = (sqlText: string): Promise<unknown[]> =>
+  new Promise((resolve, reject) => {
+    connection.execute({
+      sqlText,
+      complete: (err, _stmt, rows) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(rows ?? []);
+        }
+      },
+    });
+  });
+
+const destroyConnection = (): Promise<void> =>
+  new Promise((resolve, reject) => {
+    connection.destroy((err) => (err ? reject(err) : resolve()));
+  });
+
+(async () => {
+  console.time('[bun-smoke] connect');
+  await setupConnection();
+  console.timeEnd('[bun-smoke] connect');
+  assert.equal(connection.isUp(), true, 'connection should be up after connect()');
+
+  console.time('[bun-smoke] select 1');
+  const rows = await executeQuery('select 1');
+  console.timeEnd('[bun-smoke] select 1');
+  assert.deepStrictEqual(rows, [{ '1': 1 }]);
+
+  console.time('[bun-smoke] destroy');
+  await destroyConnection();
+  console.timeEnd('[bun-smoke] destroy');
+
+  console.log('[bun-smoke] passed');
+})();

--- a/ci/test_bun.sh
+++ b/ci/test_bun.sh
@@ -41,53 +41,21 @@ PACKAGE_NAME=$(cd $WORKSPACE && ls snowflake-sdk*.tgz)
 # Run Bun in an isolated directory OUTSIDE the repo. The repo's tsconfig.json
 # has `paths: { "asn1.js": ["./lib/types/asn1.js.d.ts"] }`, and Bun honors
 # tsconfig `paths` for runtime module resolution. Bun walks UP from the script
-# location looking for a tsconfig.json, so any directory inside $WORKSPACE (=
-# repo root in GHA) inherits that mapping and breaks transitive `require('asn1.js')`
-# calls from asn1.js-rfc5280 / @techteamer/ocsp.
-#
-# Using a temp directory outside $WORKSPACE side-steps the walk-up. We also
-# drop a neutral tsconfig.json next to the test as a belt-and-suspenders guard.
+# location looking for a tsconfig.json, so any directory inside $WORKSPACE
+# (= repo root in GHA) inherits that mapping and breaks transitive
+# `require('asn1.js')` calls from asn1.js-rfc5280 / @techteamer/ocsp.
+# A workdir under /tmp side-steps the walk-up entirely.
 BUN_TEST_DIR=$(mktemp -d -t bun-smoke-XXXXXX)
 echo "[INFO] Bun smoke test workdir: $BUN_TEST_DIR"
 trap "rm -rf $BUN_TEST_DIR" EXIT
 
 cp $SOURCE_ROOT/ci/container/test_npm_package_bun.ts $BUN_TEST_DIR/
 cp $WORKSPACE/${PACKAGE_NAME} $BUN_TEST_DIR/
-
-# Neutral tsconfig that resets `paths` so Bun doesn't pick up anything from
-# parent directories (defense-in-depth; the workdir is already outside the repo).
-cat > $BUN_TEST_DIR/tsconfig.json <<'EOF'
-{
-  "compilerOptions": {
-    "module": "node16",
-    "target": "ES2022",
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "paths": {}
-  }
-}
-EOF
-
 cd $BUN_TEST_DIR
-
-echo "[INFO] === Bun smoke test debug ==="
-echo "[INFO] pwd: $(pwd)"
-echo "[INFO] bun version: $(bun --version)"
-echo "[INFO] node version: $(node --version)"
-echo "[INFO] workdir contents:"
-ls -la
-echo "[INFO] === end debug ==="
 
 echo "[INFO] Installing $PACKAGE_NAME for Bun smoke test"
 npm init -y > /dev/null
 npm install ./${PACKAGE_NAME}
-
-# Sanity-check that `asn1.js` resolves to the real package (lib/asn1.js with
-# `asn1.define = require('./asn1/api').define`) and not to a .d.ts shim.
-echo "[INFO] Resolved asn1.js main:"
-ls -la node_modules/asn1.js/ 2>&1 || echo "[WARN] node_modules/asn1.js not found"
-node -e "console.log('asn1.js define typeof =', typeof require('asn1.js').define)" 2>&1 || true
-bun -e "console.log('bun asn1.js define typeof =', typeof require('asn1.js').define)" 2>&1 || true
 
 echo "[INFO] Running Bun smoke test"
 bun run ./test_npm_package_bun.ts

--- a/ci/test_bun.sh
+++ b/ci/test_bun.sh
@@ -1,0 +1,46 @@
+#!/bin/bash -e
+#
+# Bun smoke test for NodeJS Driver (Linux, GitHub Actions only).
+#
+# Installs the packed snowflake-sdk tarball produced by the build job and runs
+# a single Bun-driven smoke test (ci/container/test_npm_package_bun.ts).
+#
+set -o pipefail
+THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source $THIS_DIR/_init.sh
+source $THIS_DIR/scripts/set_git_info.sh
+
+export WORKSPACE=$GITHUB_WORKSPACE
+export SOURCE_ROOT=$GITHUB_WORKSPACE
+
+# Stage the build artifact (snowflake-sdk-*.tgz) at $WORKSPACE root,
+# matching the layout that ci/container/download_artifact.sh produces for GHA.
+if [[ -e "$WORKSPACE/artifacts/" ]]; then
+    echo "[INFO] cp $WORKSPACE/artifacts/* $WORKSPACE"
+    cp $WORKSPACE/artifacts/* $WORKSPACE
+    ls -l $WORKSPACE
+else
+    echo "[ERROR] No $WORKSPACE/artifacts exists"
+    ls -l $WORKSPACE
+    exit 1
+fi
+
+echo "[INFO] Setting test parameters"
+PARAMETER_FILE=$WORKSPACE/parameters.json
+eval $(jq -r '.testconnection | to_entries | map("export \(.key)=\(.value|tostring)")|.[]' $PARAMETER_FILE)
+
+# Resolve private key path to absolute (mirrors ci/container/test_component.sh)
+if [[ -n "$SNOWFLAKE_TEST_PRIVATE_KEY_FILE" && "$SNOWFLAKE_TEST_PRIVATE_KEY_FILE" != /* ]]; then
+    export SNOWFLAKE_TEST_PRIVATE_KEY_FILE="$WORKSPACE/$SNOWFLAKE_TEST_PRIVATE_KEY_FILE"
+fi
+
+env | grep SNOWFLAKE_ | grep -v -E "(PASS|KEY|SECRET|TOKEN)" | sort
+
+cd $WORKSPACE
+
+PACKAGE_NAME=$(ls snowflake-sdk*.tgz)
+echo "[INFO] Installing $PACKAGE_NAME for Bun smoke test"
+npm install $WORKSPACE/${PACKAGE_NAME}
+
+echo "[INFO] Running Bun smoke test"
+bun run $SOURCE_ROOT/ci/container/test_npm_package_bun.ts

--- a/ci/test_bun.sh
+++ b/ci/test_bun.sh
@@ -38,22 +38,56 @@ env | grep SNOWFLAKE_ | grep -v -E "(PASS|KEY|SECRET|TOKEN)" | sort
 
 PACKAGE_NAME=$(cd $WORKSPACE && ls snowflake-sdk*.tgz)
 
-# Run Bun in an isolated directory containing only the smoke test and an
-# install of the packed snowflake-sdk. The repo's own tsconfig.json has a
-# `paths` entry that remaps `asn1.js` to a local .d.ts shim; Bun honors
-# tsconfig `paths` for runtime module resolution, which breaks transitive
-# imports of the real `asn1.js` package (e.g. asn1.js-rfc5280). Running from
-# a clean directory with no tsconfig.json avoids that.
-BUN_TEST_DIR=$WORKSPACE/bun-smoke
-rm -rf $BUN_TEST_DIR
-mkdir -p $BUN_TEST_DIR
+# Run Bun in an isolated directory OUTSIDE the repo. The repo's tsconfig.json
+# has `paths: { "asn1.js": ["./lib/types/asn1.js.d.ts"] }`, and Bun honors
+# tsconfig `paths` for runtime module resolution. Bun walks UP from the script
+# location looking for a tsconfig.json, so any directory inside $WORKSPACE (=
+# repo root in GHA) inherits that mapping and breaks transitive `require('asn1.js')`
+# calls from asn1.js-rfc5280 / @techteamer/ocsp.
+#
+# Using a temp directory outside $WORKSPACE side-steps the walk-up. We also
+# drop a neutral tsconfig.json next to the test as a belt-and-suspenders guard.
+BUN_TEST_DIR=$(mktemp -d -t bun-smoke-XXXXXX)
+echo "[INFO] Bun smoke test workdir: $BUN_TEST_DIR"
+trap "rm -rf $BUN_TEST_DIR" EXIT
+
 cp $SOURCE_ROOT/ci/container/test_npm_package_bun.ts $BUN_TEST_DIR/
 cp $WORKSPACE/${PACKAGE_NAME} $BUN_TEST_DIR/
+
+# Neutral tsconfig that resets `paths` so Bun doesn't pick up anything from
+# parent directories (defense-in-depth; the workdir is already outside the repo).
+cat > $BUN_TEST_DIR/tsconfig.json <<'EOF'
+{
+  "compilerOptions": {
+    "module": "node16",
+    "target": "ES2022",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "paths": {}
+  }
+}
+EOF
+
 cd $BUN_TEST_DIR
 
-echo "[INFO] Installing $PACKAGE_NAME for Bun smoke test in $BUN_TEST_DIR"
+echo "[INFO] === Bun smoke test debug ==="
+echo "[INFO] pwd: $(pwd)"
+echo "[INFO] bun version: $(bun --version)"
+echo "[INFO] node version: $(node --version)"
+echo "[INFO] workdir contents:"
+ls -la
+echo "[INFO] === end debug ==="
+
+echo "[INFO] Installing $PACKAGE_NAME for Bun smoke test"
 npm init -y > /dev/null
 npm install ./${PACKAGE_NAME}
+
+# Sanity-check that `asn1.js` resolves to the real package (lib/asn1.js with
+# `asn1.define = require('./asn1/api').define`) and not to a .d.ts shim.
+echo "[INFO] Resolved asn1.js main:"
+ls -la node_modules/asn1.js/ 2>&1 || echo "[WARN] node_modules/asn1.js not found"
+node -e "console.log('asn1.js define typeof =', typeof require('asn1.js').define)" 2>&1 || true
+bun -e "console.log('bun asn1.js define typeof =', typeof require('asn1.js').define)" 2>&1 || true
 
 echo "[INFO] Running Bun smoke test"
 bun run ./test_npm_package_bun.ts

--- a/ci/test_bun.sh
+++ b/ci/test_bun.sh
@@ -36,11 +36,24 @@ fi
 
 env | grep SNOWFLAKE_ | grep -v -E "(PASS|KEY|SECRET|TOKEN)" | sort
 
-cd $WORKSPACE
+PACKAGE_NAME=$(cd $WORKSPACE && ls snowflake-sdk*.tgz)
 
-PACKAGE_NAME=$(ls snowflake-sdk*.tgz)
-echo "[INFO] Installing $PACKAGE_NAME for Bun smoke test"
-npm install $WORKSPACE/${PACKAGE_NAME}
+# Run Bun in an isolated directory containing only the smoke test and an
+# install of the packed snowflake-sdk. The repo's own tsconfig.json has a
+# `paths` entry that remaps `asn1.js` to a local .d.ts shim; Bun honors
+# tsconfig `paths` for runtime module resolution, which breaks transitive
+# imports of the real `asn1.js` package (e.g. asn1.js-rfc5280). Running from
+# a clean directory with no tsconfig.json avoids that.
+BUN_TEST_DIR=$WORKSPACE/bun-smoke
+rm -rf $BUN_TEST_DIR
+mkdir -p $BUN_TEST_DIR
+cp $SOURCE_ROOT/ci/container/test_npm_package_bun.ts $BUN_TEST_DIR/
+cp $WORKSPACE/${PACKAGE_NAME} $BUN_TEST_DIR/
+cd $BUN_TEST_DIR
+
+echo "[INFO] Installing $PACKAGE_NAME for Bun smoke test in $BUN_TEST_DIR"
+npm init -y > /dev/null
+npm install ./${PACKAGE_NAME}
 
 echo "[INFO] Running Bun smoke test"
-bun run $SOURCE_ROOT/ci/container/test_npm_package_bun.ts
+bun run ./test_npm_package_bun.ts


### PR DESCRIPTION
### Description

Add a Bun-based smoke test that runs once per CI build on Linux.

We don't run the full mocha suite on Bun because our tests depend on import-mocking libraries (`rewiremock`, `mock-require`) that aren't compatible with Bun's module loader. To still catch breakage when the published `snowflake-sdk` package is consumed by Bun users, this PR adds a single end-to-end smoke test:

- New `ci/container/test_npm_package_bun.ts` — imports `snowflake-sdk` from the packed tarball, connects using the same `SNOWFLAKE_TEST_*` env vars the mocha suite uses, asserts `connection.isUp()` after connect, runs `select 1` and asserts the row, and prints `console.time` durations for connect / select / destroy.
- New `ci/test_bun.sh` — decrypts `parameters.json` (AWS), stages the build artifact, exports the `SNOWFLAKE_TEST_*` env vars, installs the packed tarball, and runs the smoke test via `bun run`.
- New `test-bun` job in `.github/workflows/build-test.yml` — `needs: build`, runs on `ubuntu-latest`, uses `oven-sh/setup-bun@v2` (latest Bun), `CLOUD_PROVIDER=AWS`, no matrix.

### Checklist

- [x] Create tests which fail without the change (if possible)
- [x] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [x] Extend the types in index.d.ts file (if necessary)
- [x] Extend the README / documentation and ensure is properly displayed (if necessary)
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message