### PR TITLE
SNOW-3607300: fix global url detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ Internal:
 
 - Reverted the change from (snowflakedb/snowflake-connector-nodejs#1384) (introduced in 2.4.1) due to compatibility issues with session sharing between drivers (snowflakedb/snowflake-connector-nodejs#1428)
 
-
 ## 2.4.3
 
 Bugfixes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Bugfixes:
 
-- Fixed global URL detection incorrectly truncating account names containing "global" (e.g. `myorg-global`) (snowflakedb/snowflake-connector-nodejs#XXXX)
+- Fixed global URL detection incorrectly truncating account names containing "global" (e.g. `myorg-global`) (snowflakedb/snowflake-connector-nodejs#1423)
 
 ## 2.4.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Upcoming Release
 
-TBA
+Bugfixes:
+
+- Fixed global URL detection incorrectly truncating account names containing "global" (e.g. `myorg-global`) (snowflakedb/snowflake-connector-nodejs#XXXX)
 
 ## 2.4.3
 

--- a/lib/connection/connection_config.js
+++ b/lib/connection/connection_config.js
@@ -147,7 +147,7 @@ function consolidateHostAndAccount(options) {
     options.accessUrl = Util.format('%s://%s%s', protocol, options.host, port);
   }
 
-  if (Util.exists(realAccount) && options.accessUrl.includes('global.snowflakecomputing')) {
+  if (Util.exists(realAccount) && options.accessUrl.includes('.global.snowflakecomputing.')) {
     const dashPos = realAccount.indexOf('-');
     if (dashPos > 0) {
       // global URL

--- a/test/unit/connection/connection_config_test.js
+++ b/test/unit/connection/connection_config_test.js
@@ -975,6 +975,49 @@ describe('ConnectionConfig: basic', function () {
       },
     },
     {
+      name: 'global url with cn TLD strips org prefix',
+      input: {
+        username: 'username',
+        password: 'password',
+        account: 'myorg-myaccount.cn-northwest-1.global',
+      },
+      options: {
+        accessUrl: 'https://myorg-myaccount.cn-northwest-1.global.snowflakecomputing.cn',
+        username: 'username',
+        password: 'password',
+        account: 'myorg',
+      },
+    },
+    {
+      name: 'account name ending with global does not trigger global URL stripping',
+      input: {
+        username: 'username',
+        password: 'password',
+        account: 'myorg-global',
+      },
+      options: {
+        accessUrl: 'https://myorg-global.snowflakecomputing.com',
+        username: 'username',
+        password: 'password',
+        account: 'myorg-global',
+      },
+    },
+    {
+      name: 'account name ending with global and explicit accessUrl does not trigger global URL stripping',
+      input: {
+        username: 'username',
+        password: 'password',
+        account: 'myorg-global',
+        accessUrl: 'https://myorg-global.snowflakecomputing.com',
+      },
+      options: {
+        accessUrl: 'https://myorg-global.snowflakecomputing.com',
+        username: 'username',
+        password: 'password',
+        account: 'myorg-global',
+      },
+    },
+    {
       name: 'china url with account and cn region',
       input: {
         username: 'username',


### PR DESCRIPTION
## Issue

 in 2024 we changed the global URL check from `endsWith('global.snowflakecomputing.com')` to `includes('global.snowflakecomputing')` to support `.cn` TLDs. This broadened the match to also catch account names ending in `-global`.

## Fix

- Fixed global URL detection in `consolidateHostAndAccount()` incorrectly truncating account identifiers that contain the word "global" (e.g. `myorg-global`). The `includes('global.snowflakecomputing')` substring check was matching standard org URLs like `myorg-global.snowflakecomputing.com`, causing the account to be stripped to `myorg`. Changed to `includes('.global.snowflakecomputing.')` so only actual global deployment URLs (e.g. `myorg-myaccount.global.snowflakecomputing.com`) trigger the dash-stripping logic.
- Added unit tests for the bug scenario and for global URLs with `.cn` TLD.


## Test Plan

- [x] Existing `NOT global url` and `global url` tests still pass
- [x] New test: account name ending with "global" (`myorg-global`) is preserved
- [x] New test: account name ending with "global" with explicit `accessUrl` is preserved
- [x] New test: global URL with `.cn` TLD still correctly strips org prefix