### PR TITLE
Add native EmbeddedStreamlit helper to generate Streamlit embed URLs via OAuth token-exchange

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -719,4 +719,73 @@ declare module 'snowflake-sdk' {
     options?: ConnectionOptions,
     poolOptions?: PoolOptions,
   ): Pool<Connection>;
+
+  /**
+   * Options for constructing an {@link EmbeddedStreamlit} instance.
+   */
+  export interface EmbeddedStreamlitConfig {
+    /** Fully-qualified Streamlit app name `db.schema.app` (must contain no `:`). */
+    streamlitId: string;
+    /** Origin of the embedding (3rd-party) page, e.g. `https://analytics.example.com`. */
+    parentOrigin: string;
+  }
+
+  /**
+   * Options accepted by {@link EmbeddedStreamlit.prepare} (and
+   * {@link generateStreamlitEmbedUrl}). Exactly one credential mode must be
+   * supplied: `pat`, `keyPair`, `sessionToken`, or an explicit `subjectToken`.
+   */
+  export interface EmbeddedStreamlitPrepareOptions {
+    /** Programmatic Access Token value. */
+    pat?: string;
+    /** A pre-signed RS256 key-pair JWT. */
+    keyPair?: string;
+    /** An existing Snowflake session token. */
+    sessionToken?: string;
+    /** Explicit `subject_token` value (forward-compatibility escape hatch). */
+    subjectToken?: string;
+    /**
+     * Explicit / overriding `subject_token_type` URN. For the `keyPair` mode
+     * this defaults to the PROVISIONAL `urn:ietf:params:oauth:token-type:jwt`
+     * (no GS enum value exists for key-pair JWT yet).
+     */
+    subjectTokenType?: string;
+    /** A Snowflake {@link Connection} used to resolve the account `accessUrl`. */
+    connection?: Connection;
+    /** Account name, used to construct the host when `host`/`connection` are absent. */
+    account?: string;
+    /** Explicit host or full base URL (overrides `connection`/`account`). */
+    host?: string;
+    /** Account user (reserved; not required by the token-exchange today). */
+    user?: string;
+    /** Explicit `/oauth/token` endpoint URL (primarily for tests). */
+    tokenEndpoint?: string;
+    /** Injectable axios instance (primarily for tests). */
+    axiosInstance?: unknown;
+  }
+
+  /**
+   * Generates a short-lived Streamlit embed URL by performing an OAuth
+   * token-exchange against the Snowflake `/oauth/token` endpoint with a service
+   * credential, then assembling the embed URL. Replaces the
+   * `SYSTEM$STREAMLIT_GENERATE_EMBED_URL` SQL system function for embedding
+   * Streamlit-in-Snowflake apps in 3rd-party pages without a SQL session.
+   */
+  export class EmbeddedStreamlit {
+    constructor(config: EmbeddedStreamlitConfig);
+    /** Prepare the credential and target endpoint. Returns `this` for chaining. */
+    prepare(options: EmbeddedStreamlitPrepareOptions): EmbeddedStreamlit;
+    /** Perform the token-exchange and return the assembled embed URL. */
+    getEmbedUrl(): Promise<string>;
+    /** The token-exchange `expires_in` (seconds), available after `getEmbedUrl()`. */
+    getExpiresIn(): number | undefined;
+  }
+
+  /**
+   * One-shot convenience wrapper around {@link EmbeddedStreamlit}: prepares the
+   * credential and returns the assembled embed URL.
+   */
+  export function generateStreamlitEmbedUrl(
+    options: EmbeddedStreamlitConfig & EmbeddedStreamlitPrepareOptions,
+  ): Promise<string>;
 }

--- a/lib/core.js
+++ b/lib/core.js
@@ -12,6 +12,7 @@ const DataTypes = require('./connection/result/data_types');
 const GlobalConfig = require('./global_config');
 const GlobalConfigTyped = require('./global_config_typed').default;
 const { loadConnectionConfiguration } = require('./configuration/connection_configuration');
