### PR TITLE
Fix GitHub actions

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -51,7 +51,7 @@ jobs:
         # (CVE-2026-48931 fix) that makes node-fetch@2 throw "Premature close" and breaks the
         # WireMock REST client in tests (nodejs/node#63989). Fixed in 22.23.1 / 24.18.0. Revert to
         # floating majors once GitHub runner tool-cache no longer serves the broken patches.
-        nodeVersion: ['20.20.2', '22.23.1', '24.18.0']
+        nodeVersion: ['20.x', '22.23.1', '24.18.0']
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -95,7 +95,7 @@ jobs:
         # WireMock REST client in tests (https://github.com/nodejs/node/issues/63989).
         # Fixed in 22.23.1 / 24.18.0.
         # Revert to floating majors once GitHub runner tool-cache no longer serves the broken patches.
-        nodeVersion: ['20.20.2', '22.23.1', '24.18.0']
+        nodeVersion: ['20.x', '22.23.1', '24.18.0']
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -162,7 +162,7 @@ jobs:
         # WireMock REST client in tests (https://github.com/nodejs/node/issues/63989).
         # Fixed in 22.23.1 / 24.18.0.
         # Revert to floating majors once GitHub runner tool-cache no longer serves the broken patches.
-        nodeVersion: ['20.20.2', '22.23.1', '24.18.0']
+        nodeVersion: ['20.x', '22.23.1', '24.18.0']
     steps:
       - uses: actions/checkout@v4
       - name: Download Build Artifacts

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -92,8 +92,9 @@ jobs:
         cloud: ['AWS', 'AZURE', 'GCP']
         # Pin to patched releases: Node 22.23.0/24.17.0 shipped a keep-alive socket guard
         # (CVE-2026-48931 fix) that makes node-fetch@2 throw "Premature close" and breaks the
-        # WireMock REST client in tests (nodejs/node#63989). Fixed in 22.23.1 / 24.18.0. Revert to
-        # floating majors once GitHub runner tool-cache no longer serves the broken patches.
+        # WireMock REST client in tests (https://github.com/nodejs/node/issues/63989).
+        # Fixed in 22.23.1 / 24.18.0.
+        # Revert to floating majors once GitHub runner tool-cache no longer serves the broken patches.
         nodeVersion: ['20.20.2', '22.23.1', '24.18.0']
     steps:
       - uses: actions/checkout@v4
@@ -158,8 +159,9 @@ jobs:
         cloud: ['AWS', 'AZURE', 'GCP']
         # Pin to patched releases: Node 22.23.0/24.17.0 shipped a keep-alive socket guard
         # (CVE-2026-48931 fix) that makes node-fetch@2 throw "Premature close" and breaks the
-        # WireMock REST client in tests (nodejs/node#63989). Fixed in 22.23.1 / 24.18.0. Revert to
-        # floating majors once GitHub runner tool-cache no longer serves the broken patches.
+        # WireMock REST client in tests (https://github.com/nodejs/node/issues/63989).
+        # Fixed in 22.23.1 / 24.18.0.
+        # Revert to floating majors once GitHub runner tool-cache no longer serves the broken patches.
         nodeVersion: ['20.20.2', '22.23.1', '24.18.0']
     steps:
       - uses: actions/checkout@v4
@@ -194,8 +196,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          # Pinned to patched 22.23.1 (see nodeVersion comment above): 22.23.0 breaks node-fetch@2.
-          node-version: '22.23.1'
+          node-version: '22.x'
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -41,7 +41,7 @@ jobs:
 
   test-mac:
     needs: build
-    name: Tests on Mac
+    name: Tests on Mac (${{ matrix.cloud }}, ${{ matrix.nodeVersion.label }})
     runs-on: macos-latest
     strategy:
       fail-fast: false
@@ -50,14 +50,18 @@ jobs:
         # Pin to patched releases: Node 22.23.0/24.17.0 shipped a keep-alive socket guard
         # (CVE-2026-48931 fix) that makes node-fetch@2 throw "Premature close" and breaks the
         # WireMock REST client in tests (https://github.com/nodejs/node/issues/63989).
