### PR TITLE
SNOW-3675650: remove util.isString from bind uploader (and add some extra logging)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Bugfixes:
 
-- Fixed the `util.isString` in bind uploader and replaced it with Node 24 compatible method, also added logging to the site which was silently crashing due to this deprecation. Finally, also replaced `util.isArray` in affected tests (snowflakedb/snowflake-connector-nodejs#1436).
+- Removed usage of deprecated `util.isString` to fix Node 24 compatibility. Added additional logging where this caused silent failure (snowflakedb/snowflake-connector-nodejs#1436).
 
 ## 3.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Upcoming Release
 
-- TBA
+Bugfixes:
+
+- Fixed the `util.isString` in bind uploader and replaced it with Node 24 compatible method, also added logging to the site which was silently crashing due to this deprecation. Finally, also replaced `util.isArray` in affected tests (snowflakedb/snowflake-connector-nodejs#XXXX).
 
 ## 3.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Bugfixes:
 
-- Fixed the `util.isString` in bind uploader and replaced it with Node 24 compatible method, also added logging to the site which was silently crashing due to this deprecation. Finally, also replaced `util.isArray` in affected tests (snowflakedb/snowflake-connector-nodejs#XXXX).
+- Fixed the `util.isString` in bind uploader and replaced it with Node 24 compatible method, also added logging to the site which was silently crashing due to this deprecation. Finally, also replaced `util.isArray` in affected tests (snowflakedb/snowflake-connector-nodejs#1436).
 
 ## 3.0.0
 

--- a/lib/connection/bind_uploader.js
+++ b/lib/connection/bind_uploader.js
@@ -1,4 +1,3 @@
-const { isString } = require('util');
 const Logger = require('../logger');
 const Statement = require('./statement');
 
@@ -122,7 +121,7 @@ function BindUploader(options, services, connectionConfig, requestId) {
     if (data.toString() === '') {
       return '""';
     }
-    if (!isString(data)) {
+    if (!(typeof data === 'string')) {
       if (data instanceof Date) {
         data = data.toJSON();
       } else {

--- a/lib/connection/bind_uploader.js
+++ b/lib/connection/bind_uploader.js
@@ -121,7 +121,7 @@ function BindUploader(options, services, connectionConfig, requestId) {
     if (data.toString() === '') {
       return '""';
     }
-    if (!(typeof data === 'string')) {
+    if (typeof data !== 'string') {
       if (data instanceof Date) {
         data = data.toJSON();
       } else {

--- a/lib/connection/statement.js
+++ b/lib/connection/statement.js
@@ -974,6 +974,7 @@ function StageBindingStatementPreExec(statementOptions, context, services, conne
       await bind.Upload(context.binds);
       return createRowStatementPreExec(options, context, services, connectionConfig);
     } catch (error) {
+      Logger.getInstance().warn('Stage binding failed, falling back to inline binds: %s', error);
       context.bindStage = null;
       return createRowStatementPreExec(options, context, services, connectionConfig);
     }

--- a/system_test/testSystemSetWhSnowflakeSupportFlag.js
+++ b/system_test/testSystemSetWhSnowflakeSupportFlag.js
@@ -5,7 +5,6 @@
  */
 const assert = require('assert');
 const async = require('async');
-const util = require('util');
 const snowflake = require('../lib/snowflake').default;
 const connOptions = require('../test/integration/connectionOptions');
 const connOptionsInternal = require('./connectionOptions');
@@ -145,7 +144,7 @@ describe.skip('exclude support warehouses', function () {
       sqlText: sqlText,
       complete: function (err, statement, rows) {
         assert.ok(!err);
-        assert.ok(util.isArray(rows));
+        assert.ok(Array.isArray(rows));
         assert.strictEqual(rows.length, 1);
 
         callback(rows[0].uuid);
@@ -202,7 +201,7 @@ describe.skip('exclude support warehouses', function () {
       sqlText: sqlText,
       complete: function (err, statement, rows) {
         assert.ok(!err);
-        assert.ok(util.isArray(rows));
+        assert.ok(Array.isArray(rows));
         assert.strictEqual(rows.length, 1);
 
         // the value is a string so compare with 'true' to convert to boolean

--- a/test/integration/testBind.js
+++ b/test/integration/testBind.js
@@ -1,7 +1,6 @@
 const async = require('async');
 const assert = require('assert');
 const testUtil = require('./testUtil');
-const util = require('util');
 const sharedStatement = require('./sharedStatements');
 
 describe('Test Bind Varible', function () {
@@ -184,7 +183,7 @@ describe('Test Bind Varible', function () {
             sqlText: 'select * from testTbl where colA is null',
             complete: function (err, statement, rows) {
               assert.ok(!err);
-              assert.ok(util.isArray(rows));
+              assert.ok(Array.isArray(rows));
               assert.ok(rows.length === 1);
               callback();
             },


### PR DESCRIPTION
### Description
Please see the full story in the internal jira, but basically the driver is broken in the following use-case:
* sufficiently big INSERT is used, which exceeds array binding threshold, so driver takes the bind upload path
* node 24 is used

In this case, the INSERT reverts to the non-bind upload path, which technically still works but with performance penalties and taking significantly more time. (In the reproducer which used 325k binds per batch; it took ~29s with node 22 and ~154s with node 24, with changing nothing just the node runtime)

### Root cause
Well, node 24 seems to have finally removed some `util.is*` methods which were [deprecated](https://nodejs.org/docs/latest-v22.x/api/util.html#utilisstringobject) since node 4.  The issue was not very straightforward to troubleshoot since we swallow the error in `StageBindingRequest ` so the only clue (besides the extremely slow  INSERT, that is) was the presence of `context.bindStage = null;` in a situation where everything pointed that there should be a bind stage; as its creation mandatorily precedes the bind upload. 

With adding logs to local reproduction, the error was quite clear:
```
Stage binding failed, falling back to inline binds: 
  TypeError: isString is not a function\\n    
    at BindUploader.csvData (/repro/node_modules/snowflake-sdk/dist/lib/connection/bind_uploader.js:107:14)\\n    
    at BindUploader.Upload (/repro/node_modules/snowflake-sdk/dist/lib/connection/bind_uploader.js:88:36)\\n    
    at process.processTicksAndRejections (node:internal/process/task_queues:104:5)\\n    
    at async StageBinding"}'
```

There's no `util.isString` in node 24 anymore so it was broken (and failed silently). The function is still there in node 22 LTS, although in a deprecated state. 

### Fix
1. replaced the deprecated (22) / non-existent (24) method with the supported version in the bind uploader
2. added logging for easier troubleshooting in case of bind uploader issues
3. found couple stray `util.isArray` in tests, replaced them too

### Tests
After performing the bind uploader fix locally; the performance of the local reproducer with node 24 went back to the node 22 level, and even exceeded it a bit. 