### PR TITLE
NO-SNOW Fix OAUTH_AUTHORIZATION_CODE cache eviction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Bugfixes:
 - Fixed `noProxy` connection option and `NO_PROXY` environment variable not bypassing the proxy for PrivateLink connections (snowflakedb/snowflake-connector-nodejs#1422).
 - Fixed interrupted streaming HTTP responses being treated as successful empty responses instead of errors, which could cause `streamRows()` to hang silently on large result sets (snowflakedb/snowflake-connector-nodejs#1420)
 - Fixed `LOCAL_FS` stage download writing to the wrong path by using the destination file's base name, consistent with cloud stages (snowflakedb/snowflake-connector-nodejs#1431)
+- Fixed `OAUTH_AUTHORIZATION_CODE` cold-connect lockout from a cached invalid refresh token; the bad token is now evicted and the full browser flow restarts (snowflakedb/snowflake-connector-nodejs#1435)
 
 Internal:
 

--- a/lib/authentication/auth_oauth_authorization_code.js
+++ b/lib/authentication/auth_oauth_authorization_code.js
@@ -76,7 +76,22 @@ function AuthOauthAuthorizationCode(connectionConfig, httpClient) {
         if (accessTokenFromCache && connectionConfig.getClientStoreTemporaryCredential()) {
           return accessTokenFromCache;
         } else if (refreshTokenFromCache && connectionConfig.getClientStoreTemporaryCredential()) {
-          return this.getAccessTokenUsingRefreshToken(refreshTokenFromCache);
+          try {
+            return await this.getAccessTokenUsingRefreshToken(refreshTokenFromCache);
+          } catch (error) {
+            // A cached refresh token can be revoked, expired, or already
+            // consumed (single-use). Without eviction the bad token stays in
+            // the cache and every subsequent connect repeats this failure with
+            // no recovery path.
+            await removeFromCache(refreshTokenKey);
+            Logger().warn(
+              format(
+                'Error while getting access token using cached refresh token. Message: %s. The refresh token is removed from cache - authentication will proceed from the beginning',
+                error.message,
+              ),
+            );
+            return this.executeFullAuthorizationCodeFlow();
+          }
         } else {
           return this.executeFullAuthorizationCodeFlow();
         }

--- a/test/integration/wiremock/testOauthRefreshToken.js
+++ b/test/integration/wiremock/testOauthRefreshToken.js
@@ -186,6 +186,25 @@ describe('Oauth Refresh token for Autorization Code', function () {
     assert.strictEqual(refreshTokenInCache, 'new-refresh-token-123');
   });
 
+  it('Restarts full flow on cold connect when only an invalid refresh token is cached', async function () {
+    await authUtil.writeToCache(refreshTokenKey, 'invalid_refresh_token');
+    await addWireMockMappingsFromFile(
+      wireMock,
+      'wiremock/mappings/oauth/token_cache_and_refresh/restarting_full_flow_on_cold_connect_refresh_token_error.json',
+    );
+    await addWireMockMappingsFromFile(wireMock, 'wiremock/mappings/login_request_ok.json');
+    await authTest.createConnection({
+      ...connectionOptionAuthorizationCode,
+      openExternalBrowserCallback: simulateBrowserRedirect,
+    });
+    await authTest.connectAsync();
+    authTest.verifyNoErrorWasThrown();
+    const accessTokenInCache = await authUtil.readCache(accessTokenKey);
+    const refreshTokenInCache = await authUtil.readCache(refreshTokenKey);
+    assert.strictEqual(accessTokenInCache, 'new-refreshed-access-token-123');
+    assert.strictEqual(refreshTokenInCache, 'new-refresh-token-123');
+  });
+
   it('Using cached token for successful authentication ', async function () {
     await authUtil.writeToCache(accessTokenKey, 'reused-access-token-123');
     await addWireMockMappingsFromFile(

--- a/wiremock/mappings/oauth/token_cache_and_refresh/restarting_full_flow_on_cold_connect_refresh_token_error.json
+++ b/wiremock/mappings/oauth/token_cache_and_refresh/restarting_full_flow_on_cold_connect_refresh_token_error.json
@@ -1,0 +1,82 @@
+{
+  "mappings": [
+    {
+      "scenarioName": "Cold connect refresh token error restarts full flow",
+      "newScenarioState": "Refresh token rejected",
+      "request": {
+        "urlPathPattern": "/oauth/token-request.*",
+        "method": "POST",
+        "headers": {
+          "Content-Type": {
+            "contains": "application/x-www-form-urlencoded;charset=UTF-8"
+          }
+        },
+        "formParameters": {
+          "grant_type": {
+            "equalTo": "refresh_token"
+          },
+          "refresh_token": {
+            "equalTo": "invalid_refresh_token"
+          },
+          "client_secret": {
+            "equalTo": "clientSecret"
+          },
+          "client_id": {
+            "equalTo": "123"
+          }
+        }
+      },
+      "response": {
+        "status": 400,
+        "jsonBody": {
+          "error": "invalid_grant",
+          "error_description": "The refresh token is invalid, expired, revoked, or was already used."
+        }
+      }
+    },
+    {
+      "scenarioName": "Cold connect refresh token error restarts full flow",
+      "requiredScenarioState": "Refresh token rejected",
+      "newScenarioState": "Acquired new access token and new refresh token after full flow",
+      "request": {
+        "urlPathPattern": "/oauth/token-request.*",
+        "method": "POST",
+        "headers": {
+          "Content-Type": {
+            "contains": "application/x-www-form-urlencoded;charset=UTF-8"
+          }
+        },
+        "formParameters": {
+          "redirect_uri": {
+            "contains": "snowflake/oauth-redirect"
+          },
+          "code_verifier": {
+            "matches": "[a-zA-Z0-9\\-_]+"
+          },
+          "grant_type": {
+            "equalTo": "authorization_code"
+          },
+          "client_id": {
+            "equalTo": "123"
+          },
+          "client_secret": {
+            "equalTo": "clientSecret"
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "jsonBody": {
+          "access_token": "new-refreshed-access-token-123",
+          "refresh_token": "new-refresh-token-123",
+          "token_type": "Bearer",
+          "expires_in": 599,
+          "idpInitiated": false
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
### Description

Fixes a permanent OAuth lockout in the `OAUTH_AUTHORIZATION_CODE` authenticator (`lib/authentication/auth_oauth_authorization_code.js`).

**Problem:** On a cold connect where only a refresh token is cached (no access token), `authenticate()` calls `getAccessTokenUsingRefreshToken()` with no error handling. If the cached refresh token is invalid — revoked, expired, or single-use already consumed — the refresh request throws, the bad token is never evicted, and the error propagates out of connect. Because the token stays cached, every subsequent connect repeats the same failure and the browser flow is never reopened. The only recovery is manually deleting `credential_cache_v1.json`.

This is inconsistent with the sibling `reauthenticate()` path (used when GS rejects a token mid-login), which already handles refresh failure by evicting the refresh token and restarting authentication.

**Fix:** Mirror `reauthenticate()` in the `authenticate()` refresh branch — wrap the refresh call in try/catch, `removeFromCache(refreshTokenKey)` on failure, and fall back to the full authorization-code (browser) flow. The fallback calls `executeFullAuthorizationCodeFlow()` directly rather than `authenticate()` to avoid re-entering `coordinateAuth()` with the same key, which would deadlock on the in-flight auth promise.

**Tests:** Added a WireMock integration test (`test/integration/wiremock/testOauthRefreshToken.js`) that seeds only an invalid refresh token, asserts the refresh fails, the full flow restarts, and fresh tokens are cached. Verified it fails before the fix and passes after; the full `testOauthRefreshToken.js` suite (10 tests) passes with no regressions.

### Checklist

- [x] Create tests which fail without the change (if possible)
- [x] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [x] Extend the types in index.d.ts file (if necessary)
- [x] Extend the README / documentation and ensure is properly displayed (if necessary)
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message