### PR TITLE
SNOW-2013822 add customLogger option to funnel driver logs into user-supplied logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 New features:
 
 - Added `workloadIdentityAwsUseOutboundToken` connection option (default `false`) that switches AWS Workload Identity attestation to STS `GetWebIdentityToken` JWTs. This method is recommended and may become the default in a future release (snowflakedb/snowflake-connector-nodejs#1437)
+- Added a `customLogger` option to `snowflake.configure()` to route the driver's log messages through your own logger (e.g. winston, pino, OpenTelemetry) instead of the built-in file/console logging (snowflakedb/snowflake-connector-nodejs#1045).
 
 Bugfixes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 New features:
 
 - Added `workloadIdentityAwsUseOutboundToken` connection option (default `false`) that switches AWS Workload Identity attestation to STS `GetWebIdentityToken` JWTs. This method is recommended and may become the default in a future release (snowflakedb/snowflake-connector-nodejs#1437)
-- Added a `customLogger` option to `snowflake.configure()` to route the driver's log messages through your own logger (e.g. winston, pino, OpenTelemetry) instead of the built-in file/console logging (snowflakedb/snowflake-connector-nodejs#1045).
+- Added a `customLogger` option to `snowflake.configure()` to route the driver's log messages through your own logger (e.g. winston, pino, OpenTelemetry) instead of the built-in file/console logging (snowflakedb/snowflake-connector-nodejs#1438).
 
 Bugfixes:
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -19,6 +19,39 @@ declare module 'snowflake-sdk' {
   export type ConnectionCallback = (err: SnowflakeError | undefined, conn: Connection) => void;
   export type RowMode = 'object' | 'array' | 'object_with_renamed_duplicated_columns';
   export type LogLevel = 'ERROR' | 'WARN' | 'INFO' | 'DEBUG' | 'TRACE' | 'OFF';
+
+  /**
+   * A logger that can be supplied via {@link ConfigureOptions.customLogger} to receive
+   * the driver's log messages instead of the built-in file/console logger. Each method
+   * receives an already-formatted, secret-masked message string.
+   *
+   * Any logger that exposes these five methods works drop-in: pino, bunyan, and the
+   * built-in `console` all conform. Winston uses different level names (`verbose`,
+   * `silly`) and has no `.trace()`; wrap it with a small adapter:
+   *
+   * @example
+   * // pino / bunyan / console — drop-in:
+   * snowflake.configure({ customLogger: require('pino')() });
+   *
+   * // winston — wrap to map levels:
+   * const logger = require('winston').createLogger({ ... });
+   * snowflake.configure({
+   *   customLogger: {
+   *     error: (m) => logger.error(m),
+   *     warn:  (m) => logger.warn(m),
+   *     info:  (m) => logger.info(m),
+   *     debug: (m) => logger.debug(m),
+   *     trace: (m) => logger.debug(m), // winston has no trace; fold into debug
+   *   },
+   * });
+   */
+  export interface SnowflakeLogger {
+    error(message: string): void;
+    warn(message: string): void;
+    info(message: string): void;
+    debug(message: string): void;
+    trace(message: string): void;
+  }
   export type DataType = 'String' | 'Boolean' | 'Number' | 'Date' | 'JSON' | 'Buffer';
   export type QueryStatus =
     | 'RUNNING'
@@ -59,6 +92,14 @@ declare module 'snowflake-sdk' {
      * additionalLogToConsole is a Boolean value that indicates whether to send log messages also to the console when a filePath is specified.
      */
     additionalLogToConsole?: boolean | null;
+
+    /**
+     * A custom logger to receive driver log messages. When set, it fully overrides
+     * the built-in file/console logging. Messages are already level-filtered,
+     * formatted, and secret-masked before reaching the logger. See {@link SnowflakeLogger}
+     * for the required interface and examples.
+     */
+    customLogger?: SnowflakeLogger;
 
     /**
      * The option to turn off the OCSP check.

--- a/index.d.ts
+++ b/index.d.ts
@@ -21,29 +21,8 @@ declare module 'snowflake-sdk' {
   export type LogLevel = 'ERROR' | 'WARN' | 'INFO' | 'DEBUG' | 'TRACE' | 'OFF';
 
   /**
-   * A logger that can be supplied via {@link ConfigureOptions.customLogger} to receive
-   * the driver's log messages instead of the built-in file/console logger. Each method
-   * receives an already-formatted, secret-masked message string.
-   *
-   * Any logger that exposes these five methods works drop-in: pino, bunyan, and the
-   * built-in `console` all conform. Winston uses different level names (`verbose`,
-   * `silly`) and has no `.trace()`; wrap it with a small adapter:
-   *
-   * @example
-   * // pino / bunyan / console — drop-in:
-   * snowflake.configure({ customLogger: require('pino')() });
-   *
-   * // winston — wrap to map levels:
-   * const logger = require('winston').createLogger({ ... });
-   * snowflake.configure({
-   *   customLogger: {
-   *     error: (m) => logger.error(m),
-   *     warn:  (m) => logger.warn(m),
-   *     info:  (m) => logger.info(m),
-   *     debug: (m) => logger.debug(m),
-   *     trace: (m) => logger.debug(m), // winston has no trace; fold into debug
-   *   },
-   * });
+   * The interface a custom logger must implement. See {@link ConfigureOptions.customLogger}
+   * for behavior, requirements, and usage examples.
    */
   export interface SnowflakeLogger {
     error(message: string): void;
@@ -94,10 +73,30 @@ declare module 'snowflake-sdk' {
     additionalLogToConsole?: boolean | null;
 
     /**
-     * A custom logger to receive driver log messages. When set, it fully overrides
-     * the built-in file/console logging. Messages are already level-filtered,
-     * formatted, and secret-masked before reaching the logger. See {@link SnowflakeLogger}
-     * for the required interface and examples.
+     * A custom logger to receive the driver's log messages instead of the built-in
+     * file/console logger. When set, it fully overrides the built-in logging. Each
+     * method receives an already level-filtered, formatted, and secret-masked message
+     * string (see {@link SnowflakeLogger} for the required interface).
+     *
+     * Any logger that exposes the five methods works drop-in: pino, bunyan, and the
+     * built-in `console` all conform. Winston uses different level names (`verbose`,
+     * `silly`) and has no `.trace()`; wrap it with a small adapter.
+     *
+     * @example
+     * // pino / bunyan / console — drop-in:
+     * snowflake.configure({ customLogger: require('pino')() });
+     *
+     * // winston — wrap to map levels:
+     * const logger = require('winston').createLogger({ ... });
+     * snowflake.configure({
+     *   customLogger: {
+     *     error: (m) => logger.error(m),
+     *     warn:  (m) => logger.warn(m),
+     *     info:  (m) => logger.info(m),
+     *     debug: (m) => logger.debug(m),
+     *     trace: (m) => logger.debug(m), // winston has no trace; fold into debug
+     *   },
+     * });
      */
     customLogger?: SnowflakeLogger;
 

--- a/lib/core.js
+++ b/lib/core.js
@@ -204,18 +204,21 @@ function Core(options) {
       const logLevel = extractLogLevel(options);
       const logFilePath = options.logFilePath;
       const additionalLogToConsole = options.additionalLogToConsole;
+      const customLogger = options.customLogger;
 
-      if (logLevel != null || logFilePath) {
+      if (logLevel != null || logFilePath || customLogger) {
         Logger.getInstance().configure({
           level: logLevel,
           filePath: logFilePath,
           additionalLogToConsole: additionalLogToConsole,
+          customLogger: customLogger,
         });
         Logger.getInstance().info(
-          'Configuring logger with level: %s, filePath: %s, additionalLogToConsole: %s',
+          'Configuring logger with level: %s, filePath: %s, additionalLogToConsole: %s, customLogger: %s',
           logLevel,
           logFilePath,
           additionalLogToConsole,
+          !!customLogger,
         );
       }
 

--- a/lib/logger/core.js
+++ b/lib/logger/core.js
@@ -1,4 +1,3 @@
-const moment = require('moment');
 const Util = require('../util');
 const Errors = require('../errors');
 const SecretDetector = new (require('../secret_detector.js'))();
@@ -254,6 +253,15 @@ exports.createLogger = function (options, logMessage, reconfigureOperation) {
     },
 
     /**
+     * Returns whether the current timestamp should be included in log messages.
+     *
+     * @returns {Boolean}
+     */
+    getIncludeTimestamp: function () {
+      return includeTimestamp;
+    },
+
+    /**
      * Returns a map in which the keys are the level tags and the values are the
      * corresponding log levels.
      *
@@ -285,11 +293,6 @@ exports.createLogger = function (options, logMessage, reconfigureOperation) {
       // truncate the message if it's too long
       if (message.length > messageMaxLength) {
         message = message.slice(0, messageMaxLength);
-      }
-
-      // if needed, add the current time to the front of the message
-      if (includeTimestamp) {
-        message = Util.format('[%s]: %s', moment().format('h:mm:ss.SSS A'), message);
       }
 
       // mask secrets

--- a/lib/logger/node.js
+++ b/lib/logger/node.js
@@ -18,6 +18,7 @@ function Logger(options) {
   let filePath = getFilePath(options);
   let additionalLogToConsole = DEFAULT_ADDITIONAL_LOG_TO_CONSOLE;
   let transportLabels = [];
+  let customLogger = options && options.customLogger;
 
   this.setLogger = function (logger) {
     winstonLogger = logger;
@@ -63,6 +64,12 @@ function Logger(options) {
    * @param {String} message the message to log.
    */
   const logMessage = function (levelTag, message) {
+    // a custom logger fully overrides the built-in winston file/console logging
+    if (customLogger) {
+      customLogger[levelTag.toLowerCase()](message);
+      return;
+    }
+
     // initialize the winston logger if needed
     if (!winstonLogger) {
       let transports;
@@ -124,6 +131,9 @@ function Logger(options) {
       additionalLogToConsole = options.additionalLogToConsole;
     } else {
       additionalLogToConsole = DEFAULT_ADDITIONAL_LOG_TO_CONSOLE;
+    }
+    if (options.customLogger) {
+      customLogger = options.customLogger;
     }
     common.configure(options);
   };

--- a/lib/logger/node.js
+++ b/lib/logger/node.js
@@ -1,4 +1,5 @@
 const winston = require('winston');
+const moment = require('moment');
 const Core = require('./core');
 const Util = require('../util');
 const Errors = require('../errors');
@@ -64,7 +65,15 @@ function Logger(options) {
    * @param {String} message the message to log.
    */
   const logMessage = function (levelTag, message) {
-    // a custom logger fully overrides the built-in winston file/console logging
+    // A custom logger fully overrides the built-in winston file/console logging and
+    // receives the bare (secret-masked) message; it is expected to add its own
+    // timestamp, so we do not prepend the driver's one here.
+    //
+    // Universal Driver refactor: customLogger should become a first-class citizen
+    // here - i.e. the logger always dispatches to a logger implementing this
+    // interface, and the built-in file/console behavior becomes just a `defaultLogger`
+    // implementing the same SnowflakeLogger interface (rather than the special-cased
+    // winston branch below).
     if (customLogger) {
       customLogger[levelTag.toLowerCase()](message);
       return;
@@ -95,6 +104,11 @@ function Logger(options) {
         levels: common.getLevelTagsMap(),
       });
       setTransportLabels(transportLabels);
+    }
+
+    // the built-in file/console format includes the driver timestamp
+    if (common.getIncludeTimestamp()) {
+      message = Util.format('[%s]: %s', moment().format('h:mm:ss.SSS A'), message);
     }
 
     // get the appropriate logging method using the level tag and use this

--- a/lib/logger/node.js
+++ b/lib/logger/node.js
@@ -18,7 +18,7 @@ function Logger(options) {
   let filePath = getFilePath(options);
   let additionalLogToConsole = DEFAULT_ADDITIONAL_LOG_TO_CONSOLE;
   let transportLabels = [];
-  let customLogger = options && options.customLogger;
+  let customLogger;
 
   this.setLogger = function (logger) {
     winstonLogger = logger;
@@ -132,9 +132,10 @@ function Logger(options) {
     } else {
       additionalLogToConsole = DEFAULT_ADDITIONAL_LOG_TO_CONSOLE;
     }
-    if (options.customLogger) {
-      customLogger = options.customLogger;
-    }
+    // Declarative like additionalLogToConsole above: each configure() call fully
+    // describes the desired logging state. Omitting customLogger reverts to the
+    // built-in file/console logging; it is not sticky across configure() calls.
+    customLogger = options.customLogger ?? undefined;
     common.configure(options);
   };
 

--- a/test/unit/logger/node_test.js
+++ b/test/unit/logger/node_test.js
@@ -194,6 +194,87 @@ describe('Logger node tests', function () {
     assert.deepStrictEqual(infoLogs[2], OBJ_LOG_MSG_INFO);
   });
 
+  it('should route messages to a custom logger and not to a file', async function () {
+    // given
+    const collected = [];
+    const customLogger = {
+      error: (message) => collected.push({ level: ERROR, message }),
+      warn: (message) => collected.push({ level: WARN, message }),
+      info: (message) => collected.push({ level: INFO, message }),
+      debug: (message) => collected.push({ level: DEBUG, message }),
+      trace: (message) => collected.push({ level: TRACE, message }),
+    };
+    const filePath = path.join(tempDir, 'custom_logger_should_not_exist.log');
+    const logger = new NodeLogger({
+      includeTimestamp: false,
+      level: logTagToLevel(LOG_LEVEL_TAGS.TRACE),
+      filePath: filePath,
+      customLogger: customLogger,
+    });
+
+    // when
+    logMessages(logger);
+
+    // then - everything went to the custom logger, respecting the level order
+    assert.deepStrictEqual(collected, [
+      OBJ_LOG_MSG_ERROR,
+      OBJ_LOG_MSG_WARN,
+      OBJ_LOG_MSG_INFO,
+      OBJ_LOG_MSG_DEBUG,
+      OBJ_LOG_MSG_TRACE,
+    ]);
+    // and nothing was written to a log file
+    await logger.closeTransports();
+    await assert.rejects(
+      async () => await readLogs(filePath),
+      (err) => {
+        assert.strictEqual(err.name, 'Error');
+        assert.match(err.message, /ENOENT: no such file or directory./);
+        return true;
+      },
+    );
+  });
+
+  it('should respect the log level when using a custom logger', function () {
+    // given
+    const collected = [];
+    const customLogger = {
+      error: (message) => collected.push({ level: ERROR, message }),
+      warn: (message) => collected.push({ level: WARN, message }),
+      info: (message) => collected.push({ level: INFO, message }),
+      debug: (message) => collected.push({ level: DEBUG, message }),
+      trace: (message) => collected.push({ level: TRACE, message }),
+    };
+    const logger = new NodeLogger({
+      includeTimestamp: false,
+      level: logTagToLevel(LOG_LEVEL_TAGS.WARN),
+      customLogger: customLogger,
+    });
+
+    // when
+    logMessages(logger);
+
+    // then - only error and warn pass the level filter
+    assert.deepStrictEqual(collected, [OBJ_LOG_MSG_ERROR, OBJ_LOG_MSG_WARN]);
+  });
+
+  it('should apply a custom logger set via configure()', function () {
+    const collected = [];
+    const customLogger = {
+      error: (message) => collected.push({ level: ERROR, message }),
+      warn: (message) => collected.push({ level: WARN, message }),
+      info: (message) => collected.push({ level: INFO, message }),
+      debug: (message) => collected.push({ level: DEBUG, message }),
+      trace: (message) => collected.push({ level: TRACE, message }),
+    };
+    const logger = new NodeLogger({ includeTimestamp: false });
+
+    logger.configure({ customLogger });
+    logMessages(logger);
+
+    assert.deepStrictEqual(collected, [OBJ_LOG_MSG_ERROR, OBJ_LOG_MSG_WARN, OBJ_LOG_MSG_INFO]);
+  });
+
   async function readLogs(filePath) {
     const logs = await fsPromises.readFile(filePath, { encoding: 'utf8' });
     return logs

--- a/test/unit/logger/node_test.js
+++ b/test/unit/logger/node_test.js
@@ -194,23 +194,17 @@ describe('Logger node tests', function () {
     assert.deepStrictEqual(infoLogs[2], OBJ_LOG_MSG_INFO);
   });
 
-  it('should route messages to a custom logger and not to a file', async function () {
+  it('routes messages to a custom logger and not to a file', async function () {
     // given
     const collected = [];
-    const customLogger = {
-      error: (message) => collected.push({ level: ERROR, message }),
-      warn: (message) => collected.push({ level: WARN, message }),
-      info: (message) => collected.push({ level: INFO, message }),
-      debug: (message) => collected.push({ level: DEBUG, message }),
-      trace: (message) => collected.push({ level: TRACE, message }),
-    };
+    const customLogger = createCollectingLogger(collected);
     const filePath = path.join(tempDir, 'custom_logger_should_not_exist.log');
     const logger = new NodeLogger({
       includeTimestamp: false,
       level: logTagToLevel(LOG_LEVEL_TAGS.TRACE),
       filePath: filePath,
-      customLogger: customLogger,
     });
+    logger.configure({ customLogger });
 
     // when
     logMessages(logger);
@@ -235,21 +229,15 @@ describe('Logger node tests', function () {
     );
   });
 
-  it('should respect the log level when using a custom logger', function () {
+  it('respects the log level when using a custom logger', function () {
     // given
     const collected = [];
-    const customLogger = {
-      error: (message) => collected.push({ level: ERROR, message }),
-      warn: (message) => collected.push({ level: WARN, message }),
-      info: (message) => collected.push({ level: INFO, message }),
-      debug: (message) => collected.push({ level: DEBUG, message }),
-      trace: (message) => collected.push({ level: TRACE, message }),
-    };
+    const customLogger = createCollectingLogger(collected);
     const logger = new NodeLogger({
       includeTimestamp: false,
       level: logTagToLevel(LOG_LEVEL_TAGS.WARN),
-      customLogger: customLogger,
     });
+    logger.configure({ customLogger });
 
     // when
     logMessages(logger);
@@ -258,21 +246,40 @@ describe('Logger node tests', function () {
     assert.deepStrictEqual(collected, [OBJ_LOG_MSG_ERROR, OBJ_LOG_MSG_WARN]);
   });
 
-  it('should apply a custom logger set via configure()', function () {
+  it('applies a custom logger set via configure()', function () {
     const collected = [];
-    const customLogger = {
-      error: (message) => collected.push({ level: ERROR, message }),
-      warn: (message) => collected.push({ level: WARN, message }),
-      info: (message) => collected.push({ level: INFO, message }),
-      debug: (message) => collected.push({ level: DEBUG, message }),
-      trace: (message) => collected.push({ level: TRACE, message }),
-    };
+    const customLogger = createCollectingLogger(collected);
     const logger = new NodeLogger({ includeTimestamp: false });
 
     logger.configure({ customLogger });
     logMessages(logger);
 
     assert.deepStrictEqual(collected, [OBJ_LOG_MSG_ERROR, OBJ_LOG_MSG_WARN, OBJ_LOG_MSG_INFO]);
+  });
+
+  it('reverts to file logging when configure() is called without a custom logger', async function () {
+    // given - a custom logger is active
+    const collected = [];
+    const customLogger = createCollectingLogger(collected);
+    const filePath = path.join(tempDir, 'revert_to_file_logs.log');
+    const logger = new NodeLogger({
+      includeTimestamp: false,
+      level: logTagToLevel(LOG_LEVEL_TAGS.INFO),
+      filePath: filePath,
+    });
+    logger.configure({ customLogger });
+    logMessages(logger);
+    assert.deepStrictEqual(collected, [OBJ_LOG_MSG_ERROR, OBJ_LOG_MSG_WARN, OBJ_LOG_MSG_INFO]);
+
+    // when - configure() is called again without customLogger (declarative reset)
+    logger.configure({ level: logTagToLevel(LOG_LEVEL_TAGS.INFO), filePath: filePath });
+    logMessages(logger);
+
+    // then - the custom logger received nothing new, and messages went to the file
+    assert.deepStrictEqual(collected, [OBJ_LOG_MSG_ERROR, OBJ_LOG_MSG_WARN, OBJ_LOG_MSG_INFO]);
+    await logger.closeTransports();
+    const logs = await readLogs(filePath);
+    assert.deepStrictEqual(logs, [OBJ_LOG_MSG_ERROR, OBJ_LOG_MSG_WARN, OBJ_LOG_MSG_INFO]);
   });
 
   async function readLogs(filePath) {
@@ -289,6 +296,16 @@ describe('Logger node tests', function () {
       level: level,
       filePath: filePath,
     });
+  }
+
+  function createCollectingLogger(collected) {
+    return {
+      error: (message) => collected.push({ level: ERROR, message }),
+      warn: (message) => collected.push({ level: WARN, message }),
+      info: (message) => collected.push({ level: INFO, message }),
+      debug: (message) => collected.push({ level: DEBUG, message }),
+      trace: (message) => collected.push({ level: TRACE, message }),
+    };
   }
 
   function logMessages(logger) {

--- a/test/unit/logger/node_test.js
+++ b/test/unit/logger/node_test.js
@@ -257,6 +257,28 @@ describe('Logger node tests', function () {
     assert.deepStrictEqual(collected, [OBJ_LOG_MSG_ERROR, OBJ_LOG_MSG_WARN, OBJ_LOG_MSG_INFO]);
   });
 
+  it('omits the driver timestamp for a custom logger even when timestamps are enabled', function () {
+    // given - timestamps enabled (default), so the built-in path would prepend [time]:
+    const collected = [];
+    const customLogger = createCollectingLogger(collected);
+    const logger = new NodeLogger({
+      level: logTagToLevel(LOG_LEVEL_TAGS.TRACE),
+    });
+    logger.configure({ customLogger });
+
+    // when
+    logMessages(logger);
+
+    // then - the custom logger receives bare messages without a [time]: prefix
+    assert.deepStrictEqual(collected, [
+      OBJ_LOG_MSG_ERROR,
+      OBJ_LOG_MSG_WARN,
+      OBJ_LOG_MSG_INFO,
+      OBJ_LOG_MSG_DEBUG,
+      OBJ_LOG_MSG_TRACE,
+    ]);
+  });
+
   it('reverts to file logging when configure() is called without a custom logger', async function () {
     // given - a custom logger is active
     const collected = [];


### PR DESCRIPTION
Adds a `customLogger` option to `snowflake.configure()` so users can route driver log messages through their own logging pipeline instead of the built-in file/console output.

Closes #1045

## How it works

When `customLogger` is set, the built-in winston file/console logging is bypassed entirely. Messages reach the custom logger already level-filtered, formatted, and secret-masked — the same processing that would normally happen before writing to `snowflake.log`. The method matching the SDK level is called (`error`/`warn`/`info`/`debug`/`trace`).

## Interface and compatibility

The expected interface is the same five-method shape used by pino, bunyan, and the built-in `console` object — all of which work drop-in:

```js
snowflake.configure({ customLogger: require("pino")() });
snowflake.configure({ customLogger: console });
```

Winston uses different level names and has no `.trace()`; the type definition includes a small adapter example for that case.

No config-time validation is done on the supplied logger — this matches the convention across the Node.js ecosystem (knex, kafkajs, fastify, etc.): duck typing, TypeError at runtime if a method is missing.

## Testing

- Unit tests: routing to a custom logger with no file side-effect, level filtering, and applying via `configure()` after construction
- Tested live against a real Snowflake account using pino (drop-in), a winston adapter, and a plain in-memory collector — all confirmed: logs routed correctly, no `snowflake.log` written

## Checklist

- [x] Tests which fail without the change
- [x] Unit tests pass (`npm run test:unit`)
- [x] Types extended in `index.d.ts`
- [x] `CHANGELOG.md` updated