### PR TITLE
 SNOW-3680365 Add connection option for GetWebIdentityToken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,13 @@
 
 ## Upcoming Release
 
+New features:
+
+- Added `workloadIdentityUseAwsOutboundToken` connection option (default `false`) that switches AWS Workload Identity attestation to STS `GetWebIdentityToken` JWTs. This method is recommended and may become the default in a future release (snowflakedb/snowflake-connector-nodejs#TODO)
+
 Bugfixes:
 
+- Reverted the unintentional breaking change from the 3.0.0 release (snowflakedb/snowflake-connector-nodejs#1415) that switched AWS Workload Identity attestation from SigV4 `GetCallerIdentity` to STS `GetWebIdentityToken`. AWS Workload Identity again defaults to `GetCallerIdentity`; the new method is now opt-in via `workloadIdentityUseAwsOutboundToken` (snowflakedb/snowflake-connector-nodejs#TODO)
 - Removed usage of deprecated `util.isString` to fix Node 24 compatibility. Added additional logging where this caused silent failure (snowflakedb/snowflake-connector-nodejs#1436).
 
 ## 3.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 New features:
 
-- Added `workloadIdentityUseAwsOutboundToken` connection option (default `false`) that switches AWS Workload Identity attestation to STS `GetWebIdentityToken` JWTs. This method is recommended and may become the default in a future release (snowflakedb/snowflake-connector-nodejs#TODO)
+- Added `workloadIdentityUseAwsOutboundToken` connection option (default `false`) that switches AWS Workload Identity attestation to STS `GetWebIdentityToken` JWTs. This method is recommended and may become the default in a future release (snowflakedb/snowflake-connector-nodejs#1437)
 
 Bugfixes:
 
-- Reverted the unintentional breaking change from the 3.0.0 release (snowflakedb/snowflake-connector-nodejs#1415) that switched AWS Workload Identity attestation from SigV4 `GetCallerIdentity` to STS `GetWebIdentityToken`. AWS Workload Identity again defaults to `GetCallerIdentity`; the new method is now opt-in via `workloadIdentityUseAwsOutboundToken` (snowflakedb/snowflake-connector-nodejs#TODO)
+- Reverted the unintentional breaking change from the 3.0.0 release (snowflakedb/snowflake-connector-nodejs#1415) that switched AWS Workload Identity attestation from SigV4 `GetCallerIdentity` to STS `GetWebIdentityToken`. AWS Workload Identity again defaults to `GetCallerIdentity`; the new method is now opt-in via `workloadIdentityUseAwsOutboundToken` (snowflakedb/snowflake-connector-nodejs#1437)
 - Removed usage of deprecated `util.isString` to fix Node 24 compatibility. Added additional logging where this caused silent failure (snowflakedb/snowflake-connector-nodejs#1436).
 
 ## 3.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 New features:
 
-- Added `workloadIdentityUseAwsOutboundToken` connection option (default `false`) that switches AWS Workload Identity attestation to STS `GetWebIdentityToken` JWTs. This method is recommended and may become the default in a future release (snowflakedb/snowflake-connector-nodejs#1437)
+- Added `workloadIdentityAwsUseOutboundToken` connection option (default `false`) that switches AWS Workload Identity attestation to STS `GetWebIdentityToken` JWTs. This method is recommended and may become the default in a future release (snowflakedb/snowflake-connector-nodejs#1437)
 
 Bugfixes:
 
-- Reverted the unintentional breaking change from the 3.0.0 release (snowflakedb/snowflake-connector-nodejs#1415) that switched AWS Workload Identity attestation from SigV4 `GetCallerIdentity` to STS `GetWebIdentityToken`. AWS Workload Identity again defaults to `GetCallerIdentity`; the new method is now opt-in via `workloadIdentityUseAwsOutboundToken` (snowflakedb/snowflake-connector-nodejs#1437)
+- Reverted the unintentional breaking change from the 3.0.0 release (snowflakedb/snowflake-connector-nodejs#1415) that switched AWS Workload Identity attestation from SigV4 `GetCallerIdentity` to STS `GetWebIdentityToken`. AWS Workload Identity again defaults to `GetCallerIdentity`; the new method is now opt-in via `workloadIdentityAwsUseOutboundToken` (snowflakedb/snowflake-connector-nodejs#1437)
 - Removed usage of deprecated `util.isString` to fix Node 24 compatibility. Added additional logging where this caused silent failure (snowflakedb/snowflake-connector-nodejs#1436).
 
 ## 3.0.0

--- a/lib/authentication/auth_workload_identity/attestation_aws.ts
+++ b/lib/authentication/auth_workload_identity/attestation_aws.ts
@@ -1,5 +1,5 @@
 import { defaultProvider } from '@aws-sdk/credential-provider-node';
-import { STSClient, AssumeRoleCommand } from '@aws-sdk/client-sts';
+import { STSClient, AssumeRoleCommand, GetWebIdentityTokenCommand } from '@aws-sdk/client-sts';
 import { MetadataService } from '@aws-sdk/ec2-metadata-service';
 import { HttpRequest } from '@smithy/protocol-http';
 import { SignatureV4 } from '@smithy/signature-v4';
@@ -50,10 +50,24 @@ export function getStsHostname(region: string) {
   return `sts.${region}.${domain}`;
 }
 
-export async function getAwsAttestationToken(impersonationPath?: string[]) {
+export async function getAwsAttestationToken(
+  useOutboundToken = false,
+  impersonationPath?: string[],
+) {
   const region = await getAwsRegion();
   const credentials = await getAwsCredentials(region, impersonationPath);
 
+  if (useOutboundToken) {
+    return getOutboundWebIdentityToken(region, credentials);
+  } else {
+    return getCallerIdentityToken(region, credentials);
+  }
+}
+
+async function getCallerIdentityToken(
+  region: string,
+  credentials: Awaited<ReturnType<typeof getAwsCredentials>>,
+) {
   const stsHostname = getStsHostname(region);
   const request = new HttpRequest({
     method: 'POST',
@@ -83,4 +97,24 @@ export async function getAwsAttestationToken(impersonationPath?: string[]) {
     headers: signedRequest.headers,
   };
   return btoa(JSON.stringify(token));
+}
+
+async function getOutboundWebIdentityToken(
+  region: string,
+  credentials: Awaited<ReturnType<typeof getAwsCredentials>>,
+) {
+  const stsClient = new STSClient({ credentials, region });
+  const response = await stsClient.send(
+    new GetWebIdentityTokenCommand({
+      Audience: ['snowflakecomputing.com'],
+      SigningAlgorithm: 'ES384',
+    }),
+  );
+
+  const token = response.WebIdentityToken;
+  if (!token) {
+    throw new Error('Failed to obtain AWS web identity token from STS');
+  }
+
+  return token;
 }

--- a/lib/authentication/auth_workload_identity/attestation_aws.ts
+++ b/lib/authentication/auth_workload_identity/attestation_aws.ts
@@ -1,6 +1,9 @@
 import { defaultProvider } from '@aws-sdk/credential-provider-node';
-import { STSClient, AssumeRoleCommand, GetWebIdentityTokenCommand } from '@aws-sdk/client-sts';
+import { STSClient, AssumeRoleCommand } from '@aws-sdk/client-sts';
 import { MetadataService } from '@aws-sdk/ec2-metadata-service';
+import { HttpRequest } from '@smithy/protocol-http';
+import { SignatureV4 } from '@smithy/signature-v4';
+import { Sha256 } from '@aws-crypto/sha256-js';
 import Logger from '../../logger';
 
 export async function getAwsCredentials(region: string, impersonationPath: string[] = []) {
@@ -42,22 +45,42 @@ export async function getAwsRegion() {
   }
 }
 
+export function getStsHostname(region: string) {
+  const domain = region.startsWith('cn-') ? 'amazonaws.com.cn' : 'amazonaws.com';
+  return `sts.${region}.${domain}`;
+}
+
 export async function getAwsAttestationToken(impersonationPath?: string[]) {
   const region = await getAwsRegion();
   const credentials = await getAwsCredentials(region, impersonationPath);
 
-  const stsClient = new STSClient({ credentials, region });
-  const response = await stsClient.send(
-    new GetWebIdentityTokenCommand({
-      Audience: ['snowflakecomputing.com'],
-      SigningAlgorithm: 'ES384',
-    }),
-  );
+  const stsHostname = getStsHostname(region);
+  const request = new HttpRequest({
+    method: 'POST',
+    protocol: 'https',
+    hostname: stsHostname,
+    path: '/',
+    headers: {
+      host: stsHostname,
+      'x-snowflake-audience': 'snowflakecomputing.com',
+    },
+    query: {
+      Action: 'GetCallerIdentity',
+      Version: '2011-06-15',
+    },
+  });
+  const signedRequest = await new SignatureV4({
+    credentials,
+    applyChecksum: false,
+    region,
+    service: 'sts',
+    sha256: Sha256,
+  }).sign(request);
 
-  const token = response.WebIdentityToken;
-  if (!token) {
-    throw new Error('Failed to obtain AWS web identity token from STS');
-  }
-
-  return token;
+  const token = {
+    url: `https://${stsHostname}/?Action=GetCallerIdentity&Version=2011-06-15`,
+    method: 'POST',
+    headers: signedRequest.headers,
+  };
+  return btoa(JSON.stringify(token));
 }

--- a/lib/authentication/auth_workload_identity/auth_workload_identity.ts
+++ b/lib/authentication/auth_workload_identity/auth_workload_identity.ts
@@ -36,7 +36,10 @@ class AuthWorkloadIdentity implements AuthClass {
     }
 
     if (provider === WorkloadIdentityProvider.AWS) {
-      token = await getAwsAttestationToken(impersonationPath);
+      token = await getAwsAttestationToken(
+        this.connectionConfig.workloadIdentityUseAwsOutboundToken,
+        impersonationPath,
+      );
     } else if (provider === WorkloadIdentityProvider.AZURE) {
       token = await getAzureAttestationToken({
         managedIdentityClientId: this.connectionConfig.workloadIdentityAzureClientId,

--- a/lib/authentication/auth_workload_identity/auth_workload_identity.ts
+++ b/lib/authentication/auth_workload_identity/auth_workload_identity.ts
@@ -37,7 +37,7 @@ class AuthWorkloadIdentity implements AuthClass {
 
     if (provider === WorkloadIdentityProvider.AWS) {
       token = await getAwsAttestationToken(
-        this.connectionConfig.workloadIdentityUseAwsOutboundToken,
+        this.connectionConfig.workloadIdentityAwsUseOutboundToken,
         impersonationPath,
       );
     } else if (provider === WorkloadIdentityProvider.AZURE) {

--- a/lib/connection/connection_config.js
+++ b/lib/connection/connection_config.js
@@ -84,7 +84,7 @@ const DEFAULT_PARAMS = [
   'workloadIdentityImpersonationPath',
   'workloadIdentityAzureEntraIdResource',
   'workloadIdentityAzureClientId',
-  'workloadIdentityUseAwsOutboundToken',
+  'workloadIdentityAwsUseOutboundToken',
   'queryTag',
   'certRevocationCheckMode',
   'crlAllowCertificatesWithoutCrlURL',
@@ -1146,7 +1146,7 @@ function ConnectionConfig(options, validateCredentials, qaMode, clientInfo) {
   this.workloadIdentityImpersonationPath = options.workloadIdentityImpersonationPath;
   this.workloadIdentityAzureEntraIdResource = options.workloadIdentityAzureEntraIdResource;
   this.workloadIdentityAzureClientId = options.workloadIdentityAzureClientId;
-  this.workloadIdentityUseAwsOutboundToken = options.workloadIdentityUseAwsOutboundToken ?? false;
+  this.workloadIdentityAwsUseOutboundToken = options.workloadIdentityAwsUseOutboundToken ?? false;
   this.rowStreamHighWaterMark = options.rowStreamHighWaterMark ?? 10;
   this.crlValidatorConfig = {
     checkMode: options.certRevocationCheckMode ?? 'DISABLED',

--- a/lib/connection/connection_config.js
+++ b/lib/connection/connection_config.js
@@ -84,6 +84,7 @@ const DEFAULT_PARAMS = [
   'workloadIdentityImpersonationPath',
   'workloadIdentityAzureEntraIdResource',
   'workloadIdentityAzureClientId',
+  'workloadIdentityUseAwsOutboundToken',
   'queryTag',
   'certRevocationCheckMode',
   'crlAllowCertificatesWithoutCrlURL',
@@ -1145,6 +1146,7 @@ function ConnectionConfig(options, validateCredentials, qaMode, clientInfo) {
   this.workloadIdentityImpersonationPath = options.workloadIdentityImpersonationPath;
   this.workloadIdentityAzureEntraIdResource = options.workloadIdentityAzureEntraIdResource;
   this.workloadIdentityAzureClientId = options.workloadIdentityAzureClientId;
+  this.workloadIdentityUseAwsOutboundToken = options.workloadIdentityUseAwsOutboundToken ?? false;
   this.rowStreamHighWaterMark = options.rowStreamHighWaterMark ?? 10;
   this.crlValidatorConfig = {
     checkMode: options.certRevocationCheckMode ?? 'DISABLED',

--- a/lib/connection/types.ts
+++ b/lib/connection/types.ts
@@ -274,7 +274,7 @@ export interface WIP_ConnectionOptions {
 
   /**
    * When authenticator=WORKLOAD_IDENTITY, specifies the identity provider. Available options:
-   * * AWS - Uses `@aws-sdk` to find credentials and calls STS `GetWebIdentityToken` to obtain a signed JWT token
+   * * AWS - Uses `@aws-sdk` to find credentials and encodes signed GetCallerIdentity request as token
    * * AZURE - Uses `@azure/identity` to find credentials and get JWT token
    * * GCP - Uses `google-auth-library` to find credentials and get JWT token
    * * OIDC - Reads JWT token from `ConnectionOptions.token`

--- a/lib/connection/types.ts
+++ b/lib/connection/types.ts
@@ -276,7 +276,7 @@ export interface WIP_ConnectionOptions {
    * When authenticator=WORKLOAD_IDENTITY, specifies the identity provider. Available options:
    * * AWS - Uses `@aws-sdk` to find credentials. Supports two attestation methods:
    *   * `GetCallerIdentity` (default) - encodes a SigV4-signed `GetCallerIdentity` request as the token
-   *   * `GetWebIdentityToken` - obtains a signed JWT token, enabled via {@link workloadIdentityUseAwsOutboundToken}
+   *   * `GetWebIdentityToken` - obtains a signed JWT token, enabled via {@link workloadIdentityAwsUseOutboundToken}
    * * AZURE - Uses `@azure/identity` to find credentials and get JWT token
    * * GCP - Uses `google-auth-library` to find credentials and get JWT token
    * * OIDC - Reads JWT token from `ConnectionOptions.token`
@@ -321,7 +321,7 @@ export interface WIP_ConnectionOptions {
    *
    * @default false
    */
-  workloadIdentityUseAwsOutboundToken?: boolean;
+  workloadIdentityAwsUseOutboundToken?: boolean;
 
   /**
    * Enables Certificate Revocation List (CRL) validation.
@@ -442,7 +442,7 @@ export type WIP_ConnectionConfig =
     | 'workloadIdentityImpersonationPath'
     | 'workloadIdentityAzureEntraIdResource'
     | 'workloadIdentityAzureClientId'
-    | 'workloadIdentityUseAwsOutboundToken'
+    | 'workloadIdentityAwsUseOutboundToken'
     | 'oauthEnableSingleUseRefreshTokens'
     | 'rowStreamHighWaterMark'
   > & {

--- a/lib/connection/types.ts
+++ b/lib/connection/types.ts
@@ -274,7 +274,9 @@ export interface WIP_ConnectionOptions {
 
   /**
    * When authenticator=WORKLOAD_IDENTITY, specifies the identity provider. Available options:
-   * * AWS - Uses `@aws-sdk` to find credentials and encodes signed GetCallerIdentity request as token
+   * * AWS - Uses `@aws-sdk` to find credentials. Supports two attestation methods:
+   *   * `GetCallerIdentity` (default) - encodes a SigV4-signed `GetCallerIdentity` request as the token
+   *   * `GetWebIdentityToken` - obtains a signed JWT token, enabled via {@link workloadIdentityUseAwsOutboundToken}
    * * AZURE - Uses `@azure/identity` to find credentials and get JWT token
    * * GCP - Uses `google-auth-library` to find credentials and get JWT token
    * * OIDC - Reads JWT token from `ConnectionOptions.token`
@@ -299,6 +301,27 @@ export interface WIP_ConnectionOptions {
    * When workloadIdentityProvider=AZURE, customize Azure Managed Identity Client Id
    */
   workloadIdentityAzureClientId?: string;
+
+  /**
+   * When workloadIdentityProvider=AWS, selects the AWS attestation method.
+   *
+   * AWS WIF supports two methods:
+   * * `GetCallerIdentity` (default, `false`) - the connector encodes a SigV4-signed
+   *   `GetCallerIdentity` request as the attestation token.
+   * * `GetWebIdentityToken` (`true`) - the connector calls STS `GetWebIdentityToken` and
+   *   forwards a standards-based JWT instead. This provides stateless token verification and
+   *   compatibility with AWS outbound identity federation. It requires the AWS IAM role to have
+   *   `sts:GetWebIdentityToken` permission and the Snowflake service user to be configured with an
+   *   `ISSUER`.
+   *
+   * The `GetWebIdentityToken` method is recommended and may become the default in a future release.
+   *
+   * See {@link https://docs.snowflake.com/en/user-guide/workload-identity-federation#label-wif-aws-upgrade-jwt}
+   * for setup instructions, including the Node.js connector configuration.
+   *
+   * @default false
+   */
+  workloadIdentityUseAwsOutboundToken?: boolean;
 
   /**
    * Enables Certificate Revocation List (CRL) validation.
@@ -419,6 +442,7 @@ export type WIP_ConnectionConfig =
     | 'workloadIdentityImpersonationPath'
     | 'workloadIdentityAzureEntraIdResource'
     | 'workloadIdentityAzureClientId'
+    | 'workloadIdentityUseAwsOutboundToken'
     | 'oauthEnableSingleUseRefreshTokens'
     | 'rowStreamHighWaterMark'
   > & {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "node": ">=20"
   },
   "dependencies": {
+    "@aws-crypto/sha256-js": "^5.2.0",
     "@aws-sdk/client-s3": "^3.1051.0",
     "@aws-sdk/client-sts": "^3.1051.0",
     "@aws-sdk/credential-provider-node": "^3.972.43",
@@ -13,6 +14,8 @@
     "@azure/identity": "^4.10.1",
     "@azure/storage-blob": "12.26.x",
     "@smithy/node-http-handler": "^4.4.9",
+    "@smithy/protocol-http": "^5.3.8",
+    "@smithy/signature-v4": "^5.3.8",
     "@techteamer/ocsp": "1.0.1",
     "asn1.js": "^5.0.0",
     "asn1.js-rfc2560": "^5.0.0",

--- a/test/auth-workload-identity-e2e.ts
+++ b/test/auth-workload-identity-e2e.ts
@@ -32,14 +32,20 @@ describe('Workload Identity Authentication E2E', () => {
 
   // NOTE:
   // AWS WIF supports two attestation methods: GetCallerIdentity (default) and
-  // GetWebIdentityToken (outbound, enabled via workloadIdentityUseAwsOutboundToken).
-  // The test above covers the default GetCallerIdentity method against SNOWFLAKE_TEST_WIF_USERNAME.
-  // This test covers the outbound token method, which maps to a distinct ISSUER-configured user.
+  // GetWebIdentityToken (enabled via workloadIdentityUseAwsOutboundToken).
+  // This test covers the GetCallerIdentity method against the dedicated
+  // TEST_WIF_E2E_AWS_WITH_ISSUER Snowflake user. Since an EC2 instance can only have one
+  // IAM role, the test impersonates a dedicated role that maps to that user.
   if (provider === 'AWS') {
-    it('connects using AWS outbound token', async () => {
+    it('connects using GetCallerIdentity', async () => {
       await connectAndVerify(
-        { ...connectionOptions, workloadIdentityUseAwsOutboundToken: true },
-        'TEST_WIF_E2E_AWS_OUTBOUND',
+        {
+          ...connectionOptions,
+          workloadIdentityImpersonationPath: [
+            'arn:aws:iam::376129840140:role/drivers-wif-automated-tests-with-issuer',
+          ],
+        },
+        'TEST_WIF_E2E_AWS_WITH_ISSUER',
       );
     });
   }

--- a/test/auth-workload-identity-e2e.ts
+++ b/test/auth-workload-identity-e2e.ts
@@ -30,6 +30,20 @@ describe('Workload Identity Authentication E2E', () => {
     await connectAndVerify(connectionOptions, expectedUsername);
   });
 
+  // NOTE:
+  // AWS WIF supports two attestation methods: GetCallerIdentity (default) and
+  // GetWebIdentityToken (outbound, enabled via workloadIdentityUseAwsOutboundToken).
+  // The test above covers the default GetCallerIdentity method against SNOWFLAKE_TEST_WIF_USERNAME.
+  // This test covers the outbound token method, which maps to a distinct ISSUER-configured user.
+  if (provider === 'AWS') {
+    it('connects using AWS outbound token', async () => {
+      await connectAndVerify(
+        { ...connectionOptions, workloadIdentityUseAwsOutboundToken: true },
+        'TEST_WIF_E2E_AWS_OUTBOUND',
+      );
+    });
+  }
+
   if (provider === 'AWS' || provider === 'GCP') {
     it('connects using transitive impersonation', async () => {
       const impersonationPath = getValueFromEnv('SNOWFLAKE_TEST_WIF_IMPERSONATION_PATH').split(',');

--- a/test/auth-workload-identity-e2e.ts
+++ b/test/auth-workload-identity-e2e.ts
@@ -31,7 +31,7 @@ describe('Workload Identity Authentication E2E', () => {
   });
 
   // AWS WIF supports two attestation methods: GetCallerIdentity (default) and
-  // GetWebIdentityToken (enabled via workloadIdentityUseAwsOutboundToken).
+  // GetWebIdentityToken (enabled via workloadIdentityAwsUseOutboundToken).
   // This test covers the GetWebIdentityToken method against the dedicated
   // TEST_WIF_E2E_AWS_WITH_ISSUER Snowflake user (configured with an ISSUER). Since an EC2 instance
   // can only have one IAM role, the test impersonates a dedicated role that maps to that user.
@@ -40,7 +40,7 @@ describe('Workload Identity Authentication E2E', () => {
       await connectAndVerify(
         {
           ...connectionOptions,
-          workloadIdentityUseAwsOutboundToken: true,
+          workloadIdentityAwsUseOutboundToken: true,
           workloadIdentityImpersonationPath: [
             'arn:aws:iam::376129840140:role/drivers-wif-automated-tests-with-issuer',
           ],

--- a/test/auth-workload-identity-e2e.ts
+++ b/test/auth-workload-identity-e2e.ts
@@ -30,17 +30,17 @@ describe('Workload Identity Authentication E2E', () => {
     await connectAndVerify(connectionOptions, expectedUsername);
   });
 
-  // NOTE:
   // AWS WIF supports two attestation methods: GetCallerIdentity (default) and
   // GetWebIdentityToken (enabled via workloadIdentityUseAwsOutboundToken).
-  // This test covers the GetCallerIdentity method against the dedicated
-  // TEST_WIF_E2E_AWS_WITH_ISSUER Snowflake user. Since an EC2 instance can only have one
-  // IAM role, the test impersonates a dedicated role that maps to that user.
+  // This test covers the GetWebIdentityToken method against the dedicated
+  // TEST_WIF_E2E_AWS_WITH_ISSUER Snowflake user (configured with an ISSUER). Since an EC2 instance
+  // can only have one IAM role, the test impersonates a dedicated role that maps to that user.
   if (provider === 'AWS') {
-    it('connects using GetCallerIdentity', async () => {
+    it('connects using GetWebIdentityToken', async () => {
       await connectAndVerify(
         {
           ...connectionOptions,
+          workloadIdentityUseAwsOutboundToken: true,
           workloadIdentityImpersonationPath: [
             'arn:aws:iam::376129840140:role/drivers-wif-automated-tests-with-issuer',
           ],

--- a/test/unit/authentication/auth_workload_identity/attestation_aws_test.ts
+++ b/test/unit/authentication/auth_workload_identity/attestation_aws_test.ts
@@ -2,18 +2,14 @@ import sinon from 'sinon';
 import assert from 'assert';
 import rewiremock from 'rewiremock/node';
 import * as OriginalAttestationAws from '../../../../lib/authentication/auth_workload_identity/attestation_aws';
-import { AWS_CREDENTIALS, AWS_REGION, AWS_WEB_IDENTITY_TOKEN } from './test_utils';
-
-class FakeAssumeRoleCommand {}
-class FakeGetWebIdentityTokenCommand {}
+import { assertAwsAttestationToken, AWS_CREDENTIALS, AWS_REGION } from './test_utils';
 
 describe('Attestation AWS', () => {
   const sinonSandbox = sinon.createSandbox();
   const awsSdkMock = {
     getDefaultCredentials: sinonSandbox.stub(),
     getMetadataRegion: sinonSandbox.stub(),
-    sendAssumeRole: sinonSandbox.stub().returns({ Credentials: null }),
-    sendGetWebIdentityToken: sinonSandbox.stub(),
+    sendStsCommand: sinonSandbox.stub().returns({ Credentials: null }),
   };
   let AttestationAws: typeof OriginalAttestationAws;
   const noCredentialsError = new Error('No credentials found');
@@ -26,15 +22,9 @@ describe('Attestation AWS', () => {
       defaultProvider: () => awsSdkMock.getDefaultCredentials,
     });
     rewiremock('@aws-sdk/client-sts').with({
-      AssumeRoleCommand: FakeAssumeRoleCommand,
-      GetWebIdentityTokenCommand: FakeGetWebIdentityTokenCommand,
+      AssumeRoleCommand: class {},
       STSClient: class {
-        send = (command: unknown) => {
-          if (command instanceof FakeGetWebIdentityTokenCommand) {
-            return awsSdkMock.sendGetWebIdentityToken();
-          }
-          return awsSdkMock.sendAssumeRole();
-        };
+        send = () => awsSdkMock.sendStsCommand();
       },
     });
     rewiremock('@aws-sdk/ec2-metadata-service').with({
@@ -48,12 +38,8 @@ describe('Attestation AWS', () => {
 
   beforeEach(() => {
     sinonSandbox.restore();
-    awsSdkMock.sendAssumeRole.resetHistory();
-    awsSdkMock.sendGetWebIdentityToken.resetHistory();
     awsSdkMock.getDefaultCredentials.throws(noCredentialsError);
     awsSdkMock.getMetadataRegion.throws(noRegionError);
-    awsSdkMock.sendAssumeRole.returns({ Credentials: null });
-    awsSdkMock.sendGetWebIdentityToken.returns({ WebIdentityToken: AWS_WEB_IDENTITY_TOKEN });
   });
 
   after(() => {
@@ -84,7 +70,7 @@ describe('Attestation AWS', () => {
         SecretAccessKey: 'impersonation-secret-access-key',
       };
       awsSdkMock.getDefaultCredentials.returns(AWS_CREDENTIALS);
-      awsSdkMock.sendAssumeRole.returns({ Credentials: impersonationCredentials });
+      awsSdkMock.sendStsCommand.returns({ Credentials: impersonationCredentials });
       assert.deepEqual(await AttestationAws.getAwsCredentials(AWS_REGION, ['impersonation-role']), {
         accessKeyId: impersonationCredentials.AccessKeyId,
         secretAccessKey: impersonationCredentials.SecretAccessKey,
@@ -109,45 +95,34 @@ describe('Attestation AWS', () => {
     });
   });
 
+  describe('getStsHostname', () => {
+    it('returns valid name for china region', () => {
+      assert.strictEqual(
+        AttestationAws.getStsHostname('cn-northwest-1'),
+        'sts.cn-northwest-1.amazonaws.com.cn',
+      );
+    });
+
+    it('returns valid name for non-china region', () => {
+      assert.strictEqual(AttestationAws.getStsHostname('us-east-1'), 'sts.us-east-1.amazonaws.com');
+    });
+  });
+
   describe('getAwsAttestationToken', () => {
     it('throws error when no credentials are found', async () => {
       awsSdkMock.getMetadataRegion.returns(AWS_REGION);
       await assert.rejects(AttestationAws.getAwsAttestationToken(), noCredentialsError);
     });
 
-    it('throws error when no region is found', async () => {
+    it('returns error when no region is found', async () => {
       await assert.rejects(AttestationAws.getAwsAttestationToken(), noRegionError);
     });
 
-    it('throws error when STS returns no WebIdentityToken', async () => {
-      awsSdkMock.getDefaultCredentials.returns(AWS_CREDENTIALS);
-      awsSdkMock.getMetadataRegion.returns(AWS_REGION);
-      awsSdkMock.sendGetWebIdentityToken.returns({});
-      await assert.rejects(
-        AttestationAws.getAwsAttestationToken(),
-        /Failed to obtain AWS web identity token from STS/,
-      );
-    });
-
-    it('returns the WebIdentityToken JWT from STS', async () => {
+    it('returns a valid attestation token', async () => {
       awsSdkMock.getDefaultCredentials.returns(AWS_CREDENTIALS);
       awsSdkMock.getMetadataRegion.returns(AWS_REGION);
       const token = await AttestationAws.getAwsAttestationToken();
-      assert.strictEqual(token, AWS_WEB_IDENTITY_TOKEN);
-    });
-
-    it('returns the WebIdentityToken JWT when impersonation path is provided', async () => {
-      const impersonationCredentials = {
-        AccessKeyId: 'impersonation-access-key-id',
-        SecretAccessKey: 'impersonation-secret-access-key',
-      };
-      awsSdkMock.getDefaultCredentials.returns(AWS_CREDENTIALS);
-      awsSdkMock.getMetadataRegion.returns(AWS_REGION);
-      awsSdkMock.sendAssumeRole.returns({ Credentials: impersonationCredentials });
-      const token = await AttestationAws.getAwsAttestationToken(['impersonation-role']);
-      assert.strictEqual(token, AWS_WEB_IDENTITY_TOKEN);
-      assert.strictEqual(awsSdkMock.sendAssumeRole.callCount, 1);
-      assert.strictEqual(awsSdkMock.sendGetWebIdentityToken.callCount, 1);
+      assertAwsAttestationToken(token, AWS_REGION);
     });
   });
 });

--- a/test/unit/authentication/auth_workload_identity/attestation_aws_test.ts
+++ b/test/unit/authentication/auth_workload_identity/attestation_aws_test.ts
@@ -114,6 +114,19 @@ describe('Attestation AWS', () => {
     });
   });
 
+  describe('getStsHostname', () => {
+    it('returns valid name for china region', () => {
+      assert.strictEqual(
+        AttestationAws.getStsHostname('cn-northwest-1'),
+        'sts.cn-northwest-1.amazonaws.com.cn',
+      );
+    });
+
+    it('returns valid name for non-china region', () => {
+      assert.strictEqual(AttestationAws.getStsHostname('us-east-1'), 'sts.us-east-1.amazonaws.com');
+    });
+  });
+
   describe('getAwsAttestationToken', () => {
     it('throws error when no credentials are found', async () => {
       awsSdkMock.getMetadataRegion.returns(AWS_REGION);

--- a/test/unit/authentication/auth_workload_identity/attestation_aws_test.ts
+++ b/test/unit/authentication/auth_workload_identity/attestation_aws_test.ts
@@ -114,19 +114,6 @@ describe('Attestation AWS', () => {
     });
   });
 
-  describe('getStsHostname', () => {
-    it('returns valid name for china region', () => {
-      assert.strictEqual(
-        AttestationAws.getStsHostname('cn-northwest-1'),
-        'sts.cn-northwest-1.amazonaws.com.cn',
-      );
-    });
-
-    it('returns valid name for non-china region', () => {
-      assert.strictEqual(AttestationAws.getStsHostname('us-east-1'), 'sts.us-east-1.amazonaws.com');
-    });
-  });
-
   describe('getAwsAttestationToken', () => {
     it('throws error when no credentials are found', async () => {
       awsSdkMock.getMetadataRegion.returns(AWS_REGION);

--- a/test/unit/authentication/auth_workload_identity/attestation_aws_test.ts
+++ b/test/unit/authentication/auth_workload_identity/attestation_aws_test.ts
@@ -2,14 +2,23 @@ import sinon from 'sinon';
 import assert from 'assert';
 import rewiremock from 'rewiremock/node';
 import * as OriginalAttestationAws from '../../../../lib/authentication/auth_workload_identity/attestation_aws';
-import { assertAwsAttestationToken, AWS_CREDENTIALS, AWS_REGION } from './test_utils';
+import {
+  assertAwsAttestationToken,
+  AWS_CREDENTIALS,
+  AWS_REGION,
+  AWS_WEB_IDENTITY_TOKEN,
+} from './test_utils';
+
+class FakeAssumeRoleCommand {}
+class FakeGetWebIdentityTokenCommand {}
 
 describe('Attestation AWS', () => {
   const sinonSandbox = sinon.createSandbox();
   const awsSdkMock = {
     getDefaultCredentials: sinonSandbox.stub(),
     getMetadataRegion: sinonSandbox.stub(),
-    sendStsCommand: sinonSandbox.stub().returns({ Credentials: null }),
+    sendAssumeRole: sinonSandbox.stub().returns({ Credentials: null }),
+    sendGetWebIdentityToken: sinonSandbox.stub(),
   };
   let AttestationAws: typeof OriginalAttestationAws;
   const noCredentialsError = new Error('No credentials found');
@@ -22,9 +31,15 @@ describe('Attestation AWS', () => {
       defaultProvider: () => awsSdkMock.getDefaultCredentials,
     });
     rewiremock('@aws-sdk/client-sts').with({
-      AssumeRoleCommand: class {},
+      AssumeRoleCommand: FakeAssumeRoleCommand,
+      GetWebIdentityTokenCommand: FakeGetWebIdentityTokenCommand,
       STSClient: class {
-        send = () => awsSdkMock.sendStsCommand();
+        send = (command: unknown) => {
+          if (command instanceof FakeGetWebIdentityTokenCommand) {
+            return awsSdkMock.sendGetWebIdentityToken();
+          }
+          return awsSdkMock.sendAssumeRole();
+        };
       },
     });
     rewiremock('@aws-sdk/ec2-metadata-service').with({
@@ -38,8 +53,12 @@ describe('Attestation AWS', () => {
 
   beforeEach(() => {
     sinonSandbox.restore();
+    awsSdkMock.sendAssumeRole.resetHistory();
+    awsSdkMock.sendGetWebIdentityToken.resetHistory();
     awsSdkMock.getDefaultCredentials.throws(noCredentialsError);
     awsSdkMock.getMetadataRegion.throws(noRegionError);
+    awsSdkMock.sendAssumeRole.returns({ Credentials: null });
+    awsSdkMock.sendGetWebIdentityToken.returns({ WebIdentityToken: AWS_WEB_IDENTITY_TOKEN });
   });
 
   after(() => {
@@ -70,7 +89,7 @@ describe('Attestation AWS', () => {
         SecretAccessKey: 'impersonation-secret-access-key',
       };
       awsSdkMock.getDefaultCredentials.returns(AWS_CREDENTIALS);
-      awsSdkMock.sendStsCommand.returns({ Credentials: impersonationCredentials });
+      awsSdkMock.sendAssumeRole.returns({ Credentials: impersonationCredentials });
       assert.deepEqual(await AttestationAws.getAwsCredentials(AWS_REGION, ['impersonation-role']), {
         accessKeyId: impersonationCredentials.AccessKeyId,
         secretAccessKey: impersonationCredentials.SecretAccessKey,
@@ -114,15 +133,32 @@ describe('Attestation AWS', () => {
       await assert.rejects(AttestationAws.getAwsAttestationToken(), noCredentialsError);
     });
 
-    it('returns error when no region is found', async () => {
+    it('throws error when no region is found', async () => {
       await assert.rejects(AttestationAws.getAwsAttestationToken(), noRegionError);
     });
 
-    it('returns a valid attestation token', async () => {
+    it('returns a valid SigV4 attestation token by default', async () => {
       awsSdkMock.getDefaultCredentials.returns(AWS_CREDENTIALS);
       awsSdkMock.getMetadataRegion.returns(AWS_REGION);
       const token = await AttestationAws.getAwsAttestationToken();
       assertAwsAttestationToken(token, AWS_REGION);
+    });
+
+    it('throws error when STS returns no WebIdentityToken with outbound token', async () => {
+      awsSdkMock.getDefaultCredentials.returns(AWS_CREDENTIALS);
+      awsSdkMock.getMetadataRegion.returns(AWS_REGION);
+      awsSdkMock.sendGetWebIdentityToken.returns({});
+      await assert.rejects(
+        AttestationAws.getAwsAttestationToken(true),
+        /Failed to obtain AWS web identity token from STS/,
+      );
+    });
+
+    it('returns the WebIdentityToken JWT from STS with outbound token', async () => {
+      awsSdkMock.getDefaultCredentials.returns(AWS_CREDENTIALS);
+      awsSdkMock.getMetadataRegion.returns(AWS_REGION);
+      const token = await AttestationAws.getAwsAttestationToken(true);
+      assert.strictEqual(token, AWS_WEB_IDENTITY_TOKEN);
     });
   });
 });

--- a/test/unit/authentication/auth_workload_identity/auth_workload_identity_test.ts
+++ b/test/unit/authentication/auth_workload_identity/auth_workload_identity_test.ts
@@ -7,7 +7,7 @@ import { GoogleAuth } from 'google-auth-library';
 import { WIP_ConnectionConfig, WIP_ConnectionOptions } from '../../../../lib/connection/types';
 import { AuthRequestBody } from '../../../../lib/authentication/types';
 import OriginalAuthWorkloadIdentity from '../../../../lib/authentication/auth_workload_identity';
-import { AWS_CREDENTIALS, AWS_REGION, AWS_WEB_IDENTITY_TOKEN } from './test_utils';
+import { assertAwsAttestationToken, AWS_CREDENTIALS, AWS_REGION } from './test_utils';
 import ConnectionConfig from '../../../../lib/connection/connection_config';
 
 describe('Workload Identity Authentication', async () => {
@@ -15,7 +15,6 @@ describe('Workload Identity Authentication', async () => {
   const awsSdkMock = {
     getCredentials: cloudSdkStubs.stub(),
     getMetadataRegion: cloudSdkStubs.stub(),
-    sendGetWebIdentityToken: cloudSdkStubs.stub(),
   };
   const getAzureTokenMock = cloudSdkStubs.stub();
   const getGcpTokenMock = cloudSdkStubs.stub();
@@ -36,13 +35,6 @@ describe('Workload Identity Authentication', async () => {
     // Sinon can't stub frozen AWS SDK properties, so we need to mock entire require
     rewiremock('@aws-sdk/credential-provider-node').with({
       defaultProvider: () => awsSdkMock.getCredentials,
-    });
-    rewiremock('@aws-sdk/client-sts').with({
-      AssumeRoleCommand: class {},
-      GetWebIdentityTokenCommand: class {},
-      STSClient: class {
-        send = () => awsSdkMock.sendGetWebIdentityToken();
-      },
     });
     rewiremock('@aws-sdk/ec2-metadata-service').with({
       MetadataService: class {
@@ -136,10 +128,6 @@ describe('Workload Identity Authentication', async () => {
       workloadIdentityProvider: 'AWS',
     });
 
-    beforeEach(() => {
-      awsSdkMock.sendGetWebIdentityToken.returns({ WebIdentityToken: AWS_WEB_IDENTITY_TOKEN });
-    });
-
     it('throws error when credentials are not found', async () => {
       const err = new Error('No credentials found');
       awsSdkMock.getCredentials.throws(err);
@@ -156,7 +144,7 @@ describe('Workload Identity Authentication', async () => {
       auth.updateBody(body);
       assert.strictEqual(body.data.AUTHENTICATOR, 'WORKLOAD_IDENTITY');
       assert.strictEqual(body.data.PROVIDER, 'AWS');
-      assert.strictEqual(body.data.TOKEN, AWS_WEB_IDENTITY_TOKEN);
+      assertAwsAttestationToken(body.data.TOKEN, AWS_REGION);
     });
   });
 

--- a/test/unit/authentication/auth_workload_identity/auth_workload_identity_test.ts
+++ b/test/unit/authentication/auth_workload_identity/auth_workload_identity_test.ts
@@ -167,7 +167,7 @@ describe('Workload Identity Authentication', async () => {
       const auth = new AuthWorkloadIdentity(
         getConnectionConfig({
           workloadIdentityProvider: 'AWS',
-          workloadIdentityUseAwsOutboundToken: true,
+          workloadIdentityAwsUseOutboundToken: true,
         }),
       );
       const body: AuthRequestBody = { data: {} };

--- a/test/unit/authentication/auth_workload_identity/auth_workload_identity_test.ts
+++ b/test/unit/authentication/auth_workload_identity/auth_workload_identity_test.ts
@@ -7,7 +7,12 @@ import { GoogleAuth } from 'google-auth-library';
 import { WIP_ConnectionConfig, WIP_ConnectionOptions } from '../../../../lib/connection/types';
 import { AuthRequestBody } from '../../../../lib/authentication/types';
 import OriginalAuthWorkloadIdentity from '../../../../lib/authentication/auth_workload_identity';
-import { assertAwsAttestationToken, AWS_CREDENTIALS, AWS_REGION } from './test_utils';
+import {
+  assertAwsAttestationToken,
+  AWS_CREDENTIALS,
+  AWS_REGION,
+  AWS_WEB_IDENTITY_TOKEN,
+} from './test_utils';
 import ConnectionConfig from '../../../../lib/connection/connection_config';
 
 describe('Workload Identity Authentication', async () => {
@@ -15,6 +20,7 @@ describe('Workload Identity Authentication', async () => {
   const awsSdkMock = {
     getCredentials: cloudSdkStubs.stub(),
     getMetadataRegion: cloudSdkStubs.stub(),
+    sendGetWebIdentityToken: cloudSdkStubs.stub(),
   };
   const getAzureTokenMock = cloudSdkStubs.stub();
   const getGcpTokenMock = cloudSdkStubs.stub();
@@ -35,6 +41,13 @@ describe('Workload Identity Authentication', async () => {
     // Sinon can't stub frozen AWS SDK properties, so we need to mock entire require
     rewiremock('@aws-sdk/credential-provider-node').with({
       defaultProvider: () => awsSdkMock.getCredentials,
+    });
+    rewiremock('@aws-sdk/client-sts').with({
+      AssumeRoleCommand: class {},
+      GetWebIdentityTokenCommand: class {},
+      STSClient: class {
+        send = () => awsSdkMock.sendGetWebIdentityToken();
+      },
     });
     rewiremock('@aws-sdk/ec2-metadata-service').with({
       MetadataService: class {
@@ -135,7 +148,7 @@ describe('Workload Identity Authentication', async () => {
       await assert.rejects(auth.authenticate(), err);
     });
 
-    it('sets valid fields for updateBody() to use', async () => {
+    it('sets valid fields for updateBody() to use with GetCallerIdentity (default)', async () => {
       awsSdkMock.getCredentials.returns(AWS_CREDENTIALS);
       awsSdkMock.getMetadataRegion.returns(AWS_REGION);
       const auth = new AuthWorkloadIdentity(connectionConfig);
@@ -145,6 +158,24 @@ describe('Workload Identity Authentication', async () => {
       assert.strictEqual(body.data.AUTHENTICATOR, 'WORKLOAD_IDENTITY');
       assert.strictEqual(body.data.PROVIDER, 'AWS');
       assertAwsAttestationToken(body.data.TOKEN, AWS_REGION);
+    });
+
+    it('sets valid fields for updateBody() to use with GetWebIdentityToken (outbound)', async () => {
+      awsSdkMock.getCredentials.returns(AWS_CREDENTIALS);
+      awsSdkMock.getMetadataRegion.returns(AWS_REGION);
+      awsSdkMock.sendGetWebIdentityToken.returns({ WebIdentityToken: AWS_WEB_IDENTITY_TOKEN });
+      const auth = new AuthWorkloadIdentity(
+        getConnectionConfig({
+          workloadIdentityProvider: 'AWS',
+          workloadIdentityUseAwsOutboundToken: true,
+        }),
+      );
+      const body: AuthRequestBody = { data: {} };
+      await auth.authenticate();
+      auth.updateBody(body);
+      assert.strictEqual(body.data.AUTHENTICATOR, 'WORKLOAD_IDENTITY');
+      assert.strictEqual(body.data.PROVIDER, 'AWS');
+      assert.strictEqual(body.data.TOKEN, AWS_WEB_IDENTITY_TOKEN);
     });
   });
 

--- a/test/unit/authentication/auth_workload_identity/test_utils.ts
+++ b/test/unit/authentication/auth_workload_identity/test_utils.ts
@@ -1,7 +1,29 @@
+import assert from 'assert';
+
 export const AWS_REGION = 'test-region';
 export const AWS_CREDENTIALS = {
   accessKeyId: 'test',
   secretAccessKey: 'test',
   sessionToken: 'test',
 };
-export const AWS_WEB_IDENTITY_TOKEN = 'fake.jwt.token-for-testing-only';
+
+export function assertAwsAttestationToken(token: string | null | undefined, region: string) {
+  if (!token) {
+    assert.fail('Token is empty');
+  }
+  const decodedToken = JSON.parse(atob(token));
+  const parsedUrl = new URL(decodedToken.url);
+  assert.strictEqual(parsedUrl.hostname, `sts.${region}.amazonaws.com`);
+  assert.strictEqual(parsedUrl.searchParams.get('Action'), 'GetCallerIdentity');
+  assert.strictEqual(parsedUrl.searchParams.get('Version'), '2011-06-15');
+  assert.strictEqual(decodedToken.method, 'POST');
+  assert.deepStrictEqual(Object.keys(decodedToken.headers), [
+    'host',
+    'x-snowflake-audience',
+    'x-amz-date',
+    'x-amz-security-token',
+    'authorization',
+  ]);
+  assert.strictEqual(decodedToken.headers.host, `sts.${region}.amazonaws.com`);
+  assert.strictEqual(decodedToken.headers['x-snowflake-audience'], 'snowflakecomputing.com');
+}

--- a/test/unit/authentication/auth_workload_identity/test_utils.ts
+++ b/test/unit/authentication/auth_workload_identity/test_utils.ts
@@ -6,6 +6,7 @@ export const AWS_CREDENTIALS = {
   secretAccessKey: 'test',
   sessionToken: 'test',
 };
+export const AWS_WEB_IDENTITY_TOKEN = 'fake.jwt.token-for-testing-only';
 
 export function assertAwsAttestationToken(token: string | null | undefined, region: string) {
   if (!token) {


### PR DESCRIPTION
### Description

SNOW-3680365: Fix AWS Workload Identity attestation and make the JWT-based method opt-in.

PR #1415 (shipped in 3.0.0) switched AWS `WORKLOAD_IDENTITY` attestation from the SigV4-signed `GetCallerIdentity` envelope to STS `GetWebIdentityToken` JWTs. That was an unintentional breaking change for existing AWS WIF users whose Snowflake service users are not configured with an `ISSUER`. This PR reverts that change and re-introduces the new method as an explicit opt-in.

Changes:

- Reverted #1415: AWS WIF again defaults to the SigV4 `GetCallerIdentity` attestation method (restores the `getStsHostname` helper, the SigV4 signing path, and the `@aws-crypto/sha256-js`, `@smithy/protocol-http`, `@smithy/signature-v4` dependencies).
- Added the `workloadIdentityUseAwsOutboundToken` connection option (boolean, default `false`). When `true`, the connector calls STS `GetWebIdentityToken` and forwards the signed JWT instead of the SigV4 envelope.
  - `lib/connection/connection_config.js`: new option (defaults to `false`).
  - `lib/connection/types.ts`: documented the two AWS methods, the default, and that the JWT method is recommended and may become the default in a future release; links to the WIF AWS upgrade docs.
  - `lib/authentication/auth_workload_identity/attestation_aws.ts`: `getAwsAttestationToken(useOutboundToken, impersonationPath)` branches between `getCallerIdentityToken` (default) and `getOutboundWebIdentityToken`.
  - `lib/authentication/auth_workload_identity/auth_workload_identity.ts`: threads the option through.
- Tests:
  - `attestation_aws_test.ts`: keeps the original default SigV4 coverage and adds the new outbound `GetWebIdentityToken` cases (JWT returned, and error when STS returns no token).
  - `auth_workload_identity_test.ts`: asserts the SigV4 envelope by default and the JWT when the option is enabled.
  - `test/auth-workload-identity-e2e.ts`: AWS-only test connecting with `workloadIdentityUseAwsOutboundToken: true` against a distinct user.
- `CHANGELOG.md`: entry under Upcoming Release (Bugfixes for the revert, New features for the opt-in option).

### Checklist

- [x] Create tests which fail without the change (if possible)
- [x] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [x] Extend the types in index.d.ts file (if necessary) — N/A; the option is documented in `lib/connection/types.ts` (`WIP_ConnectionOptions`)
- [x] Extend the README / documentation and ensure is properly displayed (if necessary) — added JSDoc for `workloadIdentityUseAwsOutboundToken`
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message (SNOW-3680365)