### PR TITLE
Fix Node process crash in compressFileWithGZIP on unreadable PUT source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Upcoming Release
 
-- TBA
+Bugfixes:
+
+- Fixed `compressFileWithGZIP` crashing the Node process with an unhandled stream `'error'` event when the source file for a `PUT` cannot be read (e.g. it is removed before compression). The gzip read/transform/write chain now uses `stream.pipeline`, so such failures reject the `PUT` operation instead of terminating the process.
 
 ## 3.1.0
 

--- a/lib/file_util.js
+++ b/lib/file_util.js
@@ -1,6 +1,7 @@
 const crypto = require('crypto');
 const fs = require('fs');
 const fsPromises = require('node:fs/promises');
+const { pipeline } = require('node:stream/promises');
 const path = require('path');
 const zlib = require('zlib');
 const os = require('os');
@@ -59,18 +60,15 @@ function FileUtil() {
     const baseName = path.basename(fileName);
     const gzipFileName = path.join(tmpDir, baseName + '_c.gz');
 
-    await new Promise(function (resolve) {
-      // Create gzip object
-      const gzip = zlib.createGzip();
-      // Create stream object for reader and writer
-      const reader = fs.createReadStream(fileName);
-      const writer = fs.createWriteStream(gzipFileName);
-      // Write and compress file
-      const result = reader.pipe(gzip).pipe(writer);
-      result.on('finish', function () {
-        resolve();
-      });
-    });
+    // Use stream.pipeline so that an error on any stream (e.g. the source file
+    // is missing or unreadable) rejects this call and destroys every stream,
+    // instead of surfacing as an unhandled 'error' event that crashes the
+    // process while the promise (which only listened for 'finish') never settles.
+    await pipeline(
+      fs.createReadStream(fileName),
+      zlib.createGzip(),
+      fs.createWriteStream(gzipFileName),
+    );
 
     await this.normalizeGzipHeader(gzipFileName);
 

--- a/test/unit/file_transfer_agent/file_util_test.js
+++ b/test/unit/file_transfer_agent/file_util_test.js
@@ -33,6 +33,42 @@ describe('FileUtil.getDigestAndSizeForFile()', function () {
   });
 });
 
+describe('FileUtil.compressFileWithGZIP()', function () {
+  it('gzip-compresses a file and the output round-trips to the source content', async function () {
+    const zlib = require('zlib');
+    const fileUtil = new FileUtil();
+    const tmpDir = await fsPromises.mkdtemp(path.join(os.tmpdir(), 'compress-'));
+    const srcPath = path.join(tmpDir, `src_${crypto.randomUUID()}.txt`);
+    const content = Buffer.from('snowflake-nodejs-compress-test\n'.repeat(100));
+
+    await fsPromises.writeFile(srcPath, content);
+    try {
+      const result = await fileUtil.compressFileWithGZIP(srcPath, tmpDir);
+      assert.ok(result.name.endsWith('_c.gz'));
+      assert.ok(result.size > 0);
+      const decompressed = zlib.gunzipSync(await fsPromises.readFile(result.name));
+      assert.deepStrictEqual(decompressed, content);
+    } finally {
+      await fsPromises.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects instead of crashing the process when the source file is missing', async function () {
+    const fileUtil = new FileUtil();
+    const tmpDir = await fsPromises.mkdtemp(path.join(os.tmpdir(), 'compress-'));
+    const missingPath = path.join(tmpDir, `missing_${crypto.randomUUID()}.txt`);
+
+    try {
+      await assert.rejects(
+        () => fileUtil.compressFileWithGZIP(missingPath, tmpDir),
+        (err) => err && err.code === 'ENOENT',
+      );
+    } finally {
+      await fsPromises.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
 describe('globToRegex', function () {
   const files = [
     'matched.gzip',


### PR DESCRIPTION
### Description

`FileUtil.compressFileWithGZIP` (`lib/file_util.js`) pipes the source file through gzip into a temp file and `await`s a promise that only listens for the writable's `finish` event — none of the read/gzip/write streams has an `error` handler. If the source file is missing or unreadable when a `PUT ... AUTO_COMPRESS=TRUE` runs, the read stream emits an `error` with no listener, which Node escalates to an `uncaughtException` that crashes the whole process; the wrapping promise also never settles.

This is reachable whenever a file disappears between when the `PUT` file list is resolved and when a given file is compressed (an external cleanup process, a race, or a path that no longer exists).

**Fix:** use `stream.pipeline` from `node:stream/promises`. It propagates an error from any stream in the chain into a single rejection and destroys every stream, so a missing/unreadable source now rejects `compressFileWithGZIP` — which propagates through the existing `try/catch` in `uploadOneFile` and surfaces as a failed `PUT` — instead of terminating the process. No behavior change on the success path.

Minimal repro (crashes on current `master`):

```js
const os = require('os');
const { FileUtil } = require('snowflake-sdk/lib/file_util');
await new FileUtil().compressFileWithGZIP('/path/does-not-exist.csv', os.tmpdir());
// -> uncaughtException: ENOENT (process crash); the promise never settles
```

### Checklist

- [x] Create tests which fail without the change (added `FileUtil.compressFileWithGZIP()` tests: gzip round-trip + rejection when the source file is missing; the latter crashes the runner without this fix)
- [x] Unit tests pass (`npm run test:unit`); prettier, oxlint and `check-ts` pass. Integration tests not run locally (require a live account)
- [ ] Extend the types in index.d.ts file (not necessary — no public API change)
- [x] Updated `CHANGELOG.md`
- [ ] Provide JIRA/GitHub issue id (external contribution; no JIRA id — happy to link a GitHub issue if preferred)

> Draft: opening for early feedback.