+const { EmbeddedStreamlit, generateStreamlitEmbedUrl } = require('./streamlit_embed');
 
 /**
  * Creates a new instance of the Snowflake core module.
@@ -314,6 +315,11 @@ function Core(options) {
       }
     },
   };
+
+  // Streamlit embed: generate an embed URL via OAuth token-exchange, replacing
+  // the SYSTEM$STREAMLIT_GENERATE_EMBED_URL SQL system function.
+  instance.EmbeddedStreamlit = EmbeddedStreamlit;
+  instance.generateStreamlitEmbedUrl = generateStreamlitEmbedUrl;
 
   function extractLogLevel(options) {
     const logTag = options.logLevel;

--- a/lib/streamlit_embed.js
+++ b/lib/streamlit_embed.js
@@ -1,0 +1,471 @@
+const Util = require('./util');
+const Logger = require('./logger');
+const defaultAxios = require('./http/axios_instance').default;
+
+/**
+ * Subject token type URNs accepted by the Snowflake OAuth token-exchange
+ * endpoint for the streamlit embed scope. Verified against
+ * GlobalServices SFOAuthTokenType (modules/dbsec/authn-api), 2026-06-25.
+ *
+ * NOTE: There is no key-pair-JWT subject_token_type in the GS enum today.
+ * For the key-pair credential mode the driver does NOT hardcode a type; it
+ * exposes an overridable subject_token_type that defaults to
+ * SUBJECT_TOKEN_TYPE.JWT below and is documented as PROVISIONAL pending the
+ * GS keypair extension.
+ */
+const SUBJECT_TOKEN_TYPE = {
+  SESSION: 'urn:snowflake:token-type:session',
+  PAT: 'programmatic_access_token',
+  WIF: 'urn:snowflake:token-type:wif',
+  OAUTH_ACCESS_TOKEN: 'urn:ietf:params:oauth:token-type:access_token',
+  // PROVISIONAL: no GS enum value for key-pair JWT yet (overridable).
+  JWT: 'urn:ietf:params:oauth:token-type:jwt',
+};
+
+const GRANT_TYPE_TOKEN_EXCHANGE = 'urn:ietf:params:oauth:grant-type:token-exchange';
+const TOKEN_PATH = '/oauth/token';
+
+/**
+ * Resolve the base origin (scheme://host[:port]) for the account, used to
+ * build the token-exchange endpoint when an explicit endpoint is not given.
+ *
+ * Precedence: explicit host (or full token endpoint) > connection accessUrl >
+ * constructed hostname from account.
+ *
+ * @param {{ host?: string, account?: string, connection?: Object }} opts
+ *
+ * @returns {string} an origin such as 'https://myaccount.snowflakecomputing.com'
+ */
+function resolveAccountOrigin(opts) {
+  // 1. Explicit host wins. Accept either a bare host or a full URL.
+  if (Util.isNotEmptyString(opts.host)) {
+    const host = opts.host.trim();
+    if (host.startsWith('http://') || host.startsWith('https://')) {
+      const parsed = new URL(host);
+      return `${parsed.protocol}//${parsed.host}`;
+    }
+    return `https://${host}`;
+  }
+
+  // 2. Connection config accessUrl (set from account/host/region at config time).
+  if (opts.connection && typeof opts.connection.accessUrl === 'string') {
+    const parsed = new URL(opts.connection.accessUrl);
+    return `${parsed.protocol}//${parsed.host}`;
+  }
+  if (opts.connection && typeof opts.connection.getAccessUrl === 'function') {
+    const accessUrl = opts.connection.getAccessUrl();
+    if (Util.isNotEmptyString(accessUrl)) {
+      const parsed = new URL(accessUrl);
+      return `${parsed.protocol}//${parsed.host}`;
+    }
+  }
+
+  // 3. Fall back to constructing a hostname from the account.
+  if (Util.isNotEmptyString(opts.account)) {
+    return `https://${Util.constructHostname(null, opts.account)}`;
+  }
+
+  throw new Error(
+    'Unable to resolve the Snowflake account origin: provide one of host, ' +
+      'connection, account, or an explicit tokenEndpoint.',
+  );
+}
+
+/**
+ * Build the absolute /oauth/token endpoint. An explicit tokenEndpoint (used by
+ * tests / forward-compatibility) is returned verbatim.
+ *
+ * @param {Object} opts
+ *
+ * @returns {string}
+ */
+function resolveTokenEndpoint(opts) {
+  if (Util.isNotEmptyString(opts.tokenEndpoint)) {
+    return opts.tokenEndpoint.trim();
+  }
+  return resolveAccountOrigin(opts) + TOKEN_PATH;
+}
+
+/**
+ * Resolve the (subject_token, subject_token_type) pair from the prepared
+ * credential. Exactly one credential mode must be supplied.
+ *
+ * Modes (in precedence order):
+ *  - subjectToken (+ optional subjectTokenType): explicit escape hatch for
+ *    forward-compatibility; the caller fully controls both values.
+ *  - pat: Programmatic Access Token -> 'programmatic_access_token'.
+ *  - keyPair: a pre-signed key-pair JWT -> PROVISIONAL JWT URN (overridable
+ *    via subjectTokenType).
+ *  - sessionToken: an existing Snowflake session token -> session URN.
+ *
+ * Never logs the credential value.
+ *
+ * @param {Object} opts
+ *
+ * @returns {{ subjectToken: string, subjectTokenType: string }}
+ */
+function resolveCredential(opts) {
+  // Explicit escape hatch: caller provides the raw pair.
+  if (Util.isNotEmptyString(opts.subjectToken)) {
+    return {
+      subjectToken: opts.subjectToken,
+      // Default to the provisional JWT URN only if the caller did not name one.
+      subjectTokenType: Util.isNotEmptyString(opts.subjectTokenType)
+        ? opts.subjectTokenType
+        : SUBJECT_TOKEN_TYPE.JWT,
+    };
+  }
+
+  if (Util.isNotEmptyString(opts.pat)) {
+    return {
+      subjectToken: opts.pat,
+      subjectTokenType: SUBJECT_TOKEN_TYPE.PAT,
+    };
+  }
+
+  if (Util.isNotEmptyString(opts.keyPair)) {
+    // keyPair is a pre-signed RS256 JWT. No GS subject_token_type exists for
+    // key-pair JWT yet, so the type is PROVISIONAL and overridable.
+    return {
+      subjectToken: opts.keyPair,
+      subjectTokenType: Util.isNotEmptyString(opts.subjectTokenType)
+        ? opts.subjectTokenType
+        : SUBJECT_TOKEN_TYPE.JWT,
+    };
+  }
+
+  if (Util.isNotEmptyString(opts.sessionToken)) {
+    return {
+      subjectToken: opts.sessionToken,
+      subjectTokenType: SUBJECT_TOKEN_TYPE.SESSION,
+    };
+  }
+
+  throw new Error(
+    'No credential supplied to EmbeddedStreamlit.prepare(): provide one of ' +
+      'pat, keyPair, sessionToken, or an explicit (subjectToken, subjectTokenType).',
+  );
+}
+
+/**
+ * Build the token-exchange scope for a streamlit app. The streamlitId is the
+ * fully-qualified name (db.schema.app) and MUST contain no ':' so it cannot
+ * break out of the scope grammar.
+ *
+ * @param {string} streamlitId
+ *
+ * @returns {string} e.g. 'session:streamlit:db.schema.app'
+ */
+function buildScope(streamlitId) {
+  if (!Util.isNotEmptyString(streamlitId)) {
+    throw new Error('streamlitId (the db.schema.app fully-qualified name) is required.');
+  }
+  if (streamlitId.indexOf(':') >= 0) {
+    throw new Error(
+      `Invalid streamlitId "${streamlitId}": the fully-qualified name must contain no ':'.`,
+    );
+  }
+  return `session:streamlit:${streamlitId}`;
+}
+
+/**
+ * Match the RAW (un-decoded) value of a 'code' parameter inside a fragment or
+ * query string. We deliberately do NOT parse with URLSearchParams, because that
+ * percent-decodes the value (and turns '+' into a space). GS treats the azcode
+ * opaquely (StreamlitGenerateEmbedUrl.java does setFragment("code=" + azCode)),
+ * so the driver must round-trip the code byte-for-byte: an opaque/base64url
+ * code containing '+', '/', '=' or '%' must reach the browser unchanged.
+ *
+ * @param {string} segment the raw fragment or query string (no leading '#'/'?')
+ *
+ * @returns {string|null} the raw value following 'code=' up to the next '&', or null
+ */
+function matchRawCode(segment) {
+  // (?:^|&)code=  anchors on a full parameter boundary so 'somecode=x' never matches.
+  const match = /(?:^|&)code=([^&]*)/.exec(segment);
+  return match ? match[1] : null;
+}
+
+/**
+ * Extract the single-use authorization code from a token-exchange
+ * redirect_uri. The code may be carried as a URL fragment ('#code=...') OR
+ * query ('?code=...' / '&code=...'). The fragment form is checked first.
+ *
+ * The code is sliced out of the RAW fragment/query substring (not decoded via
+ * URLSearchParams) so it is byte-faithful to whatever GS placed in
+ * redirect_uri, regardless of the code's character set.
+ *
+ * @param {string} redirectUri
+ *
+ * @returns {string} the authorization code, exactly as carried in redirect_uri
+ */
+function extractAuthorizationCode(redirectUri) {
+  const parsed = new URL(redirectUri);
+
+  // 1. Fragment form: '#code=...' (may carry multiple '&'-joined pairs).
+  if (parsed.hash) {
+    // Strip the leading '#'. parsed.hash is the raw, un-decoded fragment.
+    const fragment = parsed.hash.startsWith('#') ? parsed.hash.slice(1) : parsed.hash;
+    const fragCode = matchRawCode(fragment);
+    if (fragCode !== null && fragCode.length > 0) {
+      return fragCode;
+    }
+  }
+
+  // 2. Query form: '?code=...' / '&code=...'. parsed.search is the raw,
+  //    un-decoded query (including the leading '?', which we strip).
+  if (parsed.search) {
+    const query = parsed.search.startsWith('?') ? parsed.search.slice(1) : parsed.search;
+    const queryCode = matchRawCode(query);
+    if (queryCode !== null && queryCode.length > 0) {
+      return queryCode;
+    }
+  }
+
+  throw new Error('Token-exchange redirect_uri did not contain an authorization code.');
+}
+
+/**
+ * Compute the embed base URL: scheme://host[:port]/path of redirect_uri, with
+ * the authorization code removed AND any pre-existing __embeddedApp /
+ * __parentOrigin params stripped, preserving any other query params.
+ *
+ * @param {string} redirectUri
+ *
+ * @returns {URL} a URL whose hash is cleared and whose reserved params are removed
+ */
+function computeEmbedBase(redirectUri) {
+  const base = new URL(redirectUri);
+  // The code lives in the fragment in the common case; always clear it.
+  base.hash = '';
+  // Remove the code and the reserved embed params if the server echoed them.
+  base.searchParams.delete('code');
+  base.searchParams.delete('__embeddedApp');
+  base.searchParams.delete('__parentOrigin');
+  return base;
+}
+
+/**
+ * Assemble the final embed URL, reproducing the proven system-function output
+ * format from GS StreamlitGenerateEmbedUrl.java:
+ *   base + '?__parentOrigin=' + urlencode(parentOrigin)
+ *        + '&__embeddedApp=true'
+ *        + '#code=' + code
+ * If the base already carries query params, the embed params are appended with
+ * '&' rather than '?'.
+ *
+ * @param {string} redirectUri the server-provided redirect_uri
+ * @param {string} parentOrigin the embedding page origin
+ *
+ * @returns {string} the final embed URL
+ */
+function assembleEmbedUrl(redirectUri, parentOrigin) {
+  const code = extractAuthorizationCode(redirectUri);
+  const base = computeEmbedBase(redirectUri);
+
+  // Preserve any surviving query string, then append reserved params.
+  const existingQuery = base.search; // includes leading '?' or '' if none
+  const separator = existingQuery && existingQuery.length > 1 ? '&' : '?';
+  const baseStr = `${base.protocol}//${base.host}${base.pathname}${existingQuery}`;
+
+  return (
+    baseStr +
+    separator +
+    '__parentOrigin=' +
+    encodeURIComponent(parentOrigin) +
+    '&__embeddedApp=true' +
+    '#code=' +
+    code
+  );
+}
+
+/**
+ * POST the token-exchange request as application/x-www-form-urlencoded.
+ *
+ * This deliberately uses the raw axios instance (not http/base.js
+ * requestAsync, which gzips and JSON-stringifies the body) so the body is sent
+ * as a clean form-encoded grant request, mirroring how
+ * lib/authentication/auth_oauth_client_credentials.ts builds its urlencoded
+ * grant.
+ *
+ * The streamlit-embed token-exchange path carries NO OAuth client identity:
+ * no Authorization header, no client_id / client_secret.
+ *
+ * @param {Object} cfg
+ * @param {string} cfg.tokenEndpoint absolute /oauth/token URL
+ * @param {string} cfg.subjectToken the credential value (secret)
+ * @param {string} cfg.subjectTokenType the subject_token_type URN
+ * @param {string} cfg.scope the session:streamlit:<fqn> scope
+ * @param {Object} cfg.axiosInstance injectable axios instance (for tests)
+ *
+ * @returns {Promise<Object>} parsed JSON response body
+ */
+async function postTokenExchange(cfg) {
+  const body = new URLSearchParams();
+  // oxlint-disable-next-line camelcase
+  body.set('grant_type', GRANT_TYPE_TOKEN_EXCHANGE);
+  // oxlint-disable-next-line camelcase
+  body.set('subject_token', cfg.subjectToken);
+  // oxlint-disable-next-line camelcase
+  body.set('subject_token_type', cfg.subjectTokenType);
+  body.set('scope', cfg.scope);
+
+  Logger.getInstance().debug(
+    'EmbeddedStreamlit: requesting token exchange at %s (scope=%s, subject_token_type=%s)',
+    cfg.tokenEndpoint,
+    cfg.scope,
+    cfg.subjectTokenType,
+  );
+
+  const response = await cfg.axiosInstance.request({
+    method: 'POST',
+    url: cfg.tokenEndpoint,
+    data: body.toString(),
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
+      Accept: 'application/json',
+    },
+    // Resolve for any status so we can craft a precise error message.
+    validateStatus: () => true,
+  });
+
+  if (response.status !== 200) {
+    throw new Error(
+      `Token exchange failed with HTTP ${response.status} from ${cfg.tokenEndpoint}.`,
+    );
+  }
+
+  const data =
+    typeof response.data === 'string' && response.data.length > 0
+      ? JSON.parse(response.data)
+      : response.data;
+
+  if (!data || !Util.isNotEmptyString(data.redirect_uri)) {
+    throw new Error('Token exchange response did not contain a redirect_uri.');
+  }
+
+  return data;
+}
+
+/**
+ * Helper to generate a Streamlit embed URL via OAuth token-exchange. This is a
+ * one-shot convenience wrapper around the EmbeddedStreamlit class.
+ *
+ * @param {Object} options { streamlitId, parentOrigin, ...credential }
+ *
+ * @returns {Promise<string>} the final embed URL
+ */
+async function generateStreamlitEmbedUrl(options = {}) {
+  const embed = new EmbeddedStreamlit({
+    streamlitId: options.streamlitId,
+    parentOrigin: options.parentOrigin,
+  });
+  embed.prepare(options);
+  return embed.getEmbedUrl();
+}
+
+/**
+ * Generates a short-lived Streamlit embed URL by performing an OAuth
+ * token-exchange against the Snowflake /oauth/token endpoint with a service
+ * credential, then assembling the embed URL. This replaces the
+ * SYSTEM$STREAMLIT_GENERATE_EMBED_URL SQL system function for embedding
+ * Streamlit-in-Snowflake apps in 3rd-party pages, without a SQL session.
+ *
+ * Usage:
+ *   const embed = new snowflake.EmbeddedStreamlit({
+ *     streamlitId: 'db.schema.app',
+ *     parentOrigin: 'https://analytics.example.com',
+ *   });
+ *   embed.prepare({ pat: '<pat>', account: 'myaccount' });
+ *   const url = await embed.getEmbedUrl();
+ */
+class EmbeddedStreamlit {
+  /**
+   * @param {Object} config
+   * @param {string} config.streamlitId fully-qualified app name (db.schema.app)
+   * @param {string} config.parentOrigin origin of the embedding page
+   */
+  constructor(config = {}) {
+    this._streamlitId = config.streamlitId;
+    this._parentOrigin = config.parentOrigin;
+    this._prepared = null;
+  }
+
+  /**
+   * Prepare the credential and target endpoint. Exactly one credential mode
+   * must be supplied (pat | keyPair | sessionToken | explicit subjectToken).
+   *
+   * @param {Object} options
+   * @param {string} [options.pat] Programmatic Access Token value
+   * @param {string} [options.keyPair] a pre-signed RS256 key-pair JWT
+   * @param {string} [options.sessionToken] an existing Snowflake session token
+   * @param {string} [options.subjectToken] explicit subject_token (escape hatch)
+   * @param {string} [options.subjectTokenType] explicit/override subject_token_type
+   * @param {Object} [options.connection] a Snowflake connection (for accessUrl)
+   * @param {string} [options.account] account name (used to construct the host)
+   * @param {string} [options.host] explicit host or full base URL
+   * @param {string} [options.user] account user (reserved; not required today)
+   * @param {string} [options.tokenEndpoint] explicit /oauth/token URL (tests)
+   * @param {Object} [options.axiosInstance] injectable axios instance (tests)
+   *
+   * @returns {EmbeddedStreamlit} this, for chaining
+   */
+  prepare(options = {}) {
+    if (!Util.isNotEmptyString(this._parentOrigin)) {
+      throw new Error('parentOrigin is required to build the embed URL.');
+    }
+    // Validate the scope eagerly so a bad streamlitId fails fast.
+    const scope = buildScope(this._streamlitId);
+    const credential = resolveCredential(options);
+    const tokenEndpoint = resolveTokenEndpoint(options);
+
+    this._prepared = {
+      scope,
+      subjectToken: credential.subjectToken,
+      subjectTokenType: credential.subjectTokenType,
+      tokenEndpoint,
+      axiosInstance: options.axiosInstance || defaultAxios,
+    };
+    return this;
+  }
+
+  /**
+   * Perform the token-exchange and return the assembled embed URL.
+   *
+   * @returns {Promise<string>} the final embed URL
+   */
+  async getEmbedUrl() {
+    if (!this._prepared) {
+      throw new Error('EmbeddedStreamlit.getEmbedUrl() called before prepare().');
+    }
+    const data = await postTokenExchange(this._prepared);
+    this._expiresIn = typeof data.expires_in === 'number' ? data.expires_in : undefined;
+    return assembleEmbedUrl(data.redirect_uri, this._parentOrigin);
+  }
+
+  /**
+   * The token-exchange expires_in (seconds), available after getEmbedUrl().
+   *
+   * @returns {number|undefined}
+   */
+  getExpiresIn() {
+    return this._expiresIn;
+  }
+}
+
+module.exports = {
+  EmbeddedStreamlit,
+  generateStreamlitEmbedUrl,
+  SUBJECT_TOKEN_TYPE,
+  // Exported for unit testing of the internal pieces.
+  _internal: {
+    resolveAccountOrigin,
+    resolveTokenEndpoint,
+    resolveCredential,
+    buildScope,
+    extractAuthorizationCode,
+    computeEmbedBase,
+    assembleEmbedUrl,
+    postTokenExchange,
+  },
+};

