### PR TITLE
SNOW-3589640 Fix http error being hidden when streaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Upcoming Release
 
-TBA
+Bugfixes:
+
+- Fixed interrupted streaming HTTP responses being treated as successful empty responses instead of errors, which could cause `streamRows()` to hang silently on large result sets (snowflakedb/snowflake-connector-nodejs#1420)
 
 ## 2.4.3
 

--- a/lib/http/base.js
+++ b/lib/http/base.js
@@ -89,7 +89,7 @@ HttpClient.prototype.request = function (options) {
               requestUtil.describeRequestFromOptions(requestOptions),
               err.response.status,
             );
-            options.callback(null, normalizeResponse(err.response), err.response.data);
+            options.callback(err, normalizeResponse(err.response), err.response.data);
           } else {
             Logger.getInstance().trace(
               'Request%s - calling callback function for error without response.',

--- a/lib/http/base.js
+++ b/lib/http/base.js
@@ -82,14 +82,15 @@ HttpClient.prototype.request = function (options) {
         );
         sanitizeAxiosError(err);
         if (Util.isFunction(options.callback)) {
-          if (err.response) {
+          // Partial streaming response might have a status but no data yet
+          if (err.response && err.response.data !== undefined) {
             // axios returns error for not 2xx responses - let's unwrap it
             Logger.getInstance().trace(
               'Request%s - calling callback function for error from response. Received code: ',
               requestUtil.describeRequestFromOptions(requestOptions),
               err.response.status,
             );
-            options.callback(err, normalizeResponse(err.response), err.response.data);
+            options.callback(null, normalizeResponse(err.response), err.response.data);
           } else {
             Logger.getInstance().trace(
               'Request%s - calling callback function for error without response.',

--- a/test/unit/http/base_test.ts
+++ b/test/unit/http/base_test.ts
@@ -1,0 +1,78 @@
+import assert from 'assert';
+import sinon from 'sinon';
+import axios from '../../../lib/http/axios_instance';
+
+const { NodeHttpClient } = require('../../../lib/http/node');
+const ConnectionConfig = require('../../../lib/connection/connection_config');
+
+describe('HttpClient.request error handling', () => {
+  let adapterStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    adapterStub = sinon.stub();
+    sinon.stub(axios.defaults, 'adapter').value(adapterStub);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  function createHttpClient() {
+    const connectionConfig = new ConnectionConfig({
+      username: 'username',
+      password: 'password',
+      account: 'account',
+    });
+    return new NodeHttpClient(connectionConfig);
+  }
+
+  it('invokes the error callback when a streaming response is interrupted (status but no data)', (done) => {
+    // An interrupted streaming response: axios rejects after the status line was
+    // received but before the body arrived, so err.response exists but its data
+    // is undefined. The callback must surface this as an error, not a success.
+    adapterStub.rejects({
+      response: { status: 200, headers: {}, data: undefined },
+      message: 'aborted',
+      code: 'ECONNRESET',
+    });
+
+    createHttpClient().request({
+      method: 'GET',
+      url: 'https://s3.snowflake.com/chunk',
+      callback: (err: unknown, _response: unknown, body: unknown) => {
+        try {
+          assert.ok(err, 'callback must receive an error for an interrupted stream');
+          assert.strictEqual(body, null, 'body must be null when an error is reported');
+          done();
+        } catch (assertionError) {
+          done(assertionError as Error);
+        }
+      },
+    });
+  });
+
+  it('invokes the success callback with the error body when the response has data', (done) => {
+    // A non-2xx response that still carries a body (e.g. S3 returning an XML
+    // error) must keep being unwrapped and delivered as a successful callback.
+    const errorBody = '<Error><Code>AccessDenied</Code></Error>';
+    adapterStub.rejects({
+      response: { status: 403, headers: {}, data: errorBody },
+      message: 'Request failed with status code 403',
+    });
+
+    createHttpClient().request({
+      method: 'GET',
+      url: 'https://s3.snowflake.com/chunk',
+      callback: (err: unknown, response: { statusCode?: number }, body: unknown) => {
+        try {
+          assert.strictEqual(err, null, 'error must be null when a response body is present');
+          assert.strictEqual(body, errorBody, 'the error response body must be passed through');
+          assert.strictEqual(response.statusCode, 403);
+          done();
+        } catch (assertionError) {
+          done(assertionError as Error);
+        }
+      },
+    });
+  });
+});


### PR DESCRIPTION
### Description

Fixes SNOW-3589640 / #1418.

Interrupted streaming HTTP responses were being misreported to callbacks as
successful empty responses instead of errors. In `HttpClient.request`'s error
handler (`lib/http/base.js`), any failure that had an `err.response` was unwrapped
and passed to the callback as a success (`callback(null, response, err.response.data)`).
When a streamed response was interrupted after the status line arrived but before
the body did, `err.response.data` is `undefined`, so the callback received
`err = null` and an `undefined` body.

For large result sets this `undefined` body was stored as the chunk's rowset,
`chunk.getRows()` returned `undefined`, and `row_stream.js` called `.slice()` on it,
throwing a `TypeError`. That throw was then swallowed in `large_result_set.js`, so
the stream never emitted `'error'` or `'end'` — `streamRows()` hung forever.

The fix tightens the condition so an error response is only unwrapped as a
successful body when a body is actually present: the check changes from
`if (err.response)` to `if (err.response && err.response.data !== undefined)`.

Now any interrupted streamed response (status but no data) is routed through the
error path and surfaced to the callback as a real error, so consumers get an
`'error'` event instead of a silent hang. This applies to all callback-based HTTP
requests, not just large-result-set chunk downloads.

Added unit tests in `test/unit/http/base_test.ts`:
- an interrupted streaming response (`err.response` present, `data === undefined`)
  now invokes the callback with an error and a `null` body — this test fails without
  the change;
- a non-2xx response that carries a body (e.g. an S3 XML error) still unwraps the
  body and invokes the callback as a success (regression guard).

### Checklist

- [x] Create tests which fail without the change (if possible)
- [x] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [x]  Extend the types in index.d.ts file (if necessary)
- [x] Extend the README / documentation and ensure is properly displayed (if necessary)
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message