### PR TITLE
Fix fetchResult typing and polish prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+lib/minicore/rust_minicore/target/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Bugfixes:
 
-- Fixed the TypeScript typing for `connection.fetchResult()`, which incorrectly required `sqlText` and omitted `queryId` (snowflakedb/snowflake-connector-nodejs#TODO)
+- Fixed the TypeScript typing for `connection.fetchResult()`, which incorrectly required `sqlText` and omitted `queryId` (snowflakedb/snowflake-connector-nodejs#1462)
 
 ## 3.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Upcoming Release
 
-- TBA
+Bugfixes:
+
+- Fixed the TypeScript typing for `connection.fetchResult()`, which incorrectly required `sqlText` and omitted `queryId` (snowflakedb/snowflake-connector-nodejs#TODO)
 
 ## 3.1.0
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -308,7 +308,9 @@ declare module 'snowflake-sdk' {
     /**
      * Fetches the result of a previously issued statement.
      */
-    fetchResult(options: StatementOption): RowStatement | FileAndStageBindStatement;
+    fetchResult(
+      options: { queryId: string } & Partial<StatementOption>,
+    ): RowStatement | FileAndStageBindStatement;
 
     /**
      * Immediately terminates the connection without waiting for currently executing statements to complete.


### PR DESCRIPTION
### Description

* fix `connection.fetchResult()` typing
* add rust build folder to prettier ignore to speed it up

### Checklist

- [x] Create tests which fail without the change (if possible)
- [x] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [x] Extend the types in index.d.ts file (if necessary)
- [x] Extend the README / documentation and ensure is properly displayed (if necessary)
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message