--- a/test/unit/streamlit_embed_test.js
+++ b/test/unit/streamlit_embed_test.js
@@ -1,0 +1,475 @@
+const assert = require('assert');
+const snowflakeEmbed = require('./../../lib/streamlit_embed');
+const { EmbeddedStreamlit, generateStreamlitEmbedUrl, SUBJECT_TOKEN_TYPE } = snowflakeEmbed;
+
+// A fake axios instance whose request() records the last request and returns a
+// caller-supplied response. This mocks the HTTP layer so no network is used and
+// the server endpoint (not in prod yet) is never contacted.
+function makeFakeAxios(responder) {
+  const calls = [];
+  return {
+    calls,
+    request: async (config) => {
+      calls.push(config);
+      return responder(config);
+    },
+  };
+}
+
+// A standard 200 token-exchange response whose redirect_uri carries the code in
+// the fragment, mirroring the GS system-function output.
+function okFragmentResponse(code = 'AZCODE123', redirectHost = 'app.snowflakecomputing.com') {
+  return {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+    data: {
+      // oxlint-disable-next-line camelcase
+      redirect_uri: `https://${redirectHost}/streamlit-app#code=${code}`,
+      // oxlint-disable-next-line camelcase
+      expires_in: 600,
+    },
+  };
+}
+
+describe('EmbeddedStreamlit', function () {
+  const STREAMLIT_ID = 'mydb.myschema.myapp';
+  const PARENT_ORIGIN = 'https://analytics.bmw.com';
+  const TOKEN_ENDPOINT = 'https://fake.example.com/oauth/token';
+
+  describe('credential modes -> subject_token_type mapping', function () {
+    it('PAT maps to programmatic_access_token', async function () {
+      const axiosInstance = makeFakeAxios(() => okFragmentResponse());
+      const embed = new EmbeddedStreamlit({
+        streamlitId: STREAMLIT_ID,
+        parentOrigin: PARENT_ORIGIN,
+      });
+      embed.prepare({ pat: 'pat-secret-value', tokenEndpoint: TOKEN_ENDPOINT, axiosInstance });
+      await embed.getEmbedUrl();
+
+      const body = new URLSearchParams(axiosInstance.calls[0].data);
+      assert.strictEqual(body.get('subject_token'), 'pat-secret-value');
+      assert.strictEqual(body.get('subject_token_type'), SUBJECT_TOKEN_TYPE.PAT);
+      assert.strictEqual(body.get('subject_token_type'), 'programmatic_access_token');
+    });
+
+    it('keyPair maps to provisional JWT URN by default', async function () {
+      const axiosInstance = makeFakeAxios(() => okFragmentResponse());
+      const embed = new EmbeddedStreamlit({
+        streamlitId: STREAMLIT_ID,
+        parentOrigin: PARENT_ORIGIN,
+      });
+      embed.prepare({ keyPair: 'signed.jwt.value', tokenEndpoint: TOKEN_ENDPOINT, axiosInstance });
+      await embed.getEmbedUrl();
+
+      const body = new URLSearchParams(axiosInstance.calls[0].data);
+      assert.strictEqual(body.get('subject_token'), 'signed.jwt.value');
+      assert.strictEqual(body.get('subject_token_type'), 'urn:ietf:params:oauth:token-type:jwt');
+    });
+
+    it('keyPair subject_token_type is overridable', async function () {
+      const axiosInstance = makeFakeAxios(() => okFragmentResponse());
+      const embed = new EmbeddedStreamlit({
+        streamlitId: STREAMLIT_ID,
+        parentOrigin: PARENT_ORIGIN,
+      });
+      embed.prepare({
+        keyPair: 'signed.jwt.value',
+        subjectTokenType: 'urn:snowflake:token-type:keypair-future',
+        tokenEndpoint: TOKEN_ENDPOINT,
+        axiosInstance,
+      });
+      await embed.getEmbedUrl();
+
+      const body = new URLSearchParams(axiosInstance.calls[0].data);
+      assert.strictEqual(body.get('subject_token_type'), 'urn:snowflake:token-type:keypair-future');
+    });
+
+    it('sessionToken maps to the session URN', async function () {
+      const axiosInstance = makeFakeAxios(() => okFragmentResponse());
+      const embed = new EmbeddedStreamlit({
+        streamlitId: STREAMLIT_ID,
+        parentOrigin: PARENT_ORIGIN,
+      });
+      embed.prepare({ sessionToken: 'sess-tok', tokenEndpoint: TOKEN_ENDPOINT, axiosInstance });
+      await embed.getEmbedUrl();
+
+      const body = new URLSearchParams(axiosInstance.calls[0].data);
+      assert.strictEqual(body.get('subject_token'), 'sess-tok');
+      assert.strictEqual(body.get('subject_token_type'), 'urn:snowflake:token-type:session');
+    });
+
+    it('explicit subjectToken + subjectTokenType passes through verbatim (e.g. WIF)', async function () {
+      const axiosInstance = makeFakeAxios(() => okFragmentResponse());
+      const embed = new EmbeddedStreamlit({
+        streamlitId: STREAMLIT_ID,
+        parentOrigin: PARENT_ORIGIN,
+      });
+      embed.prepare({
+        subjectToken: 'wif-token',
+        subjectTokenType: SUBJECT_TOKEN_TYPE.WIF,
+        tokenEndpoint: TOKEN_ENDPOINT,
+        axiosInstance,
+      });
+      await embed.getEmbedUrl();
+
+      const body = new URLSearchParams(axiosInstance.calls[0].data);
+      assert.strictEqual(body.get('subject_token'), 'wif-token');
+      assert.strictEqual(body.get('subject_token_type'), 'urn:snowflake:token-type:wif');
+    });
+  });
+
+  describe('request wire shape', function () {
+    it('builds scope session:streamlit:<fqn>, token-exchange grant, correct headers, no Authorization', async function () {
+      const axiosInstance = makeFakeAxios(() => okFragmentResponse());
+      const embed = new EmbeddedStreamlit({
+        streamlitId: STREAMLIT_ID,
+        parentOrigin: PARENT_ORIGIN,
+      });
+      embed.prepare({ pat: 'pat', tokenEndpoint: TOKEN_ENDPOINT, axiosInstance });
+      await embed.getEmbedUrl();
+
+      const call = axiosInstance.calls[0];
+      assert.strictEqual(call.method, 'POST');
+      assert.strictEqual(call.url, TOKEN_ENDPOINT);
+
+      const body = new URLSearchParams(call.data);
+      assert.strictEqual(body.get('scope'), 'session:streamlit:mydb.myschema.myapp');
+      assert.strictEqual(body.get('grant_type'), 'urn:ietf:params:oauth:grant-type:token-exchange');
+
+      // application/x-www-form-urlencoded, accept json, and NO client identity.
+      assert.match(call.headers['Content-Type'], /application\/x-www-form-urlencoded/);
+      assert.strictEqual(call.headers['Accept'], 'application/json');
+      assert.strictEqual(call.headers['Authorization'], undefined);
+
+      // Body is a urlencoded string, not gzipped/JSON.
+      assert.strictEqual(typeof call.data, 'string');
+      assert.ok(!call.data.startsWith('{'));
+    });
+
+    it('derives the /oauth/token endpoint from account when none is given', async function () {
+      const axiosInstance = makeFakeAxios(() => okFragmentResponse());
+      const embed = new EmbeddedStreamlit({
+        streamlitId: STREAMLIT_ID,
+        parentOrigin: PARENT_ORIGIN,
+      });
+      embed.prepare({ pat: 'pat', account: 'myacct', axiosInstance });
+      await embed.getEmbedUrl();
+
+      assert.strictEqual(
+        axiosInstance.calls[0].url,
+        'https://myacct.snowflakecomputing.com/oauth/token',
+      );
+    });
+
+    it('derives the endpoint from an explicit host', async function () {
+      const axiosInstance = makeFakeAxios(() => okFragmentResponse());
+      const embed = new EmbeddedStreamlit({
+        streamlitId: STREAMLIT_ID,
+        parentOrigin: PARENT_ORIGIN,
+      });
+      embed.prepare({ pat: 'pat', host: 'foo.us-east-1.snowflakecomputing.com', axiosInstance });
+      await embed.getEmbedUrl();
+
+      assert.strictEqual(
+        axiosInstance.calls[0].url,
+        'https://foo.us-east-1.snowflakecomputing.com/oauth/token',
+      );
+    });
+
+    it('derives the endpoint from a connection accessUrl', async function () {
+      const axiosInstance = makeFakeAxios(() => okFragmentResponse());
+      // Use a non-default port to confirm the port is preserved (URL normalizes
+      // away the default :443, so a custom port is the meaningful assertion).
+      const fakeConnection = { accessUrl: 'https://acct.eu-west-1.snowflakecomputing.com:8443' };
+      const embed = new EmbeddedStreamlit({
+        streamlitId: STREAMLIT_ID,
+        parentOrigin: PARENT_ORIGIN,
+      });
+      embed.prepare({ pat: 'pat', connection: fakeConnection, axiosInstance });
+      await embed.getEmbedUrl();
+
+      assert.strictEqual(
+        axiosInstance.calls[0].url,
+        'https://acct.eu-west-1.snowflakecomputing.com:8443/oauth/token',
+      );
+    });
+
+    it('sends validateStatus that resolves for non-2xx so the HTTP-status error message is produced', async function () {
+      // Without validateStatus, the real axios instance would reject 4xx/5xx
+      // before the module's precise "Token exchange failed with HTTP <status>"
+      // message is produced. The injected fake never throws, so we must assert
+      // validateStatus is present and permissive directly to protect the
+      // error-message contract against accidental removal.
+      const axiosInstance = makeFakeAxios(() => okFragmentResponse());
+      const embed = new EmbeddedStreamlit({
+        streamlitId: STREAMLIT_ID,
+        parentOrigin: PARENT_ORIGIN,
+      });
+      embed.prepare({ pat: 'pat', tokenEndpoint: TOKEN_ENDPOINT, axiosInstance });
+      await embed.getEmbedUrl();
+
+      const validateStatus = axiosInstance.calls[0].validateStatus;
+      assert.strictEqual(typeof validateStatus, 'function');
+      assert.strictEqual(validateStatus(403), true);
+      assert.strictEqual(validateStatus(500), true);
+      assert.strictEqual(validateStatus(200), true);
+    });
+  });
+
+  describe('embed URL assembly', function () {
+    async function getUrlForRedirect(redirectUri, parentOrigin = PARENT_ORIGIN) {
+      const axiosInstance = makeFakeAxios(() => ({
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+        // oxlint-disable-next-line camelcase
+        data: { redirect_uri: redirectUri, expires_in: 600 },
+      }));
+      const embed = new EmbeddedStreamlit({ streamlitId: STREAMLIT_ID, parentOrigin });
+      embed.prepare({ pat: 'pat', tokenEndpoint: TOKEN_ENDPOINT, axiosInstance });
+      return embed.getEmbedUrl();
+    }
+
+    it('extracts the code from the redirect_uri fragment (#code=)', async function () {
+      const url = await getUrlForRedirect('https://app.snowflakecomputing.com/sl#code=FRAGCODE');
+      assert.strictEqual(
+        url,
+        'https://app.snowflakecomputing.com/sl?__parentOrigin=https%3A%2F%2Fanalytics.bmw.com&__embeddedApp=true#code=FRAGCODE',
+      );
+    });
+
+    it('extracts the code from the redirect_uri query (?code=)', async function () {
+      const url = await getUrlForRedirect('https://app.snowflakecomputing.com/sl?code=QUERYCODE');
+      assert.strictEqual(
+        url,
+        'https://app.snowflakecomputing.com/sl?__parentOrigin=https%3A%2F%2Fanalytics.bmw.com&__embeddedApp=true#code=QUERYCODE',
+      );
+    });
+
+    it('extracts the code from a trailing query (&code=) and preserves other query params', async function () {
+      const url = await getUrlForRedirect(
+        'https://app.snowflakecomputing.com/sl?foo=bar&code=AMPCODE',
+      );
+      assert.strictEqual(
+        url,
+        'https://app.snowflakecomputing.com/sl?foo=bar&__parentOrigin=https%3A%2F%2Fanalytics.bmw.com&__embeddedApp=true#code=AMPCODE',
+      );
+    });
+
+    it('prefers the fragment code over a query code when both are present', async function () {
+      // Contract: fragment is checked first, then query. With both present the
+      // fragment code must win.
+      const url = await getUrlForRedirect(
+        'https://app.snowflakecomputing.com/sl?code=QUERYCODE#code=FRAGCODE',
+      );
+      assert.ok(url.endsWith('#code=FRAGCODE'));
+      assert.ok(!url.includes('FRAGCODE&'));
+      // The query-form code must NOT have leaked into the assembled URL.
+      assert.ok(!url.includes('QUERYCODE'));
+    });
+
+    it('round-trips an opaque azcode byte-faithfully (no percent-decoding)', async function () {
+      // A non-hex, base64url/base64-ish code carrying '+', '/', '=' and a
+      // percent-encoded byte. URLSearchParams would corrupt this ('+' -> space,
+      // '%2B' -> '+'); the raw substring extraction must preserve it verbatim.
+      const opaque = 'ab+c/d=e%2Bf';
+      const url = await getUrlForRedirect(`https://app.snowflakecomputing.com/sl#code=${opaque}`);
+      assert.ok(
+        url.endsWith(`#code=${opaque}`),
+        `expected the azcode to survive byte-for-byte, got: ${url}`,
+      );
+    });
+
+    it('round-trips an opaque azcode from the query form byte-faithfully', async function () {
+      const opaque = 'XY+z/9%3D';
+      const url = await getUrlForRedirect(`https://app.snowflakecomputing.com/sl?code=${opaque}`);
+      assert.ok(
+        url.endsWith(`#code=${opaque}`),
+        `expected the query-form azcode to survive byte-for-byte, got: ${url}`,
+      );
+    });
+
+    it('appends with & when the base already carries a query string', async function () {
+      const url = await getUrlForRedirect('https://app.snowflakecomputing.com/sl?keep=1#code=C');
+      // The surviving query (?keep=1) must be preserved and embed params appended with &.
+      assert.ok(url.startsWith('https://app.snowflakecomputing.com/sl?keep=1&__parentOrigin='));
+      assert.ok(url.includes('&__embeddedApp=true'));
+      assert.ok(url.endsWith('#code=C'));
+    });
+
+    it('url-encodes the parentOrigin', async function () {
+      const url = await getUrlForRedirect(
+        'https://app.snowflakecomputing.com/sl#code=C',
+        'https://my-host.example.com:8443/embed?x=1',
+      );
+      assert.ok(
+        url.includes('__parentOrigin=https%3A%2F%2Fmy-host.example.com%3A8443%2Fembed%3Fx%3D1'),
+      );
+    });
+
+    it('strips any pre-existing __embeddedApp / __parentOrigin params from the base', async function () {
+      const url = await getUrlForRedirect(
+        'https://app.snowflakecomputing.com/sl?__embeddedApp=true&__parentOrigin=https%3A%2F%2Fold.com&code=C',
+      );
+      // Old reserved params must not survive; only one of each remains.
+      assert.strictEqual((url.match(/__embeddedApp=true/g) || []).length, 1);
+      assert.strictEqual((url.match(/__parentOrigin=/g) || []).length, 1);
+      assert.ok(url.includes('__parentOrigin=https%3A%2F%2Fanalytics.bmw.com'));
+      assert.ok(!url.includes('old.com'));
+      assert.ok(url.endsWith('#code=C'));
+    });
+
+    it('exposes expires_in after getEmbedUrl()', async function () {
+      const axiosInstance = makeFakeAxios(() => okFragmentResponse());
+      const embed = new EmbeddedStreamlit({
+        streamlitId: STREAMLIT_ID,
+        parentOrigin: PARENT_ORIGIN,
+      });
+      embed.prepare({ pat: 'pat', tokenEndpoint: TOKEN_ENDPOINT, axiosInstance });
+      await embed.getEmbedUrl();
+      assert.strictEqual(embed.getExpiresIn(), 600);
+    });
+
+    it('generateStreamlitEmbedUrl convenience helper returns the assembled URL', async function () {
+      const axiosInstance = makeFakeAxios(() =>
+        okFragmentResponse('HELPERCODE', 'app.snowflakecomputing.com'),
+      );
+      const url = await generateStreamlitEmbedUrl({
+        streamlitId: STREAMLIT_ID,
+        parentOrigin: PARENT_ORIGIN,
+        pat: 'pat',
+        tokenEndpoint: TOKEN_ENDPOINT,
+        axiosInstance,
+      });
+      assert.ok(url.endsWith('#code=HELPERCODE'));
+      assert.ok(url.includes('__embeddedApp=true'));
+    });
+  });
+
+  describe('error cases', function () {
+    it('rejects prepare() with no credential', function () {
+      const embed = new EmbeddedStreamlit({
+        streamlitId: STREAMLIT_ID,
+        parentOrigin: PARENT_ORIGIN,
+      });
+      assert.throws(
+        () => embed.prepare({ tokenEndpoint: TOKEN_ENDPOINT }),
+        /No credential supplied/,
+      );
+    });
+
+    it('rejects a missing parentOrigin', function () {
+      const embed = new EmbeddedStreamlit({ streamlitId: STREAMLIT_ID });
+      assert.throws(() => embed.prepare({ pat: 'pat' }), /parentOrigin is required/);
+    });
+
+    it('rejects a streamlitId containing ":"', function () {
+      const embed = new EmbeddedStreamlit({
+        streamlitId: 'db.schema:app',
+        parentOrigin: PARENT_ORIGIN,
+      });
+      assert.throws(() => embed.prepare({ pat: 'pat' }), /must contain no ':'/);
+    });
+
+    it('rejects when the account origin cannot be resolved', function () {
+      const embed = new EmbeddedStreamlit({
+        streamlitId: STREAMLIT_ID,
+        parentOrigin: PARENT_ORIGIN,
+      });
+      // No host/connection/account/tokenEndpoint supplied.
+      assert.throws(
+        () => embed.prepare({ pat: 'pat' }),
+        /Unable to resolve the Snowflake account origin/,
+      );
+    });
+
+    it('rejects getEmbedUrl() before prepare()', async function () {
+      const embed = new EmbeddedStreamlit({
+        streamlitId: STREAMLIT_ID,
+        parentOrigin: PARENT_ORIGIN,
+      });
+      await assert.rejects(() => embed.getEmbedUrl(), /called before prepare/);
+    });
+
+    it('rejects a non-200 token-exchange response', async function () {
+      const axiosInstance = makeFakeAxios(() => ({
+        status: 403,
+        headers: { 'content-type': 'application/json' },
+        data: { error: 'forbidden' },
+      }));
+      const embed = new EmbeddedStreamlit({
+        streamlitId: STREAMLIT_ID,
+        parentOrigin: PARENT_ORIGIN,
+      });
+      embed.prepare({ pat: 'pat', tokenEndpoint: TOKEN_ENDPOINT, axiosInstance });
+      await assert.rejects(() => embed.getEmbedUrl(), /HTTP 403/);
+    });
+
+    it('rejects a 200 response missing redirect_uri', async function () {
+      const axiosInstance = makeFakeAxios(() => ({
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+        // oxlint-disable-next-line camelcase
+        data: { expires_in: 600 },
+      }));
+      const embed = new EmbeddedStreamlit({
+        streamlitId: STREAMLIT_ID,
+        parentOrigin: PARENT_ORIGIN,
+      });
+      embed.prepare({ pat: 'pat', tokenEndpoint: TOKEN_ENDPOINT, axiosInstance });
+      await assert.rejects(() => embed.getEmbedUrl(), /did not contain a redirect_uri/);
+    });
+
+    it('rejects a redirect_uri with no authorization code', async function () {
+      const axiosInstance = makeFakeAxios(() => ({
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+        // oxlint-disable-next-line camelcase
+        data: { redirect_uri: 'https://app.snowflakecomputing.com/sl', expires_in: 600 },
+      }));
+      const embed = new EmbeddedStreamlit({
+        streamlitId: STREAMLIT_ID,
+        parentOrigin: PARENT_ORIGIN,
+      });
+      embed.prepare({ pat: 'pat', tokenEndpoint: TOKEN_ENDPOINT, axiosInstance });
+      await assert.rejects(() => embed.getEmbedUrl(), /did not contain an authorization code/);
+    });
+
+    it('parses a JSON string response body (axios non-parsed)', async function () {
+      const axiosInstance = makeFakeAxios(() => ({
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+        data: JSON.stringify({
+          // oxlint-disable-next-line camelcase
+          redirect_uri: 'https://app.snowflakecomputing.com/sl#code=STRBODY',
+          // oxlint-disable-next-line camelcase
+          expires_in: 300,
+        }),
+      }));
+      const embed = new EmbeddedStreamlit({
+        streamlitId: STREAMLIT_ID,
+        parentOrigin: PARENT_ORIGIN,
+      });
+      embed.prepare({ pat: 'pat', tokenEndpoint: TOKEN_ENDPOINT, axiosInstance });
+      const url = await embed.getEmbedUrl();
+      assert.ok(url.endsWith('#code=STRBODY'));
+    });
+  });
+
+  describe('secret hygiene', function () {
+    it('does not place the credential in the request URL or headers', async function () {
+      const axiosInstance = makeFakeAxios(() => okFragmentResponse());
+      const embed = new EmbeddedStreamlit({
+        streamlitId: STREAMLIT_ID,
+        parentOrigin: PARENT_ORIGIN,
+      });
+      embed.prepare({ pat: 'super-secret-pat', tokenEndpoint: TOKEN_ENDPOINT, axiosInstance });
+      await embed.getEmbedUrl();
+
+      const call = axiosInstance.calls[0];
+      assert.ok(!call.url.includes('super-secret-pat'));
+      assert.ok(!JSON.stringify(call.headers).includes('super-secret-pat'));
+      // The credential lives only in the form body.
+      assert.ok(call.data.includes('super-secret-pat'));
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds a native helper to generate a short-lived Streamlit-in-Snowflake (SiS) embed URL via the
Snowflake OAuth 2.0 token-exchange endpoint, replacing the need for the
`SYSTEM$STREAMLIT_GENERATE_EMBED_URL` SQL system function so a customer backend can mint an
embed URL from a service credential **without a SQL session**. The new `EmbeddedStreamlit` class
(and `generateStreamlitEmbedUrl` convenience helper) POST a form-encoded
`grant_type=token-exchange` request to `/oauth/token`, extract the single-use authorization code
from the returned `redirect_uri`, and assemble the final embed URL in the exact format the GS
system function produces.

> **DRAFT** — depends on the GS server-side token-exchange streamlit-scope endpoint (not yet in
> production); all unit tests mock the HTTP layer.

## Motivation

Customer backends (e.g. `analytics.bmw.com`) embed SiS apps in 3rd-party pages and must mint a
short-lived embed URL using a service credential (PAT / key-pair / session) **without** a SQL
session, which `SYSTEM$STREAMLIT_GENERATE_EMBED_URL` requires today. This native helper performs
the token-exchange directly from the driver.

Design docs: [Streamlit Drivers](https://docs.google.com/document/d/1x4t63bbq7arzhBU5ZOyP2828hFuXk7quLzDOtNbDQZY)
and [Embedded Streamlit Authentication](https://docs.google.com/document/d/1HwA7gJGKJebDUuvMIRUoe14Tl4Q9X4Au02iakQTNkWc).

## What changed

- **`lib/streamlit_embed.js`** (new): `EmbeddedStreamlit` class + `generateStreamlitEmbedUrl`
  helper + `SUBJECT_TOKEN_TYPE` map.
- **`lib/core.js`**: attaches `instance.EmbeddedStreamlit` and `instance.generateStreamlitEmbedUrl`.
- **`index.d.ts`**: TypeScript declarations for the class, its config/prepare-option interfaces,
  and the helper.
- **`test/unit/streamlit_embed_test.js`** (new): 31 unit tests, HTTP fully mocked.

```js
const snowflake = require('snowflake-sdk');

const embed = new snowflake.EmbeddedStreamlit({
  streamlitId: 'mydb.myschema.myapp',          // db.schema.app — no ':'
  parentOrigin: 'https://analytics.bmw.com',
});
embed.prepare({ pat: process.env.SF_PAT, account: 'myaccount' });
const url = await embed.getEmbedUrl();

// one-shot helper; key-pair (provisional, overridable subjectTokenType) or WIF via escape hatch:
const url2 = await snowflake.generateStreamlitEmbedUrl({
  streamlitId: 'mydb.myschema.myapp',
  parentOrigin: 'https://analytics.bmw.com',
  account: 'myaccount',
  subjectToken: workloadIdentityAttestation,
  subjectTokenType: snowflake.SUBJECT_TOKEN_TYPE.WIF,
});
```

`prepare()` accepts one primary credential (`pat` | `keyPair` | `sessionToken` | explicit
`subjectToken`+`subjectTokenType`), plus `account`/`host`/`tokenEndpoint` (overridable for tests).

## Wire contract

- **Request:** `POST https://<account>.snowflakecomputing.com/oauth/token`,
  `Content-Type: application/x-www-form-urlencoded; charset=UTF-8`, `Accept: application/json`,
  and **no `Authorization` header / no client identity**. Body keys:
  `grant_type=urn:ietf:params:oauth:grant-type:token-exchange`, `subject_token=<credential>`,
  `subject_token_type=<URN>`, `scope=session:streamlit:<db.schema.app>` (FQN must contain no `:`).
- **`subject_token_type` mapping** (verified against GS `SFOAuthTokenType.java`):
  session → `urn:snowflake:token-type:session`; PAT → `programmatic_access_token`;
  WIF → `urn:snowflake:token-type:wif`; OAuth access token →
  `urn:ietf:params:oauth:token-type:access_token`; key-pair JWT → **provisional**
  `urn:ietf:params:oauth:token-type:jwt` (overridable). An explicit
  `(subjectToken, subjectTokenType)` pair is also accepted as a forward-compat escape hatch.
- **Response (HTTP 200, JSON):** `{ "redirect_uri": "...", "expires_in": <seconds> }`; the code
  may be a fragment (`#code=`) or query (`?code=` / `&code=`).
- **URL assembly:** extract the code (fragment first, then query) **without percent-decoding it**
  — the value is sliced raw from `redirect_uri` so an opaque/base64url code survives byte-for-byte;
  compute `scheme://host[:port]/path` minus the code and any pre-existing
  `__embeddedApp`/`__parentOrigin`; return
  `base + "?__parentOrigin=" + urlencode(parentOrigin) + "&__embeddedApp=true" + "#code=" + code`
  (append with `&` when the base already has a query). The credential and code are never logged
  above debug.

## Server dependency / open questions

1. GS must add `EntityType.STREAMLIT` + the `session:streamlit:<fqn>` scope handler at
   `POST /oauth/token`; not in production yet (this PR is DRAFT until it lands).
2. Key-pair `subject_token_type` is **provisional** — no GS enum value today; default
   `urn:ietf:params:oauth:token-type:jwt` is overridable (plus the explicit
   `subjectToken`/`subjectTokenType` escape hatch).
3. `/oauth/token` path and `redirect_uri` code placement are assumed per the verified contract;
   the helper tolerates the code in either the fragment or the query.

## Testing

`test/unit/streamlit_embed_test.js` — **31 tests**, HTTP fully mocked via an injected fake axios
instance (token endpoint overridable, no network touched): each credential mode + mapping;
key-pair override; scope; `grant_type`, urlencoded content-type, `Accept`, **absence of
Authorization**; endpoint derivation from account/host/connection.accessUrl (non-default port
preserved); code extraction from `#fragment`/`?query`/`&code=`; **fragment-wins precedence**;
**byte-faithful round-trip of an opaque azcode (`+`/`/`/`=`/`%`)** from both forms; URL assembly;
`expires_in`; secret hygiene; `validateStatus` permissiveness so the precise HTTP-status error
survives; and the full error matrix.

Commands run (observed):
```
npx mocha test/unit/streamlit_embed_test.js     => 31 passing
npx oxlint lib/streamlit_embed.js test/...      => exit 0, clean
npx prettier --check ...                        => all files conform
npx tsc --noEmit --strict ... (index.d.ts)      => exit 0
npx mocha test/unit/snowflake_test.js           => 127 passing, 1 pending (core.js wiring intact)
```
Full `npm run check-ts` was **not** run end-to-end (its build glob surfaces pre-existing WIP TS
errors in unrelated files, e.g. `lib/disk_cache.ts`); `index.d.ts` was validated in isolation with
the project's flags. No live integration/e2e — the GS endpoint is not in production yet.

## Out of scope

Live integration/e2e tests (GS endpoint not in prod); other drivers (Go / .NET / ODBC; Python and
JDBC have sibling draft PRs); removing the `SYSTEM$STREAMLIT_GENERATE_EMBED_URL` system function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