-        # Fixed in 22.23.1 / 24.18.0.
-        # Revert to floating majors once GitHub runner tool-cache no longer serves the broken patches.
-        nodeVersion: ['20.x', '22.23.1', '24.18.0']
+        # Fixed in 22.23.1 / 24.18.0. The `label` keeps the required-check name stable (e.g. 22.x)
+        # while `version` installs the patched release.
+        # Revert `version` to the floating major once GitHub runner tool-cache no longer serves the broken patches.
+        nodeVersion:
+          - { label: '20.x', version: '20.x' }
+          - { label: '22.x', version: '22.23.1' }
+          - { label: '24.x', version: '24.18.0' }
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.nodeVersion }}
+          node-version: ${{ matrix.nodeVersion.version }}
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
@@ -85,7 +89,7 @@ jobs:
 
   test-windows:
     needs: build
-    name: Tests on Windows
+    name: Tests on Windows (${{ matrix.cloud }}, ${{ matrix.nodeVersion.label }})
     runs-on: windows-latest
     strategy:
       fail-fast: false
@@ -94,9 +98,13 @@ jobs:
         # Pin to patched releases: Node 22.23.0/24.17.0 shipped a keep-alive socket guard
         # (CVE-2026-48931 fix) that makes node-fetch@2 throw "Premature close" and breaks the
         # WireMock REST client in tests (https://github.com/nodejs/node/issues/63989).
-        # Fixed in 22.23.1 / 24.18.0.
-        # Revert to floating majors once GitHub runner tool-cache no longer serves the broken patches.
-        nodeVersion: ['20.x', '22.23.1', '24.18.0']
+        # Fixed in 22.23.1 / 24.18.0. The `label` keeps the required-check name stable (e.g. 22.x)
+        # while `version` installs the patched release.
+        # Revert `version` to the floating major once GitHub runner tool-cache no longer serves the broken patches.
+        nodeVersion:
+          - { label: '20.x', version: '20.x' }
+          - { label: '22.x', version: '22.23.1' }
+          - { label: '24.x', version: '24.18.0' }
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -106,7 +114,7 @@ jobs:
           java-package: 'jre'
       - uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.nodeVersion }}
+          node-version: ${{ matrix.nodeVersion.version }}
       - uses: actions/setup-python@v5
         with:
           python-version: '3.7'
@@ -152,7 +160,7 @@ jobs:
 
   test-ubuntu:
     needs: build
-    name: Tests on Ubuntu
+    name: Tests on Ubuntu (${{ matrix.cloud }}, ${{ matrix.nodeVersion.label }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -161,9 +169,13 @@ jobs:
         # Pin to patched releases: Node 22.23.0/24.17.0 shipped a keep-alive socket guard
         # (CVE-2026-48931 fix) that makes node-fetch@2 throw "Premature close" and breaks the
         # WireMock REST client in tests (https://github.com/nodejs/node/issues/63989).
-        # Fixed in 22.23.1 / 24.18.0.
-        # Revert to floating majors once GitHub runner tool-cache no longer serves the broken patches.
-        nodeVersion: ['20.x', '22.23.1', '24.18.0']
+        # Fixed in 22.23.1 / 24.18.0. The `label` keeps the required-check name stable (e.g. 22.x)
+        # while `version` installs the patched release.
+        # Revert `version` to the floating major once GitHub runner tool-cache no longer serves the broken patches.
+        nodeVersion:
+          - { label: '20.x', version: '20.x' }
+          - { label: '22.x', version: '22.23.1' }
+          - { label: '24.x', version: '24.18.0' }
     steps:
       - uses: actions/checkout@v4
       - name: Download Build Artifacts
@@ -174,7 +186,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.nodeVersion }}
+          node-version: ${{ matrix.nodeVersion.version }}
       - name: Tests
         shell: bash
         env:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -47,7 +47,11 @@ jobs:
       fail-fast: false
       matrix:
         cloud: ['AWS', 'AZURE', 'GCP']
-        nodeVersion: ['20.x', '22.x', '24.x']
+        # Pin to patched releases: Node 22.23.0/24.17.0 shipped a keep-alive socket guard
+        # (CVE-2026-48931 fix) that makes node-fetch@2 throw "Premature close" and breaks the
+        # WireMock REST client in tests (nodejs/node#63989). Fixed in 22.23.1 / 24.18.0. Revert to
+        # floating majors once GitHub runner tool-cache no longer serves the broken patches.
+        nodeVersion: ['20.20.2', '22.23.1', '24.18.0']
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -86,7 +90,11 @@ jobs:
       fail-fast: false
       matrix:
         cloud: ['AWS', 'AZURE', 'GCP']
