### PR TITLE
SNOW-3721604 Fix empty crl handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Bugfixes:
 
 - Reverted the unintentional breaking change from the 3.0.0 release (snowflakedb/snowflake-connector-nodejs#1415) that switched AWS Workload Identity attestation from SigV4 `GetCallerIdentity` to STS `GetWebIdentityToken`. AWS Workload Identity again defaults to `GetCallerIdentity`; the new method is now opt-in via `workloadIdentityAwsUseOutboundToken` (snowflakedb/snowflake-connector-nodejs#1437)
 - Removed usage of deprecated `util.isString` to fix Node 24 compatibility. Added additional logging where this caused silent failure (snowflakedb/snowflake-connector-nodejs#1436).
+- Fixed CRL validation failing with `crl.tbsCertList.revokedCertificates is not iterable` for CRLs that contain no revoked certificates, where the OPTIONAL `revokedCertificates` field (RFC 5280 §5.1) is absent (snowflakedb/snowflake-connector-nodejs#1448).
 
 ## 3.0.0
 

--- a/lib/agent/crl_validator/certificate_utils.ts
+++ b/lib/agent/crl_validator/certificate_utils.ts
@@ -72,7 +72,7 @@ export function isCertificateRevoked(
   decodedCertificate: rfc5280.CertificateDecoded,
   crl: rfc5280.CertificateListDecoded,
 ) {
-  for (const revokedCert of crl.tbsCertList.revokedCertificates) {
+  for (const revokedCert of crl.tbsCertList.revokedCertificates ?? []) {
     if (revokedCert.userCertificate.eq(decodedCertificate.tbsCertificate.serialNumber)) {
       return true;
     }

--- a/lib/types/asn1.js.d.ts
+++ b/lib/types/asn1.js.d.ts
@@ -125,7 +125,7 @@ declare module 'asn1.js-rfc5280' {
     issuer: NameRDNSequence;
     thisUpdate: Time;
     nextUpdate: Time;
-    revokedCertificates: {
+    revokedCertificates?: {
       userCertificate: BN;
       revocationDate: Time;
       crlEntryExtensions?: Extension[];

--- a/test/unit/agent/crl_validator/certificate_utils_test.ts
+++ b/test/unit/agent/crl_validator/certificate_utils_test.ts
@@ -161,7 +161,17 @@ describe('isCertificateRevoked', () => {
 
   it('returns false in certificate is not in CRL', () => {
     const certificate = createTestCertificate();
-    const crl = createTestCRL();
+    const crl = createTestCRL({
+      revokedCertificates: [1001],
+    });
+    const isRevoked = isCertificateRevoked(certificate, crl);
+    assert.strictEqual(isRevoked, false);
+  });
+
+  it('returns false for CRL with no revoked certificates', () => {
+    const certificate = createTestCertificate();
+    const crl = createTestCRL({ revokedCertificates: undefined });
+    assert.strictEqual(crl.tbsCertList.revokedCertificates, undefined);
     const isRevoked = isCertificateRevoked(certificate, crl);
     assert.strictEqual(isRevoked, false);
   });

--- a/test/unit/agent/crl_validator/test_utils.ts
+++ b/test/unit/agent/crl_validator/test_utils.ts
@@ -218,7 +218,6 @@ export function createTestCRL(
       rsassaPssHashOid: options.rsassaPssHashOid,
     });
   const issuingDistributionPointUrls = options.issuingDistributionPointUrls ?? null;
-  const revokedCertificates = options.revokedCertificates ?? ['0'];
   const nextUpdate = options.nextUpdate ?? Date.now() + 1000 * 60 * 60 * 24 * 365; // 1 year from now
 
   const tbsCertList: rfc5280.TBSCertList = {
@@ -227,7 +226,7 @@ export function createTestCRL(
     issuer: issuerCertificate.tbsCertificate.subject,
     thisUpdate: { type: 'utcTime', value: new Date('2026-06-01T00:00:00Z').getTime() },
     nextUpdate: { type: 'utcTime', value: nextUpdate },
-    revokedCertificates: revokedCertificates.map((serialNumber) => ({
+    revokedCertificates: options.revokedCertificates?.map((serialNumber) => ({
       userCertificate: new asn1.bignum(serialNumber),
       revocationDate: {
         type: 'utcTime' as const,


### PR DESCRIPTION
### Description

CRL validation fails with CRLError: crl.tbsCertList.revokedCertificates is not iterable when downloading query result chunks from Azure Blob Storage. The Microsoft TLS G2 partitioned CRL (Microsoft TLS G2 RSA CA OCSP [02_Partition00060.crl](http://www.microsoft.com/pkiops/crl/partition/Microsoft%20TLS%20G2%20RSA%20CA%20OCSP%2002_Partition00060.crl)) has zero revoked certificates, making the revokedCertificates field null/absent. 

The driver iterates this field without null-checking. Per RFC 5280 §5.1, revokedCertificates is OPTIONAL in TBSCertList. Error occurs on every result chunk download (49 occurrences in a single query).

### Checklist

- [x] Create tests which fail without the change (if possible)
- [x] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [x] Extend the types in index.d.ts file (if necessary)
- [x] Extend the README / documentation and ensure is properly displayed (if necessary)
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message
