### PR TITLE
NO-SNOW Fix LOCAL_FS download path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Upcoming Release
 
+Bugfixes:
+
+- Fixed `LOCAL_FS` stage download writing to the wrong path by using the destination file's base name, consistent with cloud stages (snowflakedb/snowflake-connector-nodejs#1431)
+
 Internal:
 
 - Reverted the change from (snowflakedb/snowflake-connector-nodejs#1384) (introduced in 2.4.1) due to compatibility issues with session sharing between drivers (snowflakedb/snowflake-connector-nodejs#1428)

--- a/lib/file_transfer_agent/local_util.js
+++ b/lib/file_transfer_agent/local_util.js
@@ -3,6 +3,15 @@ const path = require('path');
 const expandTilde = require('expand-tilde');
 const resultStatus = require('../file_util').resultStatus;
 
+/*
+ * NOTE:
+ * LOCAL_FS is a test-only stage type, not usable in real-life deployments.
+ * The backend rejects PUT/GET on LOCAL_FS stages on prod (error 091003: "GET and PUT
+ * commands are not supported with external stage"), so this code path is only exercised
+ * in local GS / test environments. Unlike cloud stages, it performs no
+ * encryption/decryption and simply copies files between two locations on the local disk.
+ */
+
 /**
  * Creates a local utility object.
  *
@@ -70,7 +79,7 @@ function LocalUtil() {
         fs.mkdirSync(meta['localLocation'], { recursive: true });
       }
 
-      output = path.join(meta['localLocation'], meta['dstFileName']);
+      output = path.join(meta['localLocation'], path.basename(meta['dstFileName']));
 
       const writer = fs.createWriteStream(output);
       // Write file


### PR DESCRIPTION
## Summary

Fixes the LOCAL_FS stage download path to use the destination file's base
name, making it consistent with how cloud stages (S3/Azure/GCS) handle output
paths.

Previously, LocalUtil.downloadOneFile joined localLocation with the raw
dstFileName. When dstFileName carried a stage subpath, the file would be
written under an unintended nested directory (and could fail if that directory
didn't exist). Cloud stages already flatten this via path.basename in
remote_storage_util.js; this change brings LOCAL_FS in line.

  - output = path.join(meta['localLocation'], meta['dstFileName']);
  + output = path.join(meta['localLocation'], path.basename(meta['dstFileName']));

Also adds a note documenting that LOCAL_FS is a test-only stage type: the
backend rejects PUT/GET on LOCAL_FS stages in prod (error 091003), so this
path is only exercised in local GS / test environments and performs plain
disk-to-disk copies with no encryption.

## Changes

- lib/file_transfer_agent/local_util.js: use path.basename for the download
  output path; add explanatory note on LOCAL_FS being test-only.
- CHANGELOG.md: add bugfix entry.

## Testing

No tests added. The LOCAL_FS provider isn't covered by any existing tests, and
adding coverage isn't warranted here - it's a test-only stage type that the
backend rejects in real deployments, and proper handling is expected to be
addressed as part of the universal driver work.

### Checklist

- [x] Create tests which fail without the change (if possible)
- [x] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [x] Extend the types in index.d.ts file (if necessary)
- [x] Extend the README / documentation and ensure is properly displayed (if necessary)
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message