-        nodeVersion: ['20.x', '22.x', '24.x']
+        # Pin to patched releases: Node 22.23.0/24.17.0 shipped a keep-alive socket guard
+        # (CVE-2026-48931 fix) that makes node-fetch@2 throw "Premature close" and breaks the
+        # WireMock REST client in tests (nodejs/node#63989). Fixed in 22.23.1 / 24.18.0. Revert to
+        # floating majors once GitHub runner tool-cache no longer serves the broken patches.
+        nodeVersion: ['20.20.2', '22.23.1', '24.18.0']
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -148,7 +156,11 @@ jobs:
       fail-fast: false
       matrix:
         cloud: ['AWS', 'AZURE', 'GCP']
-        nodeVersion: ['20.x', '22.x', '24.x']
+        # Pin to patched releases: Node 22.23.0/24.17.0 shipped a keep-alive socket guard
+        # (CVE-2026-48931 fix) that makes node-fetch@2 throw "Premature close" and breaks the
+        # WireMock REST client in tests (nodejs/node#63989). Fixed in 22.23.1 / 24.18.0. Revert to
+        # floating majors once GitHub runner tool-cache no longer serves the broken patches.
+        nodeVersion: ['20.20.2', '22.23.1', '24.18.0']
     steps:
       - uses: actions/checkout@v4
       - name: Download Build Artifacts
@@ -182,7 +194,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '22.x'
+          # Pinned to patched 22.23.1 (see nodeVersion comment above): 22.23.0 breaks node-fetch@2.
+          node-version: '22.23.1'
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -49,8 +49,9 @@ jobs:
         cloud: ['AWS', 'AZURE', 'GCP']
         # Pin to patched releases: Node 22.23.0/24.17.0 shipped a keep-alive socket guard
         # (CVE-2026-48931 fix) that makes node-fetch@2 throw "Premature close" and breaks the
-        # WireMock REST client in tests (nodejs/node#63989). Fixed in 22.23.1 / 24.18.0. Revert to
-        # floating majors once GitHub runner tool-cache no longer serves the broken patches.
+        # WireMock REST client in tests (https://github.com/nodejs/node/issues/63989).
+        # Fixed in 22.23.1 / 24.18.0.
+        # Revert to floating majors once GitHub runner tool-cache no longer serves the broken patches.
         nodeVersion: ['20.x', '22.23.1', '24.18.0']
     steps:
       - uses: actions/checkout@v4

