### PR TITLE
fix: replace hardcoded CRL nextUpdate expiry date in test utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Upcoming Release
 
-TBA
+Internal:
+
+- Fixed CRL validator unit tests failing due to hardcoded `nextUpdate` expiry date; replaced with a dynamic 1-year-from-now value (snowflakedb/snowflake-connector-nodejs#XXXX).
 
 ## 2.4.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Internal:
 
-- Fixed CRL validator unit tests failing due to hardcoded `nextUpdate` expiry date; replaced with a dynamic 1-year-from-now value (snowflakedb/snowflake-connector-nodejs#XXXX).
+- Fixed CRL validator unit tests failing due to hardcoded `nextUpdate` expiry date; replaced with a dynamic 1-year-from-now value (snowflakedb/snowflake-connector-nodejs#1430).
 
 ## 2.4.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,7 @@
 
 ## Upcoming Release
 
-Internal:
-
-- Fixed CRL validator unit tests failing due to hardcoded `nextUpdate` expiry date; replaced with a dynamic 1-year-from-now value (snowflakedb/snowflake-connector-nodejs#1430).
+TBA
 
 ## 2.4.3
 

--- a/test/unit/agent/crl_validator/test_utils.ts
+++ b/test/unit/agent/crl_validator/test_utils.ts
@@ -220,7 +220,7 @@ export function createTestCRL(
     });
   const issuingDistributionPointUrls = options.issuingDistributionPointUrls ?? null;
   const revokedCertificates = options.revokedCertificates ?? ['0'];
-  const nextUpdate = options.nextUpdate ?? new Date('2026-06-08T00:00:00Z').getTime();
+  const nextUpdate = options.nextUpdate ?? Date.now() + 1000 * 60 * 60 * 24 * 365; // 1 year from now
 
   const tbsCertList: rfc5280.TBSCertList = {
     version: new asn1.bignum(1),


### PR DESCRIPTION
### Description

The default nextUpdate in createTestCRL() was hardcoded to 2026-06-08T00:00:00Z, which caused 5 CRL validator unit tests to fail once that date passed. Replaced with Date.now() + 1 year so tests remain valid regardless of when they run.

