### PR TITLE
SNOW-3580597: remove `SESSION_ID_AS_STRING` capability for now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Internal:
 
-- `sessionId` is again no longer sent as string (pre-2.4.1 behaviour) for the time being (snowflakedb/snowflake-connector-nodejs#XXXX).
+- `sessionId` is again no longer sent as string (pre-2.4.1 behaviour) for the time being (snowflakedb/snowflake-connector-nodejs#1428).
 
 ## 2.4.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Internal:
 
-- `sessionId` is again no longer sent as string (pre-2.4.1 behaviour) for the time being (snowflakedb/snowflake-connector-nodejs#1428).
+- Reverted the change from #1384 (introduced in 2.4.1) due to compatibility issues with session sharing between drivers (see snowflakedb/snowflake-connector-nodejs#1428).
 
 ## 2.4.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Internal:
 
-- Reverted the change from #1384 (introduced in 2.4.1) due to compatibility issues with session sharing between drivers (see snowflakedb/snowflake-connector-nodejs#1428).
+- Reverted the change from (snowflakedb/snowflake-connector-nodejs#1384) (introduced in 2.4.1) due to compatibility issues with session sharing between drivers (snowflakedb/snowflake-connector-nodejs#1428)
 
 ## 2.4.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Upcoming Release
 
-TBA
+Internal:
+
+- `sessionId` is again no longer sent as string (pre-2.4.1 behaviour) for the time being (snowflakedb/snowflake-connector-nodejs#XXXX).
 
 ## 2.4.3
 

--- a/lib/queryContextCache.js
+++ b/lib/queryContextCache.js
@@ -20,7 +20,7 @@ function QueryContextElement(id, timestamp, priority, context) {
 
 /**
  * @param {Number} capacity Maximum capacity of the cache.
- * @param {string} sessionId Session for which the cache is created.
+ * @param {Number} sessionId Session for which the cache is created.
  */
 function QueryContextCache(capacity, sessionId) {
   Logger.getInstance().debug(

--- a/lib/services/sf.js
+++ b/lib/services/sf.js
@@ -179,7 +179,7 @@ function SnowflakeService(connectionConfig, httpClient, config) {
 
   /**
    * Set the session id for the current SnowflakeService
-   * @type {function(string): void}
+   * @type {function(string|number): void}
    */
   this.setSessionId = function (sessionId) {
     this.sessionId = sessionId;
@@ -187,7 +187,7 @@ function SnowflakeService(connectionConfig, httpClient, config) {
 
   /**
    * Get the session id.
-   * @returns {string}
+   * @returns {number}
    */
   this.getSessionId = function () {
     return this.sessionId;
@@ -1103,9 +1103,6 @@ StateConnecting.prototype.continue = async function () {
   const clientInfo = {
     CLIENT_APP_ID: this.connectionConfig.getClientType(),
     CLIENT_APP_VERSION: this.connectionConfig.getClientVersion(),
-    CLIENT_CAPABILITIES: {
-      SESSION_ID_AS_STRING: true,
-    },
     CLIENT_ENVIRONMENT: {
       APPLICATION_PATH: getApplicationPath(),
       CERT_REVOCATION_CHECK_MODE: this.connectionConfig.crlValidatorConfig.checkMode,

--- a/test/unit/mock/mock_http_client.js
+++ b/test/unit/mock/mock_http_client.js
@@ -155,7 +155,6 @@ function serializeRequest(request) {
   // wiremock for better matchers
   delete clonedRequest.useSnowflakeRetryMiddleware;
   if (clonedRequest.json && clonedRequest.json.data) {
-    delete clonedRequest.json.data.CLIENT_CAPABILITIES;
     delete clonedRequest.json.data.CLIENT_ENVIRONMENT;
   }
   return JSON.stringify(clonedRequest);


### PR DESCRIPTION
## Description
This reverts PR 1384 as it led to customer facing regression in use-case where session_id is sent across several layers of Snowflake of one of which is gosnowflake which is not ready to handle string sessionid. This result in actual queries failing. 

This also brings back a possible cosmetic logging issue where the session_id logged (if it's large enough) might not match the real one; which is way less severe than the regression caused by the fix.

Will be addressed in a later release. 

## Fix
Removing the capability and revert type hints.