--- a/lib/connection/result/datetime_format_converter.js
+++ b/lib/connection/result/datetime_format_converter.js
@@ -37,7 +37,7 @@ function convertSnowflakeFormatToMomentFormat(formatSql, scale) {
   // iterate over the format string
   const length = formatSql.length;
   let formatMoment = '';
-  for (let pos = 0; pos < length; ) {
+  for (let pos = 0; pos < length;) {
     let tag = null;
     let out = null;
 

--- a/lib/connection/result/sf_timestamp.js
+++ b/lib/connection/result/sf_timestamp.js
@@ -66,7 +66,7 @@ SfTimestamp.prototype.toString = function () {
   // iterate over the format string
   const length = formatSql.length;
   let formatMoment = '';
-  for (let pos = 0; pos < length; ) {
+  for (let pos = 0; pos < length;) {
     let tag = null;
     let out = null;
 

--- a/test/unit/agent/crl_validator/test_utils.ts
+++ b/test/unit/agent/crl_validator/test_utils.ts
@@ -129,8 +129,7 @@ export function createTestCertificate(
     signatureAlgorithmOid?: string;
     rsassaPssHashOid?: string;
     crlDistributionPoints?: (
-      | TestCertificateCrlDistributionPointValue
-      | TestCertificateCrlDistributionPointValue[]
+      TestCertificateCrlDistributionPointValue | TestCertificateCrlDistributionPointValue[]
     )[];
   } = {},
 ): rfc5280.CertificateDecoded {

--- a/test/wiremockRunner.js
+++ b/test/wiremockRunner.js
@@ -42,7 +42,7 @@ async function runWireMockAsync(port, options = {}) {
       waitForWiremockStarted(wireMock, counter, maxRetries)
         .then((restClient) => {
           restClient.rootUrl = baseUri;
-          resolve(restClient);
+          resolve(patchAdminClientWithNativeFetch(restClient, baseUri));
         })
         .catch(reject);
     } catch (err) {
@@ -89,6 +89,88 @@ async function waitForWiremockStarted(wireMock, counter, maxRetries = 30) {
         return Promise.reject('Wiremock: Waiting time has expired');
       }
     });
+}
+
+/**
+ * @param {string} baseUri - WireMock base URI, e.g. http://localhost:8081
+ * @param {string} path - Admin path beginning with `/`, e.g. `/__admin/shutdown`
+ * @param {Object} [options={}] - Fetch options (method, body, ...)
+ * @returns {Promise<any>} Parsed JSON body when present, otherwise the raw text.
+ */
+async function adminFetch(baseUri, path, options = {}) {
+  const response = await fetch(`${baseUri}${path}`, {
+    headers: { 'Content-Type': 'application/json' },
+    ...options,
+  });
+  const text = await response.text();
+  if (!response.ok) {
+    throw new Error(`WireMock admin request failed: [${response.status}] ${path} - ${text}`);
+  }
+  try {
+    return text ? JSON.parse(text) : text;
+  } catch {
+    return text;
+  }
+}
+
+/**
+ * Replaces the `wiremock-rest-client` admin methods that our tests use with native-`fetch`
+ * implementations (see {@link adminFetch}). All existing call sites keep working unchanged - only
+ * the transport underneath changes.
+ *
+ * WHY THIS PATCH EXISTS:
+ * `wiremock-rest-client` routes every admin call through `cross-fetch`, which on the server side
+ * pulls in the unmaintained `node-fetch@2`. Node's June 2026 security release (CVE-2026-48931 - the
+ * HTTP "response queue poisoning" fix, shipped in 22.23.0 / 24.17.0 / 26.3.1) added a guard
+ * listener on idle keep-alive sockets. That guard makes `node-fetch@2` mis-detect a perfectly
+ * complete response as truncated and throw `FetchError: ... Premature close`
+ * (nodejs/node#63989, #64098). WireMock's admin server closes its keep-alive socket aggressively -
+ * especially on `/__admin/shutdown` - so as soon as the GitHub Actions runners picked up those Node
+ * patches, the rest-client started crashing our WireMock tests in setup/teardown hooks.
+ *
+ * Node's native `fetch` (undici) does NOT have this bug, so we re-point each admin method the tests
+ * rely on at `adminFetch`, which talks to WireMock directly. Keeping the workaround here (rather
+ * than pinning a CI Node version) makes it independent of the runtime and resilient to future
+ * re-regressions of the same kind (it already re-regressed once on the 26.x line).
+ *
+ * TODO: Drop wiremock-rest-client in the Universal Driver migration
+ *
+ * @param {Object} restClient - The WireMock REST client instance
+ * @param {string} baseUri - WireMock base URI
+ * @returns {Object} The same client, with admin methods patched.
+ */
+function patchAdminClientWithNativeFetch(restClient, baseUri) {
+  // Shutdown is pure teardown: the server is going away, so a dropped connection while it tears
+  // down its socket is expected and harmless. Swallow connection errors so cleanup never fails the
+  // suite (an unreachable server here just means it already stopped).
+  restClient.global.shutdown = async () => {
+    try {
+      return await adminFetch(baseUri, '/__admin/shutdown', { method: 'POST' });
+    } catch (err) {
+      Logger.getInstance().info(`Ignoring WireMock shutdown error: ${err.message || err}`);
+      return '';
+    }
+  };
+
+  restClient.mappings.resetAllMappings = () =>
+    adminFetch(baseUri, '/__admin/mappings/reset', { method: 'POST' });
+
+  restClient.mappings.createMapping = (stubMapping) =>
+    adminFetch(baseUri, '/__admin/mappings', {
+      method: 'POST',
+      body: JSON.stringify(stubMapping),
+    });
+
+  restClient.scenarios.resetAllScenarios = () =>
+    adminFetch(baseUri, '/__admin/scenarios/reset', { method: 'POST' });
+
+  restClient.requests.getCount = (requestPattern) =>
+    adminFetch(baseUri, '/__admin/requests/count', {
+      method: 'POST',
+      body: JSON.stringify(requestPattern),
+    });
+
+  return restClient;
 }
 
 /**

--- a/test/wiremockRunner.js
+++ b/test/wiremockRunner.js
@@ -42,7 +42,7 @@ async function runWireMockAsync(port, options = {}) {
       waitForWiremockStarted(wireMock, counter, maxRetries)
         .then((restClient) => {
           restClient.rootUrl = baseUri;
-          resolve(patchAdminClientWithNativeFetch(restClient, baseUri));
+          resolve(restClient);
         })
         .catch(reject);
     } catch (err) {
@@ -89,88 +89,6 @@ async function waitForWiremockStarted(wireMock, counter, maxRetries = 30) {
         return Promise.reject('Wiremock: Waiting time has expired');
       }
     });
-}
-
-/**
- * @param {string} baseUri - WireMock base URI, e.g. http://localhost:8081
- * @param {string} path - Admin path beginning with `/`, e.g. `/__admin/shutdown`
- * @param {Object} [options={}] - Fetch options (method, body, ...)
- * @returns {Promise<any>} Parsed JSON body when present, otherwise the raw text.
- */
-async function adminFetch(baseUri, path, options = {}) {
-  const response = await fetch(`${baseUri}${path}`, {
-    headers: { 'Content-Type': 'application/json' },
-    ...options,
-  });
-  const text = await response.text();
-  if (!response.ok) {
-    throw new Error(`WireMock admin request failed: [${response.status}] ${path} - ${text}`);
-  }
-  try {
-    return text ? JSON.parse(text) : text;
-  } catch {
-    return text;
-  }
-}
-
-/**
- * Replaces the `wiremock-rest-client` admin methods that our tests use with native-`fetch`
- * implementations (see {@link adminFetch}). All existing call sites keep working unchanged - only
- * the transport underneath changes.
- *
- * WHY THIS PATCH EXISTS:
- * `wiremock-rest-client` routes every admin call through `cross-fetch`, which on the server side
- * pulls in the unmaintained `node-fetch@2`. Node's June 2026 security release (CVE-2026-48931 - the
- * HTTP "response queue poisoning" fix, shipped in 22.23.0 / 24.17.0 / 26.3.1) added a guard
- * listener on idle keep-alive sockets. That guard makes `node-fetch@2` mis-detect a perfectly
- * complete response as truncated and throw `FetchError: ... Premature close`
- * (nodejs/node#63989, #64098). WireMock's admin server closes its keep-alive socket aggressively -
- * especially on `/__admin/shutdown` - so as soon as the GitHub Actions runners picked up those Node
- * patches, the rest-client started crashing our WireMock tests in setup/teardown hooks.
- *
- * Node's native `fetch` (undici) does NOT have this bug, so we re-point each admin method the tests
- * rely on at `adminFetch`, which talks to WireMock directly. Keeping the workaround here (rather
- * than pinning a CI Node version) makes it independent of the runtime and resilient to future
- * re-regressions of the same kind (it already re-regressed once on the 26.x line).
- *
- * TODO: Drop wiremock-rest-client in the Universal Driver migration
- *
- * @param {Object} restClient - The WireMock REST client instance
- * @param {string} baseUri - WireMock base URI
- * @returns {Object} The same client, with admin methods patched.
- */
-function patchAdminClientWithNativeFetch(restClient, baseUri) {
-  // Shutdown is pure teardown: the server is going away, so a dropped connection while it tears
-  // down its socket is expected and harmless. Swallow connection errors so cleanup never fails the
-  // suite (an unreachable server here just means it already stopped).
-  restClient.global.shutdown = async () => {
-    try {
-      return await adminFetch(baseUri, '/__admin/shutdown', { method: 'POST' });
-    } catch (err) {
-      Logger.getInstance().info(`Ignoring WireMock shutdown error: ${err.message || err}`);
-      return '';
-    }
-  };
-
-  restClient.mappings.resetAllMappings = () =>
-    adminFetch(baseUri, '/__admin/mappings/reset', { method: 'POST' });
-
-  restClient.mappings.createMapping = (stubMapping) =>
-    adminFetch(baseUri, '/__admin/mappings', {
-      method: 'POST',
-      body: JSON.stringify(stubMapping),
-    });
-
-  restClient.scenarios.resetAllScenarios = () =>
-    adminFetch(baseUri, '/__admin/scenarios/reset', { method: 'POST' });
-
-  restClient.requests.getCount = (requestPattern) =>
-    adminFetch(baseUri, '/__admin/requests/count', {
-      method: 'POST',
-      body: JSON.stringify(requestPattern),
-    });
-
-  return restClient;
 }
 
 /**


### PR DESCRIPTION
### Description

When `.x` is used GitHub action runners are returning cached node versions that contain the regression https://github.com/nodejs/node/issues/63989

There's no way to clear the cache, so forcing fixed versions

### Checklist

- [x] Create tests which fail without the change (if possible)
- [x] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [x] Extend the types in index.d.ts file (if necessary)
- [x] Extend the README / documentation and ensure is properly displayed (if necessary)
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message
