### PR TITLE
Fix public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 Changes:
 
-- Marked `RowStatement.fetchRows()` as deprecated. This method will be removed in the next major version; use `streamRows()` instead.
-- Removed the `getRowValue()` and `getRowValueAsString()` methods from the `Column` interface. These methods required an internal row representation that is never exposed publicly, so calling them on user-visible rows always threw a runtime error.
+- Marked `RowStatement.fetchRows()` as deprecated. This method will be removed in the next major version; use `streamRows()` instead (snowflakedb/snowflake-connector-nodejs#1463)
+- Removed the `getRowValue()` and `getRowValueAsString()` methods from the `Column` interface. These methods required an internal row representation that is never exposed publicly, so calling them on user-visible rows always threw a runtime error (snowflakedb/snowflake-connector-nodejs#1463)
 
 ## 3.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## Upcoming Release
 
-- TBA
+Changes:
+
+- Marked `RowStatement.fetchRows()` as deprecated. This method will be removed in the next major version; use `streamRows()` instead.
+- Removed the `getRowValue()` and `getRowValueAsString()` methods from the `Column` interface. These methods required an internal row representation that is never exposed publicly, so calling them on user-visible rows always threw a runtime error.
 
 ## 3.1.0
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -527,6 +527,9 @@ declare module 'snowflake-sdk' {
      * Fetches the rows in this statement's result and invokes each()
      * callback on each row. If start and end values are specified each()
      * callback will only be invoked on rows in the specified range.
+     *
+     * @deprecated
+     * This method is going to be removed in the next major version. Use `streamRows` instead.
      */
     fetchRows(options?: StreamOptions): Readable;
   }
@@ -636,16 +639,6 @@ declare module 'snowflake-sdk' {
      * Returns true if this column is type MAP.
      */
     isMap(): boolean;
-
-    /**
-     * Returns the value of this column in a row.
-     */
-    getRowValue(row: object): any;
-
-    /**
-     * Returns the value of this in a row as a String.
-     */
-    getRowValueAsString(row: object): string;
   }
 
   export interface OcspModes {

--- a/lib/connection/result/chunk.js
+++ b/lib/connection/result/chunk.js
@@ -317,7 +317,7 @@ function convertRowsetToRows(statement, startIndex, rowset, columns, mapColumnNa
       mapColumnNameToIndices,
     );
 
-    return column ? column.getRowValue(this) : undefined;
+    return column ? column._getRowValue(this) : undefined;
   };
 
   /**
@@ -336,7 +336,7 @@ function convertRowsetToRows(statement, startIndex, rowset, columns, mapColumnNa
       mapColumnNameToIndices,
     );
 
-    return column ? column.getRowValueAsString(this) : undefined;
+    return column ? column._getRowValueAsString(this) : undefined;
   };
 
   ///////////////////////////////////////////////////////////////////////////

--- a/lib/connection/result/column.js
+++ b/lib/connection/result/column.js
@@ -232,7 +232,7 @@ function Column({
    *
    * @returns {*}
    */
-  this.getRowValue = function (row) {
+  this._getRowValue = function (row) {
     return extractFromRow.call(this, row, context, false);
   };
 
@@ -243,7 +243,7 @@ function Column({
    *
    * @returns {String}
    */
-  this.getRowValueAsString = function (row) {
+  this._getRowValueAsString = function (row) {
     return extractFromRow.call(this, row, context, true);
   };
 }


### PR DESCRIPTION
### Description

- Marked `RowStatement.fetchRows()` as deprecated. This method will be removed in the next major version; use `streamRows()` instead.
- Removed the `getRowValue()` and `getRowValueAsString()` methods from the `Column` interface. These methods required an internal row representation that is never exposed publicly, so calling them on user-visible rows always threw a runtime error.

### Checklist

- [x] Create tests which fail without the change (if possible)
- [x] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [x] Extend the types in index.d.ts file (if necessary)
- [x] Extend the README / documentation and ensure is properly displayed (if necessary)
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message
