### PR TITLE
Fix tests

### DIFF
--- a/test/integration/testConnection.js
+++ b/test/integration/testConnection.js
@@ -49,7 +49,7 @@ describe('Connection test', function () {
     const connection = snowflake.createConnection(connOption.wrongUserName);
     connection.connect(function (err) {
       assert.ok(err, 'Username is an empty string');
-      assert.match(err['message'], /Incorrect username or password was specified/);
+      assert.match(err.message, /Incorrect username or password was specified/);
       done();
     });
   });
@@ -58,7 +58,7 @@ describe('Connection test', function () {
     const connection = snowflake.createConnection(connOption.wrongPwd);
     connection.connect(function (err) {
       assert.ok(err, 'Password is an empty string');
-      assert.match(err['message'], /Incorrect username or password was specified/);
+      assert.match(err.message, /Incorrect username or password was specified/);
       done();
     });
   });

--- a/test/integration/testConnection.js
+++ b/test/integration/testConnection.js
@@ -49,7 +49,7 @@ describe('Connection test', function () {
     const connection = snowflake.createConnection(connOption.wrongUserName);
     connection.connect(function (err) {
       assert.ok(err, 'Username is an empty string');
-      assert.match(err['message'], /Incorrect username or password was specified\./);
+      assert.match(err['message'], /Incorrect username or password was specified/);
       done();
     });
   });
@@ -58,7 +58,7 @@ describe('Connection test', function () {
     const connection = snowflake.createConnection(connOption.wrongPwd);
     connection.connect(function (err) {
       assert.ok(err, 'Password is an empty string');
-      assert.match(err['message'], /Incorrect username or password was specified\./);
+      assert.match(err['message'], /Incorrect username or password was specified/);
       done();
     });
   });
@@ -839,7 +839,7 @@ describe('Connection test - connection pool', function () {
         assert.equal(connectionPool.size, 1);
       });
     } catch (err) {
-      assert.match(err.message, /Incorrect username or password was specified\./);
+      assert.match(err.message, /Incorrect username or password was specified/);
     }
   });
 
@@ -856,7 +856,7 @@ describe('Connection test - connection pool', function () {
     try {
       await connectionPool.acquire();
     } catch (err) {
-      assert.match(err.message, /Incorrect username or password was specified\./);
+      assert.match(err.message, /Incorrect username or password was specified/);
     }
   });
 });

--- a/test/integration/testConnection.js
+++ b/test/integration/testConnection.js
@@ -49,7 +49,7 @@ describe('Connection test', function () {
     const connection = snowflake.createConnection(connOption.wrongUserName);
     connection.connect(function (err) {
       assert.ok(err, 'Username is an empty string');
-      assert.equal('Incorrect username or password was specified.', err['message']);
+      assert.match(err['message'], /Incorrect username or password was specified\./);
       done();
     });
   });
@@ -58,7 +58,7 @@ describe('Connection test', function () {
     const connection = snowflake.createConnection(connOption.wrongPwd);
     connection.connect(function (err) {
       assert.ok(err, 'Password is an empty string');
-      assert.equal('Incorrect username or password was specified.', err['message']);
+      assert.match(err['message'], /Incorrect username or password was specified\./);
       done();
     });
   });
@@ -839,7 +839,7 @@ describe('Connection test - connection pool', function () {
         assert.equal(connectionPool.size, 1);
       });
     } catch (err) {
-      assert.strictEqual(err.message, 'Incorrect username or password was specified.');
+      assert.match(err.message, /Incorrect username or password was specified\./);
     }
   });
 
@@ -856,7 +856,7 @@ describe('Connection test - connection pool', function () {
     try {
       await connectionPool.acquire();
     } catch (err) {
-      assert.strictEqual(err.message, 'Incorrect username or password was specified.');
+      assert.match(err.message, /Incorrect username or password was specified\./);
     }
   });
 });


### PR DESCRIPTION
### Description

GS released a change and error now has an id suffix:
* Before - `Incorrect username or password was specified.`
* After - `Incorrect username or password was specified. [263c39b3-e774-43d3-a1df-89083dda6a02]`

This resulted in our tests breaking. Fixed by matching pattern instead of exact string

### Checklist

- [x] Create tests which fail without the change (if possible)
- [x] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [x] Extend the types in index.d.ts file (if necessary)
- [x] Extend the README / documentation and ensure is properly displayed (if necessary)
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message
