### PR TITLE
SNOW-3411971 AWS Outbound Identity Federation Support for WIF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Upcoming Release
 
+Changes:
+
+- Switched AWS Workload Identity attestation to use STS `GetWebIdentityToken` JWTs; no longer uses SigV4 `GetCallerIdentity` envelopes. (snowflakedb/snowflake-connector-nodejs#1415)
+
 Bugfixes:
 
 - Fixed platform-detection probe not aborting within 200ms on Bun (snowflakedb/snowflake-connector-nodejs#1412)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Bugfixes:
 Internal:
 
 - Switched AWS Workload Identity attestation to use STS `GetWebIdentityToken` JWTs; no longer uses SigV4 `GetCallerIdentity` envelopes. (snowflakedb/snowflake-connector-nodejs#1415)
-- Reverted `SESSION_ID_AS_STRING` change from (snowflakedb/snowflake-connector-nodejs#1384) (introduced in 2.4.1) due to compatibility issues with session sharing between drivers (snowflakedb/snowflake-connector-nodejs#1428)
+- Reverted `SESSION_ID_AS_STRING` change from snowflakedb/snowflake-connector-nodejs#1384 (introduced in 2.4.1) due to compatibility issues with session sharing between drivers (snowflakedb/snowflake-connector-nodejs#1428)
 
 ## 2.4.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Bugfixes:
 Internal:
 
 - Switched AWS Workload Identity attestation to use STS `GetWebIdentityToken` JWTs; no longer uses SigV4 `GetCallerIdentity` envelopes. (snowflakedb/snowflake-connector-nodejs#1415)
-- Reverted the change from (snowflakedb/snowflake-connector-nodejs#1384) (introduced in 2.4.1) due to compatibility issues with session sharing between drivers (snowflakedb/snowflake-connector-nodejs#1428)
+- Reverted `SESSION_ID_AS_STRING` change from (snowflakedb/snowflake-connector-nodejs#1384) (introduced in 2.4.1) due to compatibility issues with session sharing between drivers (snowflakedb/snowflake-connector-nodejs#1428)
 
 ## 2.4.3
 

--- a/lib/authentication/auth_workload_identity/attestation_aws.ts
+++ b/lib/authentication/auth_workload_identity/attestation_aws.ts
@@ -59,6 +59,5 @@ export async function getAwsAttestationToken(impersonationPath?: string[]) {
     throw new Error('Failed to obtain AWS web identity token from STS');
   }
 
-  Logger().debug(`AWS outbound token prefix: ${token.slice(0, 10)}`);
   return token;
 }

--- a/lib/authentication/auth_workload_identity/attestation_aws.ts
+++ b/lib/authentication/auth_workload_identity/attestation_aws.ts
@@ -1,9 +1,6 @@
 import { defaultProvider } from '@aws-sdk/credential-provider-node';
-import { STSClient, AssumeRoleCommand } from '@aws-sdk/client-sts';
+import { STSClient, AssumeRoleCommand, GetWebIdentityTokenCommand } from '@aws-sdk/client-sts';
 import { MetadataService } from '@aws-sdk/ec2-metadata-service';
-import { HttpRequest } from '@smithy/protocol-http';
-import { SignatureV4 } from '@smithy/signature-v4';
-import { Sha256 } from '@aws-crypto/sha256-js';
 import Logger from '../../logger';
 
 export async function getAwsCredentials(region: string, impersonationPath: string[] = []) {
@@ -45,42 +42,23 @@ export async function getAwsRegion() {
   }
 }
 
-export function getStsHostname(region: string) {
-  const domain = region.startsWith('cn-') ? 'amazonaws.com.cn' : 'amazonaws.com';
-  return `sts.${region}.${domain}`;
-}
-
 export async function getAwsAttestationToken(impersonationPath?: string[]) {
   const region = await getAwsRegion();
   const credentials = await getAwsCredentials(region, impersonationPath);
 
-  const stsHostname = getStsHostname(region);
-  const request = new HttpRequest({
-    method: 'POST',
-    protocol: 'https',
-    hostname: stsHostname,
-    path: '/',
-    headers: {
-      host: stsHostname,
-      'x-snowflake-audience': 'snowflakecomputing.com',
-    },
-    query: {
-      Action: 'GetCallerIdentity',
-      Version: '2011-06-15',
-    },
-  });
-  const signedRequest = await new SignatureV4({
-    credentials,
-    applyChecksum: false,
-    region,
-    service: 'sts',
-    sha256: Sha256,
-  }).sign(request);
+  const stsClient = new STSClient({ credentials, region });
+  const response = await stsClient.send(
+    new GetWebIdentityTokenCommand({
+      Audience: ['snowflakecomputing.com'],
+      SigningAlgorithm: 'ES384',
+    }),
+  );
 
-  const token = {
-    url: `https://${stsHostname}/?Action=GetCallerIdentity&Version=2011-06-15`,
-    method: 'POST',
-    headers: signedRequest.headers,
-  };
-  return btoa(JSON.stringify(token));
+  const token = response.WebIdentityToken;
+  if (!token) {
+    throw new Error('Failed to obtain AWS web identity token from STS');
+  }
+
+  Logger().debug(`AWS outbound token prefix: ${token.slice(0, 10)}`);
+  return token;
 }

--- a/lib/connection/types.ts
+++ b/lib/connection/types.ts
@@ -223,7 +223,7 @@ export interface WIP_ConnectionOptions {
 
   /**
    * When authenticator=WORKLOAD_IDENTITY, specifies the identity provider. Available options:
-   * * AWS - Uses `@aws-sdk` to find credentials and encodes signed GetCallerIdentity request as token
+   * * AWS - Uses `@aws-sdk` to find credentials and calls STS `GetWebIdentityToken` to obtain a signed JWT token
    * * AZURE - Uses `@azure/identity` to find credentials and get JWT token
    * * GCP - Uses `google-auth-library` to find credentials and get JWT token
    * * OIDC - Reads JWT token from `ConnectionOptions.token`

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@aws-crypto/sha256-js": "^5.2.0",
     "@aws-sdk/client-s3": "~3.1051.0",
     "@aws-sdk/client-sts": "~3.1051.0",
     "@aws-sdk/credential-provider-node": "~3.972.43",
@@ -14,8 +13,6 @@
     "@azure/identity": "^4.10.1",
     "@azure/storage-blob": "12.26.x",
     "@smithy/node-http-handler": "^4.4.9",
-    "@smithy/protocol-http": "^5.3.8",
-    "@smithy/signature-v4": "^5.3.8",
     "@techteamer/ocsp": "1.0.1",
     "asn1.js": "^5.0.0",
     "asn1.js-rfc2560": "^5.0.0",

--- a/test/unit/authentication/auth_workload_identity/attestation_aws_test.ts
+++ b/test/unit/authentication/auth_workload_identity/attestation_aws_test.ts
@@ -2,14 +2,18 @@ import sinon from 'sinon';
 import assert from 'assert';
 import rewiremock from 'rewiremock/node';
 import * as OriginalAttestationAws from '../../../../lib/authentication/auth_workload_identity/attestation_aws';
-import { assertAwsAttestationToken, AWS_CREDENTIALS, AWS_REGION } from './test_utils';
+import { AWS_CREDENTIALS, AWS_REGION, AWS_WEB_IDENTITY_TOKEN } from './test_utils';
+
+class FakeAssumeRoleCommand {}
+class FakeGetWebIdentityTokenCommand {}
 
 describe('Attestation AWS', () => {
   const sinonSandbox = sinon.createSandbox();
   const awsSdkMock = {
     getDefaultCredentials: sinonSandbox.stub(),
     getMetadataRegion: sinonSandbox.stub(),
-    sendStsCommand: sinonSandbox.stub().returns({ Credentials: null }),
+    sendAssumeRole: sinonSandbox.stub().returns({ Credentials: null }),
+    sendGetWebIdentityToken: sinonSandbox.stub(),
   };
   let AttestationAws: typeof OriginalAttestationAws;
   const noCredentialsError = new Error('No credentials found');
@@ -22,9 +26,15 @@ describe('Attestation AWS', () => {
       defaultProvider: () => awsSdkMock.getDefaultCredentials,
     });
     rewiremock('@aws-sdk/client-sts').with({
-      AssumeRoleCommand: class {},
+      AssumeRoleCommand: FakeAssumeRoleCommand,
+      GetWebIdentityTokenCommand: FakeGetWebIdentityTokenCommand,
       STSClient: class {
-        send = () => awsSdkMock.sendStsCommand();
+        send = (command: unknown) => {
+          if (command instanceof FakeGetWebIdentityTokenCommand) {
+            return awsSdkMock.sendGetWebIdentityToken();
+          }
+          return awsSdkMock.sendAssumeRole();
+        };
       },
     });
     rewiremock('@aws-sdk/ec2-metadata-service').with({
@@ -38,8 +48,12 @@ describe('Attestation AWS', () => {
 
   beforeEach(() => {
     sinonSandbox.restore();
+    awsSdkMock.sendAssumeRole.resetHistory();
+    awsSdkMock.sendGetWebIdentityToken.resetHistory();
     awsSdkMock.getDefaultCredentials.throws(noCredentialsError);
     awsSdkMock.getMetadataRegion.throws(noRegionError);
+    awsSdkMock.sendAssumeRole.returns({ Credentials: null });
+    awsSdkMock.sendGetWebIdentityToken.returns({ WebIdentityToken: AWS_WEB_IDENTITY_TOKEN });
   });
 
   after(() => {
@@ -70,7 +84,7 @@ describe('Attestation AWS', () => {
         SecretAccessKey: 'impersonation-secret-access-key',
       };
       awsSdkMock.getDefaultCredentials.returns(AWS_CREDENTIALS);
-      awsSdkMock.sendStsCommand.returns({ Credentials: impersonationCredentials });
+      awsSdkMock.sendAssumeRole.returns({ Credentials: impersonationCredentials });
       assert.deepEqual(await AttestationAws.getAwsCredentials(AWS_REGION, ['impersonation-role']), {
         accessKeyId: impersonationCredentials.AccessKeyId,
         secretAccessKey: impersonationCredentials.SecretAccessKey,
@@ -95,34 +109,45 @@ describe('Attestation AWS', () => {
     });
   });
 
-  describe('getStsHostname', () => {
-    it('returns valid name for china region', () => {
-      assert.strictEqual(
-        AttestationAws.getStsHostname('cn-northwest-1'),
-        'sts.cn-northwest-1.amazonaws.com.cn',
-      );
-    });
-
-    it('returns valid name for non-china region', () => {
-      assert.strictEqual(AttestationAws.getStsHostname('us-east-1'), 'sts.us-east-1.amazonaws.com');
-    });
-  });
-
   describe('getAwsAttestationToken', () => {
     it('throws error when no credentials are found', async () => {
       awsSdkMock.getMetadataRegion.returns(AWS_REGION);
       await assert.rejects(AttestationAws.getAwsAttestationToken(), noCredentialsError);
     });
 
-    it('returns error when no region is found', async () => {
+    it('throws error when no region is found', async () => {
       await assert.rejects(AttestationAws.getAwsAttestationToken(), noRegionError);
     });
 
-    it('returns a valid attestation token', async () => {
+    it('throws error when STS returns no WebIdentityToken', async () => {
+      awsSdkMock.getDefaultCredentials.returns(AWS_CREDENTIALS);
+      awsSdkMock.getMetadataRegion.returns(AWS_REGION);
+      awsSdkMock.sendGetWebIdentityToken.returns({});
+      await assert.rejects(
+        AttestationAws.getAwsAttestationToken(),
+        /Failed to obtain AWS web identity token from STS/,
+      );
+    });
+
+    it('returns the WebIdentityToken JWT from STS', async () => {
       awsSdkMock.getDefaultCredentials.returns(AWS_CREDENTIALS);
       awsSdkMock.getMetadataRegion.returns(AWS_REGION);
       const token = await AttestationAws.getAwsAttestationToken();
-      assertAwsAttestationToken(token, AWS_REGION);
+      assert.strictEqual(token, AWS_WEB_IDENTITY_TOKEN);
+    });
+
+    it('returns the WebIdentityToken JWT when impersonation path is provided', async () => {
+      const impersonationCredentials = {
+        AccessKeyId: 'impersonation-access-key-id',
+        SecretAccessKey: 'impersonation-secret-access-key',
+      };
+      awsSdkMock.getDefaultCredentials.returns(AWS_CREDENTIALS);
+      awsSdkMock.getMetadataRegion.returns(AWS_REGION);
+      awsSdkMock.sendAssumeRole.returns({ Credentials: impersonationCredentials });
+      const token = await AttestationAws.getAwsAttestationToken(['impersonation-role']);
+      assert.strictEqual(token, AWS_WEB_IDENTITY_TOKEN);
+      assert.strictEqual(awsSdkMock.sendAssumeRole.callCount, 1);
+      assert.strictEqual(awsSdkMock.sendGetWebIdentityToken.callCount, 1);
     });
   });
 });

--- a/test/unit/authentication/auth_workload_identity/auth_workload_identity_test.ts
+++ b/test/unit/authentication/auth_workload_identity/auth_workload_identity_test.ts
@@ -7,7 +7,7 @@ import { GoogleAuth } from 'google-auth-library';
 import { WIP_ConnectionConfig, WIP_ConnectionOptions } from '../../../../lib/connection/types';
 import { AuthRequestBody } from '../../../../lib/authentication/types';
 import OriginalAuthWorkloadIdentity from '../../../../lib/authentication/auth_workload_identity';
-import { assertAwsAttestationToken, AWS_CREDENTIALS, AWS_REGION } from './test_utils';
+import { AWS_CREDENTIALS, AWS_REGION, AWS_WEB_IDENTITY_TOKEN } from './test_utils';
 import ConnectionConfig from '../../../../lib/connection/connection_config';
 
 describe('Workload Identity Authentication', async () => {
@@ -15,6 +15,7 @@ describe('Workload Identity Authentication', async () => {
   const awsSdkMock = {
     getCredentials: cloudSdkStubs.stub(),
     getMetadataRegion: cloudSdkStubs.stub(),
+    sendGetWebIdentityToken: cloudSdkStubs.stub(),
   };
   const getAzureTokenMock = cloudSdkStubs.stub();
   const getGcpTokenMock = cloudSdkStubs.stub();
@@ -35,6 +36,13 @@ describe('Workload Identity Authentication', async () => {
     // Sinon can't stub frozen AWS SDK properties, so we need to mock entire require
     rewiremock('@aws-sdk/credential-provider-node').with({
       defaultProvider: () => awsSdkMock.getCredentials,
+    });
+    rewiremock('@aws-sdk/client-sts').with({
+      AssumeRoleCommand: class {},
+      GetWebIdentityTokenCommand: class {},
+      STSClient: class {
+        send = () => awsSdkMock.sendGetWebIdentityToken();
+      },
     });
     rewiremock('@aws-sdk/ec2-metadata-service').with({
       MetadataService: class {
@@ -128,6 +136,10 @@ describe('Workload Identity Authentication', async () => {
       workloadIdentityProvider: 'AWS',
     });
 
+    beforeEach(() => {
+      awsSdkMock.sendGetWebIdentityToken.returns({ WebIdentityToken: AWS_WEB_IDENTITY_TOKEN });
+    });
+
     it('throws error when credentials are not found', async () => {
       const err = new Error('No credentials found');
       awsSdkMock.getCredentials.throws(err);
@@ -144,7 +156,7 @@ describe('Workload Identity Authentication', async () => {
       auth.updateBody(body);
       assert.strictEqual(body.data.AUTHENTICATOR, 'WORKLOAD_IDENTITY');
       assert.strictEqual(body.data.PROVIDER, 'AWS');
-      assertAwsAttestationToken(body.data.TOKEN, AWS_REGION);
+      assert.strictEqual(body.data.TOKEN, AWS_WEB_IDENTITY_TOKEN);
     });
   });
 

--- a/test/unit/authentication/auth_workload_identity/test_utils.ts
+++ b/test/unit/authentication/auth_workload_identity/test_utils.ts
@@ -1,29 +1,7 @@
-import assert from 'assert';
-
 export const AWS_REGION = 'test-region';
 export const AWS_CREDENTIALS = {
   accessKeyId: 'test',
   secretAccessKey: 'test',
   sessionToken: 'test',
 };
-
-export function assertAwsAttestationToken(token: string | null | undefined, region: string) {
-  if (!token) {
-    assert.fail('Token is empty');
-  }
-  const decodedToken = JSON.parse(atob(token));
-  const parsedUrl = new URL(decodedToken.url);
-  assert.strictEqual(parsedUrl.hostname, `sts.${region}.amazonaws.com`);
-  assert.strictEqual(parsedUrl.searchParams.get('Action'), 'GetCallerIdentity');
-  assert.strictEqual(parsedUrl.searchParams.get('Version'), '2011-06-15');
-  assert.strictEqual(decodedToken.method, 'POST');
-  assert.deepStrictEqual(Object.keys(decodedToken.headers), [
-    'host',
-    'x-snowflake-audience',
-    'x-amz-date',
-    'x-amz-security-token',
-    'authorization',
-  ]);
-  assert.strictEqual(decodedToken.headers.host, `sts.${region}.amazonaws.com`);
-  assert.strictEqual(decodedToken.headers['x-snowflake-audience'], 'snowflakecomputing.com');
-}
+export const AWS_WEB_IDENTITY_TOKEN = 'fake.jwt.token-for-testing-only';


### PR DESCRIPTION
### Description

SNOW-3411971: Switch AWS Workload Identity attestation to STS Outbound Identity Federation.

The AWS provider for `WORKLOAD_IDENTITY` previously produced a token by building a SigV4-signed `GetCallerIdentity` HTTP request and base64-encoding the `{url, method, headers}` envelope. This PR replaces that flow with STS's new outbound identity federation, calling `GetWebIdentityToken` and forwarding the signed JWT (audience `snowflakecomputing.com`, `ES384`) directly as the attestation token.

Changes:

- `lib/authentication/auth_workload_identity/attestation_aws.ts`: call `STSClient.send(new GetWebIdentityTokenCommand({ Audience: ['snowflakecomputing.com'], SigningAlgorithm: 'ES384' }))` and return `response.WebIdentityToken`. Throw a clear error if STS returns no token. The impersonation chain (`AssumeRole` hops) is unchanged.
- Removed the now-unused helpers (`getStsHostname`) and the manual SigV4 signing path.
- `package.json`: dropped `@aws-crypto/sha256-js`, `@smithy/protocol-http`, and `@smithy/signature-v4` — no longer imported anywhere.
- Tests:
  - `attestation_aws_test.ts`: rewiremock now exposes both `AssumeRoleCommand` and `GetWebIdentityTokenCommand` as distinct fake classes, with `STSClient.send` dispatching by `instanceof` to per-command stubs. Added cases for the new "no `WebIdentityToken` returned" error and for the JWT being returned both with and without an impersonation path. Removed the obsolete `getStsHostname` suite.
  - `auth_workload_identity_test.ts`: the AWS path now hits STS unconditionally, so the suite mocks `@aws-sdk/client-sts` minimally (returns the JWT). The end-to-end impersonation behavior is covered by `attestation_aws_test.ts` and `test/auth-workload-identity-e2e.ts`, so no duplicate impersonation case was added here.
  - `test_utils.ts`: dropped the `assertAwsAttestationToken` helper (SigV4 envelope assertions no longer apply); added `AWS_WEB_IDENTITY_TOKEN` constant.
- `CHANGELOG.md`: entry under Upcoming Release → Changes.

### Checklist

- [x] Create tests which fail without the change (if possible)
- [x] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [x] Extend the types in index.d.ts file (if necessary) — N/A, no public API changes
- [x] Extend the README / documentation and ensure is properly displayed (if necessary) — N/A; consider updating the stale JSDoc on `workloadIdentityProvider` in `lib/connection/types.ts` (currently still says "encodes signed GetCallerIdentity request as token")
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message (SNOW-3411971)