### PR TITLE
SNOW-3854016 Use stageInfo endPoint in azure_util.js to support Azure Gov

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Changes:
 Bugfixes:
 
 - Fixed the TypeScript typing for `connection.fetchResult()`, which incorrectly required `sqlText` and omitted `queryId` (snowflakedb/snowflake-connector-nodejs#1462)
+- Fixed Azure PUT/GET file transfers failing on non-commercial Azure clouds (snowflakedb/snowflake-connector-nodejs#1459)
 
 ## 3.1.0
 

--- a/lib/file_transfer_agent/azure_util.js
+++ b/lib/file_transfer_agent/azure_util.js
@@ -44,16 +44,7 @@ function AzureUtil(connectionConfig) {
     const stageCredentials = stageInfo['creds'];
     const sasToken = stageCredentials['AZURE_SAS_TOKEN'];
 
-    const account = stageInfo['storageAccount'];
-    // GS provides the correct endpoint suffix via stageInfo['endPoint'] (e.g.
-    // 'core.usgovcloudapi.net' on Azure Gov). Fall back to the commercial
-    // endpoint when GS does not send one. Strip a leading 'blob.' since the
-    // suffix is re-added below, matching the Python SDK.
-    let endPoint = stageInfo['endPoint'] || 'core.windows.net';
-    if (endPoint.startsWith('blob.')) {
-      endPoint = endPoint.substring('blob.'.length);
-    }
-    const connectionString = `https://${account}.blob.${endPoint}${sasToken}`;
+    const connectionString = buildAzureUrl(stageInfo, sasToken);
     let proxy = ProxyUtil.getProxy(connectionConfig.getProxy(), 'Azure Util');
     if (proxy && !isBypassProxy(proxy, connectionString)) {
       Logger().debug(
@@ -344,6 +335,59 @@ function AzureUtil(connectionConfig) {
     }
     meta['resultStatus'] = resultStatus.DOWNLOADED;
   };
+
+  /**
+   * Derive the Azure blob service URL (connection string) from the stage info
+   * GS supplies. Based on universal-driver code.
+   *
+   * @param {Object} stageInfo
+   * @param {String} sasToken
+   *
+   * @returns {String}
+   */
+  function buildAzureUrl(stageInfo, sasToken) {
+    const rawEndPoint = stageInfo['endPoint'];
+
+    // A full base URL (e.g. from Azurite / a mock test server) is used verbatim
+    // as scheme+host, with the storage account NOT prepended.
+    if (
+      typeof rawEndPoint === 'string' &&
+      (rawEndPoint.startsWith('http://') || rawEndPoint.startsWith('https://'))
+    ) {
+      return `${rawEndPoint}${sasToken}`;
+    }
+
+    const storageAccount = stageInfo['storageAccount'];
+    if (typeof storageAccount !== 'string' || storageAccount.length === 0) {
+      throw new Error('Azure stage is missing a non-empty storageAccount');
+    }
+
+    // Fall back to the commercial endpoint when GS does not send one.
+    let blobEndpoint =
+      typeof rawEndPoint === 'string' && rawEndPoint.length > 0 ? rawEndPoint : 'core.windows.net';
+
+    // Normalize to a bare hostname: strip a scheme, a leading slash, and any path.
+    const schemeIndex = blobEndpoint.indexOf('://');
+    if (schemeIndex !== -1) {
+      blobEndpoint = blobEndpoint.substring(schemeIndex + '://'.length);
+    }
+    if (blobEndpoint.startsWith('/')) {
+      blobEndpoint = blobEndpoint.substring(1);
+    }
+    const slashIndex = blobEndpoint.indexOf('/');
+    if (slashIndex !== -1) {
+      blobEndpoint = blobEndpoint.substring(0, slashIndex);
+    }
+
+    // Prepend `blob.` only when it is not already present, so the commercial
+    // `blob.core.windows.net` stays as-is and `core.usgovcloudapi.net`
+    // becomes `blob.core.usgovcloudapi.net`.
+    if (!blobEndpoint.startsWith('blob.')) {
+      blobEndpoint = `blob.${blobEndpoint}`;
+    }
+
+    return `https://${storageAccount}.${blobEndpoint}${sasToken}`;
+  }
 
   /**
    * Detect if the Azure token has expired.

--- a/lib/file_transfer_agent/azure_util.js
+++ b/lib/file_transfer_agent/azure_util.js
@@ -45,7 +45,15 @@ function AzureUtil(connectionConfig) {
     const sasToken = stageCredentials['AZURE_SAS_TOKEN'];
 
     const account = stageInfo['storageAccount'];
-    const connectionString = `https://${account}.blob.core.windows.net${sasToken}`;
+    // GS provides the correct endpoint suffix via stageInfo['endPoint'] (e.g.
+    // 'core.usgovcloudapi.net' on Azure Gov). Fall back to the commercial
+    // endpoint when GS does not send one. Strip a leading 'blob.' since the
+    // suffix is re-added below, matching the Python SDK.
+    let endPoint = stageInfo['endPoint'] || 'core.windows.net';
+    if (endPoint.startsWith('blob.')) {
+      endPoint = endPoint.substring('blob.'.length);
+    }
+    const connectionString = `https://${account}.blob.${endPoint}${sasToken}`;
     let proxy = ProxyUtil.getProxy(connectionConfig.getProxy(), 'Azure Util');
     if (proxy && !isBypassProxy(proxy, connectionString)) {
       Logger().debug(

--- a/test/unit/file_transfer_agent/azure_test.js
+++ b/test/unit/file_transfer_agent/azure_test.js
@@ -87,6 +87,35 @@ describe('Azure client', function () {
     assert.strictEqual(result.path, path);
   }
 
+  it('createClient uses commercial endpoint when GS sends none', function () {
+    const Azure = mockBlobClient();
+    Azure.createClient({ creds: { AZURE_SAS_TOKEN: '?sig=abc' }, storageAccount: 'myacct' });
+    const connectionString = AZURE.BlobServiceClient.firstCall.args[0];
+    assert.strictEqual(connectionString, 'https://myacct.blob.core.windows.net?sig=abc');
+  });
+
+  it('createClient honors stageInfo endPoint for Azure Gov', function () {
+    const Azure = mockBlobClient();
+    Azure.createClient({
+      creds: { AZURE_SAS_TOKEN: '?sig=abc' },
+      storageAccount: 'myacct',
+      endPoint: 'core.usgovcloudapi.net',
+    });
+    const connectionString = AZURE.BlobServiceClient.firstCall.args[0];
+    assert.strictEqual(connectionString, 'https://myacct.blob.core.usgovcloudapi.net?sig=abc');
+  });
+
+  it('createClient strips a leading blob. from stageInfo endPoint', function () {
+    const Azure = mockBlobClient();
+    Azure.createClient({
+      creds: { AZURE_SAS_TOKEN: '?sig=abc' },
+      storageAccount: 'myacct',
+      endPoint: 'blob.core.usgovcloudapi.net',
+    });
+    const connectionString = AZURE.BlobServiceClient.firstCall.args[0];
+    assert.strictEqual(connectionString, 'https://myacct.blob.core.usgovcloudapi.net?sig=abc');
+  });
+
   it('extract bucket name and path', async function () {
     const Azure = mockBlobClient();
     verifyNameAndPath(

--- a/test/unit/file_transfer_agent/azure_test.js
+++ b/test/unit/file_transfer_agent/azure_test.js
@@ -44,6 +44,7 @@ describe('Azure client', function () {
     stageInfo: {
       location: mockLocation,
       path: mockTable + '/' + mockPath + '/',
+      storageAccount: 'mockAccount',
       creds: {},
     },
     SHA256_DIGEST: mockDigest,
@@ -105,7 +106,7 @@ describe('Azure client', function () {
     assert.strictEqual(connectionString, 'https://myacct.blob.core.usgovcloudapi.net?sig=abc');
   });
 
-  it('createClient strips a leading blob. from stageInfo endPoint', function () {
+  it('createClient does not double-prefix a blob. endPoint from stageInfo', function () {
     const Azure = mockBlobClient();
     Azure.createClient({
       creds: { AZURE_SAS_TOKEN: '?sig=abc' },
@@ -114,6 +115,49 @@ describe('Azure client', function () {
     });
     const connectionString = AZURE.BlobServiceClient.firstCall.args[0];
     assert.strictEqual(connectionString, 'https://myacct.blob.core.usgovcloudapi.net?sig=abc');
+  });
+
+  it('createClient honors stageInfo endPoint for Azure China', function () {
+    const Azure = mockBlobClient();
+    Azure.createClient({
+      creds: { AZURE_SAS_TOKEN: '?sig=abc' },
+      storageAccount: 'myacct',
+      endPoint: 'core.chinacloudapi.cn',
+    });
+    const connectionString = AZURE.BlobServiceClient.firstCall.args[0];
+    assert.strictEqual(connectionString, 'https://myacct.blob.core.chinacloudapi.cn?sig=abc');
+  });
+
+  it('createClient uses a scheme-prefixed endPoint verbatim as the base URL', function () {
+    const Azure = mockBlobClient();
+    Azure.createClient({
+      creds: { AZURE_SAS_TOKEN: '?sig=abc' },
+      storageAccount: 'myacct',
+      endPoint: 'https://127.0.0.1:10000/devstoreaccount1',
+    });
+    const connectionString = AZURE.BlobServiceClient.firstCall.args[0];
+    assert.strictEqual(connectionString, 'https://127.0.0.1:10000/devstoreaccount1?sig=abc');
+  });
+
+  it('createClient throws naming storageAccount when it is missing', function () {
+    const Azure = mockBlobClient();
+    assert.throws(
+      () => Azure.createClient({ creds: { AZURE_SAS_TOKEN: '?sig=abc' } }),
+      /storageAccount/,
+    );
+  });
+
+  it('createClient throws naming storageAccount when it is empty', function () {
+    const Azure = mockBlobClient();
+    assert.throws(
+      () =>
+        Azure.createClient({
+          creds: { AZURE_SAS_TOKEN: '?sig=abc' },
+          storageAccount: '',
+          endPoint: 'core.usgovcloudapi.net',
+        }),
+      /storageAccount/,
+    );
   });
 
   it('extract bucket name and path', async function () {


### PR DESCRIPTION
## Summary
- Fixes [SNOW-3854016](https://snowflakecomputing.atlassian.net/browse/SNOW-3854016): the Node.js SDK hardcoded the commercial Azure Blob endpoint (`blob.core.windows.net`) in `lib/file_transfer_agent/azure_util.js`, so all PUT/GET file transfers failed on Azure Government (`azusgovvirginiafhp`) and any other non-commercial Azure cloud.
- `createClient()` now reads the endpoint suffix GS already supplies via `stageInfo['endPoint']` (e.g. `core.usgovcloudapi.net`), strips a leading `blob.`, and falls back to `core.windows.net` when GS sends none — so commercial behavior is unchanged.
- This mirrors what the S3 (`s3_util.js`) and GCS (`gcs_util.js`) utils already do, and matches the Python SDK's `azure_storage_client.py`.

## Changes
- `lib/file_transfer_agent/azure_util.js`: build the connection string from `stageInfo['endPoint']` instead of a hardcoded host.
- `test/unit/file_transfer_agent/azure_test.js`: add unit tests covering the commercial default, the Azure Gov endpoint, and stripping a leading `blob.` prefix.

## Test plan
- [ ] `npm test` (unit) — new tests in `test/unit/file_transfer_agent/azure_test.js` pass
- [ ] Verify `test_storage_snowservices_stage_access_nodejs` passes on an Azure Gov deployment (e.g. `azusgovvirginiafhp`)
- [ ] Confirm no regression for PUT/GET on commercial Azure

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)

[SNOW-3854016]: https://snowflakecomputing.atlassian.net/browse/SNOW-3854016?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