### PR TITLE
Improve crl signature verification performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Bugfixes:
 - Fixed Azure PUT/GET file transfers failing on non-commercial Azure clouds (snowflakedb/snowflake-connector-nodejs#1459)
 - Fixed `compressFileWithGZIP` crashing the Node process with an unhandled stream `'error'` event when the source file for a `PUT` cannot be read (snowflakedb/snowflake-connector-nodejs#1454)
 
+Internal:
+
+- Improved crl signature verification performance by 100x (snowflakedb/snowflake-connector-nodejs#1469)
+
 ## 3.1.0
 
 New features:

--- a/lib/agent/crl_validator/crl_cache.ts
+++ b/lib/agent/crl_validator/crl_cache.ts
@@ -7,14 +7,14 @@ import Logger from '../../logger';
 
 export const CRL_MEMORY_CACHE = new Map<
   string,
-  { expireAt: number; crl: rfc5280.CertificateListDecoded }
+  { expireAt: number; crl: rfc5280.CertificateListDecoded; raw: Buffer }
 >();
 
 export function getCrlFromMemory(url: string) {
   const cachedEntry = CRL_MEMORY_CACHE.get(url);
   if (cachedEntry) {
     if (cachedEntry.expireAt > Date.now()) {
-      return cachedEntry.crl;
+      return { crl: cachedEntry.crl, raw: cachedEntry.raw };
     } else {
       CRL_MEMORY_CACHE.delete(url);
       return null;
@@ -24,13 +24,14 @@ export function getCrlFromMemory(url: string) {
   }
 }
 
-export function setCrlInMemory(url: string, crl: rfc5280.CertificateListDecoded) {
+export function setCrlInMemory(url: string, crl: rfc5280.CertificateListDecoded, raw: Buffer) {
   CRL_MEMORY_CACHE.set(url, {
     expireAt: Math.min(
       Date.now() + GlobalConfigTyped.getValue('crlCacheValidityTime'),
       crl.tbsCertList.nextUpdate.value,
     ),
     crl,
+    raw,
   });
 }
 
@@ -78,7 +79,7 @@ export async function getCrlFromDisk(url: string) {
     const rawCrl = await fs.readFile(filePath);
     const decodedCrl = rfc5280.CertificateList.decode(rawCrl, 'der');
     if (decodedCrl.tbsCertList.nextUpdate.value > Date.now()) {
-      return decodedCrl;
+      return { crl: decodedCrl, raw: rawCrl };
     } else {
       Logger().debug(`CRL ${filePath} is expired, ignoring.`);
       return null;

--- a/lib/agent/crl_validator/crl_fetcher.ts
+++ b/lib/agent/crl_validator/crl_fetcher.ts
@@ -11,7 +11,13 @@ import {
   writeCrlToDisk,
 } from './crl_cache';
 
-export const PENDING_FETCH_REQUESTS = new Map<string, Promise<rfc5280.CertificateListDecoded>>();
+export const PENDING_FETCH_REQUESTS = new Map<
+  string,
+  Promise<{
+    crl: rfc5280.CertificateListDecoded;
+    raw: Buffer;
+  }>
+>();
 
 let memoryCacheCleanerInterval: NodeJS.Timeout | undefined;
 let diskCacheCleanerInterval: NodeJS.Timeout | undefined;
@@ -64,7 +70,7 @@ export async function getCrl(
     const cachedCrl = await getCrlFromDisk(url);
     if (cachedCrl) {
       if (options.inMemoryCache) {
-        setCrlInMemory(url, cachedCrl);
+        setCrlInMemory(url, cachedCrl.crl, cachedCrl.raw);
       }
       logDebug(`Returning from disk cache`);
       return cachedCrl;
@@ -74,26 +80,26 @@ export async function getCrl(
   const fetchPromise = (async () => {
     try {
       logDebug(`Downloading CRL`);
-      const { data } = await axios.get(url, {
+      const { data: raw } = await axios.get<Buffer>(url, {
         timeout: GlobalConfigTyped.getValue('crlDownloadTimeout'),
         responseType: 'arraybuffer',
         maxContentLength: GlobalConfigTyped.getValue('crlDownloadMaxSize'),
       });
 
       logDebug(`Parsing CRL`);
-      const parsedCrl = rfc5280.CertificateList.decode(data, 'der');
+      const parsedCrl = rfc5280.CertificateList.decode(raw, 'der');
 
       if (options.inMemoryCache) {
         logDebug('Saving to memory cache');
-        setCrlInMemory(url, parsedCrl);
+        setCrlInMemory(url, parsedCrl, raw);
       }
 
       if (options.onDiskCache) {
         logDebug('Saving to disk cache');
-        await writeCrlToDisk(url, data);
+        await writeCrlToDisk(url, raw);
       }
 
-      return parsedCrl;
+      return { crl: parsedCrl, raw };
     } finally {
       PENDING_FETCH_REQUESTS.delete(url);
     }

--- a/lib/agent/crl_validator/crl_signature_verifier.ts
+++ b/lib/agent/crl_validator/crl_signature_verifier.ts
@@ -1,31 +1,81 @@
 import crypto from 'crypto';
-import rfc5280 from 'asn1.js-rfc5280';
+import rfc5280, { type AlgorithmIdentifier } from 'asn1.js-rfc5280';
 import { ALGORITHM_OID } from './oids';
 import { parseRSASSAPSSParams } from './rsassa_pss_parser';
 
-type SignatureVerifier = (crl: rfc5280.CertificateListDecoded, issuerPublicKey: string) => boolean;
+type ParsedCertificateList = {
+  tbsCertList: Buffer;
+  signatureAlgorithm: Buffer;
+  signature: Buffer;
+};
 
-function digestVerifier(digestAlg: string): SignatureVerifier {
-  return (crl, issuerPublicKey) => {
-    const tbsEncoded = rfc5280.TBSCertList.encode(crl.tbsCertList, 'der');
-    return crypto.verify(digestAlg, tbsEncoded, issuerPublicKey, crl.signature.data);
+type SignatureVerifier = (
+  parsed: ParsedCertificateList,
+  signatureAlgorithm: AlgorithmIdentifier,
+  issuerPublicKey: string,
+) => boolean;
+
+// A DER CertificateList is a SEQUENCE of three TLVs (Tag-Length-Value):
+//
+//   30 <len>                         SEQUENCE (CertificateList)
+//     30 <len> ...                   TBSCertList         <- exact bytes the signature covers
+//     30 <len> <oid> [params]        AlgorithmIdentifier
+//     03 <len> 00 <sig...>           BIT STRING (signatureValue)
+//
+// Each TLV starts with a 1-byte tag, then a length: if the length byte is
+// < 0x80 it is the length itself (short form); otherwise its low 7 bits give
+// the number of following big-endian bytes that hold the length (long form).
+// We walk the three children by reading each header and skipping its content,
+// returning views (no copies). The BIT STRING value is prefixed with one
+// "unused bits" byte (always 0x00 here) which we drop to get the signature.
+function readTlv(buf: Buffer, offset: number) {
+  let length = buf[offset + 1];
+  let headerLength = 2;
+  if (length & 0x80) {
+    const numLengthBytes = length & 0x7f;
+    length = 0;
+    for (let i = 0; i < numLengthBytes; i++) {
+      length = length * 256 + buf[offset + 2 + i];
+    }
+    headerLength = 2 + numLengthBytes;
+  }
+  const contentStart = offset + headerLength;
+  return { contentStart, end: contentStart + length };
+}
+
+export function parseCertificateListForVerification(rawCrl: Buffer): ParsedCertificateList {
+  if (rawCrl[0] !== 0x30) {
+    throw new Error('Invalid CRL: expected a DER SEQUENCE');
+  }
+  const outer = readTlv(rawCrl, 0);
+  const tbs = readTlv(rawCrl, outer.contentStart);
+  const sigAlg = readTlv(rawCrl, tbs.end);
+  const sigValue = readTlv(rawCrl, sigAlg.end);
+  return {
+    tbsCertList: rawCrl.subarray(outer.contentStart, tbs.end),
+    signatureAlgorithm: rawCrl.subarray(tbs.end, sigAlg.end),
+    signature: rawCrl.subarray(sigValue.contentStart + 1, sigValue.end),
   };
 }
 
-function pssVerifier(crl: rfc5280.CertificateListDecoded, issuerPublicKey: string) {
-  const pssParams = parseRSASSAPSSParams(crl.signatureAlgorithm.parameters);
-  const tbsEncoded = rfc5280.TBSCertList.encode(crl.tbsCertList, 'der');
+function digestVerifier(digestAlg: string): SignatureVerifier {
+  return (parsed, _signatureAlgorithm, issuerPublicKey) =>
+    crypto.verify(digestAlg, parsed.tbsCertList, issuerPublicKey, parsed.signature);
+}
+
+const pssVerifier: SignatureVerifier = (parsed, signatureAlgorithm, issuerPublicKey) => {
+  const pssParams = parseRSASSAPSSParams(signatureAlgorithm.parameters);
   return crypto.verify(
     pssParams.hashAlgorithm,
-    tbsEncoded,
+    parsed.tbsCertList,
     {
       key: issuerPublicKey,
       padding: crypto.constants.RSA_PKCS1_PSS_PADDING,
       saltLength: pssParams.saltLength,
     },
-    crl.signature.data,
+    parsed.signature,
   );
-}
+};
 
 export const CRL_SIGNATURE_VERIFIERS: Record<string, SignatureVerifier> = {
   [ALGORITHM_OID.SHA256_WITH_RSA]: digestVerifier('sha256'),
@@ -37,11 +87,13 @@ export const CRL_SIGNATURE_VERIFIERS: Record<string, SignatureVerifier> = {
   [ALGORITHM_OID.RSASSA_PSS]: pssVerifier,
 };
 
-export function isCrlSignatureValid(crl: rfc5280.CertificateListDecoded, issuerPublicKey: string) {
-  const signatureAlgOid = crl.signatureAlgorithm.algorithm.join('.');
-  const verifier = CRL_SIGNATURE_VERIFIERS[signatureAlgOid];
+export function isCrlSignatureValid(rawCrl: Buffer, issuerPublicKey: string) {
+  const parsed = parseCertificateListForVerification(rawCrl);
+  const signatureAlgorithm = rfc5280.AlgorithmIdentifier.decode(parsed.signatureAlgorithm, 'der');
+  const oid = signatureAlgorithm.algorithm.join('.');
+  const verifier = CRL_SIGNATURE_VERIFIERS[oid];
   if (!verifier) {
-    throw new Error(`Unsupported signature algorithm: ${signatureAlgOid}`);
+    throw new Error(`Unsupported signature algorithm: ${oid}`);
   }
-  return verifier(crl, issuerPublicKey);
+  return verifier(parsed, signatureAlgorithm, issuerPublicKey);
 }

--- a/lib/agent/crl_validator/index.ts
+++ b/lib/agent/crl_validator/index.ts
@@ -112,13 +112,13 @@ export async function validateCrl(certChain: DetailedPeerCertificate, config: CR
 
     for (const crlUrl of crlUrls) {
       logDebug(`fetching ${crlUrl}`);
-      const crl = await getCrl(crlUrl, {
+      const { crl, raw } = await getCrl(crlUrl, {
         inMemoryCache: config.inMemoryCache,
         onDiskCache: config.onDiskCache,
       });
 
       logDebug(`validating ${crlUrl} signature`);
-      if (!isCrlSignatureValid(crl, issuerPublicKey)) {
+      if (!isCrlSignatureValid(raw, issuerPublicKey)) {
         throw new Error(
           `CRL ${crlUrl} signature is invalid. Expected signature by ${getCertificateDebugName(certificate.issuerCertificate)}`,
         );

--- a/test/unit/agent/crl_validator/crl_cache_test.ts
+++ b/test/unit/agent/crl_validator/crl_cache_test.ts
@@ -39,18 +39,20 @@ describe('CRL cache', () => {
 
   describe('setCrlInMemory', () => {
     it('adds crl to cache with expiration time equal to crl nextUpdate when nextUpdate < 24 hours', () => {
-      setCrlInMemory(crlUrl, testCrl);
+      setCrlInMemory(crlUrl, testCrl, testCrlRaw);
       const cachedEntry = CRL_MEMORY_CACHE.get(crlUrl);
       assert.strictEqual(cachedEntry?.expireAt, testCrl.tbsCertList.nextUpdate.value);
       assert.strictEqual(cachedEntry?.crl, testCrl);
+      assert.strictEqual(cachedEntry?.raw, testCrlRaw);
     });
 
     it('adds crl to cache with expiration time equal to default expiration when default is sooner', () => {
       testCrl.tbsCertList.nextUpdate.value = fakeNow + crlCacheValidityTime * 2;
-      setCrlInMemory(crlUrl, testCrl);
+      setCrlInMemory(crlUrl, testCrl, testCrlRaw);
       const cachedEntry = CRL_MEMORY_CACHE.get(crlUrl);
       assert.strictEqual(cachedEntry?.expireAt, fakeNow + crlCacheValidityTime);
       assert.strictEqual(cachedEntry?.crl, testCrl);
+      assert.strictEqual(cachedEntry?.raw, testCrlRaw);
     });
   });
 
@@ -64,19 +66,21 @@ describe('CRL cache', () => {
       CRL_MEMORY_CACHE.set(crlUrl, {
         expireAt: fakeNow - 1000,
         crl: testCrl,
+        raw: testCrlRaw,
       });
       const result = getCrlFromMemory(crlUrl);
       assert.strictEqual(result, null);
       assert.strictEqual(CRL_MEMORY_CACHE.size, 0);
     });
 
-    it('returns crl when crl is in cache and is not expired', () => {
+    it('returns crl and raw when crl is in cache and is not expired', () => {
       CRL_MEMORY_CACHE.set(crlUrl, {
         crl: testCrl,
+        raw: testCrlRaw,
         expireAt: fakeNow + 1000,
       });
       const result = getCrlFromMemory(crlUrl);
-      assert.strictEqual(result, testCrl);
+      assert.deepStrictEqual(result, { crl: testCrl, raw: testCrlRaw });
     });
   });
 
@@ -87,10 +91,12 @@ describe('CRL cache', () => {
       CRL_MEMORY_CACHE.set('http://expired.example.com/crl', {
         expireAt: fakeNow - 1000,
         crl: expiredCrl,
+        raw: testCrlRaw,
       });
       CRL_MEMORY_CACHE.set('https://valid.example.com/crl', {
         expireAt: fakeNow + 1000,
         crl: validCrl,
+        raw: testCrlRaw,
       });
       assert.strictEqual(CRL_MEMORY_CACHE.size, 2);
       clearExpiredCrlFromMemoryCache();
@@ -142,12 +148,13 @@ describe('CRL cache', () => {
       assert.strictEqual(result, null);
     });
 
-    it('returns parsed CRL when found on disk with nextUpdate > now', async () => {
+    it('returns parsed CRL and raw bytes when found on disk with nextUpdate > now', async () => {
       testCrl.tbsCertList.nextUpdate.value = fakeNow + 1000;
       testCrlRaw = rfc5280.CertificateList.encode(testCrl, 'der');
       await writeCrlToDisk(crlUrl, testCrlRaw);
       const result = await getCrlFromDisk(crlUrl);
-      assert.deepEqual(result, testCrl);
+      assert.deepEqual(result?.crl, testCrl);
+      assert.deepEqual(result?.raw, testCrlRaw);
     });
   });
 

--- a/test/unit/agent/crl_validator/crl_fetcher_test.ts
+++ b/test/unit/agent/crl_validator/crl_fetcher_test.ts
@@ -68,7 +68,8 @@ describe('getCrl', () => {
         maxContentLength: 20971520,
       }),
     );
-    assert.deepEqual(fetchedCrl, testCrl);
+    assert.deepEqual(fetchedCrl.crl, testCrl);
+    assert.deepEqual(fetchedCrl.raw, testCrlRaw);
   });
 
   it('fetches only once if multiple requests are made at the same time', async () => {
@@ -85,8 +86,8 @@ describe('getCrl', () => {
     ]);
     assert.strictEqual(axiosGetStub.callCount, 1);
     assert.strictEqual(PENDING_FETCH_REQUESTS.size, 0);
-    assert.deepEqual(crl1, testCrl);
-    assert.deepEqual(crl2, testCrl);
+    assert.deepEqual(crl1.crl, testCrl);
+    assert.deepEqual(crl2.crl, testCrl);
   });
 
   it('writes fetched data to cache', async () => {
@@ -96,18 +97,19 @@ describe('getCrl', () => {
       onDiskCache: true,
     });
     assert.strictEqual(axiosGetStub.callCount, 1);
-    assert.deepEqual(crlCacheModule.getCrlFromMemory(crlUrl), testCrl);
-    assert.deepEqual(await crlCacheModule.getCrlFromDisk(crlUrl), testCrl);
+    assert.deepEqual(crlCacheModule.getCrlFromMemory(crlUrl)?.crl, testCrl);
+    assert.deepEqual((await crlCacheModule.getCrlFromDisk(crlUrl))?.crl, testCrl);
   });
 
   it('returns from memory cache if entry exists', async () => {
-    crlCacheModule.setCrlInMemory(crlUrl, testCrl);
+    crlCacheModule.setCrlInMemory(crlUrl, testCrl, testCrlRaw);
     const fetchedCrl = await getCrl(crlUrl, {
       inMemoryCache: true,
       onDiskCache: false,
     });
     assert.strictEqual(axiosGetStub.callCount, 0);
-    assert.deepEqual(fetchedCrl, testCrl);
+    assert.deepEqual(fetchedCrl.crl, testCrl);
+    assert.deepEqual(fetchedCrl.raw, testCrlRaw);
   });
 
   it('returns from disk cache and adds to memory cache if entry exists', async () => {
@@ -117,7 +119,7 @@ describe('getCrl', () => {
       onDiskCache: true,
     });
     assert.strictEqual(axiosGetStub.callCount, 0);
-    assert.deepEqual(fetchedCrl, testCrl);
-    assert.deepEqual(crlCacheModule.getCrlFromMemory(crlUrl), testCrl);
+    assert.deepEqual(fetchedCrl.crl, testCrl);
+    assert.deepEqual(crlCacheModule.getCrlFromMemory(crlUrl)?.crl, testCrl);
   });
 });

--- a/test/unit/agent/crl_validator/crl_signature_verifier_real_test.ts
+++ b/test/unit/agent/crl_validator/crl_signature_verifier_real_test.ts
@@ -10,25 +10,25 @@ const FIXTURES_DIR = path.join(__dirname, 'fixtures');
 
 describe('isCrlSignatureValid with real OpenSSL-generated CRL', () => {
   describe('RSASSA-PSS SHA-256', () => {
-    let crl: rfc5280.CertificateListDecoded;
+    let rawCrl: Buffer;
     let caPem: string;
 
     before(() => {
-      const crlDer = fs.readFileSync(path.join(FIXTURES_DIR, 'pss_sha256.crl'));
+      rawCrl = fs.readFileSync(path.join(FIXTURES_DIR, 'pss_sha256.crl'));
       caPem = fs.readFileSync(path.join(FIXTURES_DIR, 'pss_sha256_ca.pem'), 'utf8');
-      crl = rfc5280.CertificateList.decode(crlDer, 'der');
     });
 
     it('validates the CRL against its CA public key', () => {
+      const crl = rfc5280.CertificateList.decode(rawCrl, 'der');
       const signatureOid = crl.signatureAlgorithm.algorithm.join('.');
       assert.strictEqual(signatureOid, ALGORITHM_OID.RSASSA_PSS);
-      const isValid = isCrlSignatureValid(crl, caPem);
+      const isValid = isCrlSignatureValid(rawCrl, caPem);
       assert.strictEqual(isValid, true);
     });
 
     it('rejects the CRL when verified against an unrelated key', () => {
       const unrelatedKeyPair = createCertificateKeyPair();
-      const isValid = isCrlSignatureValid(crl, unrelatedKeyPair.publicKeyPem);
+      const isValid = isCrlSignatureValid(rawCrl, unrelatedKeyPair.publicKeyPem);
       assert.strictEqual(isValid, false);
     });
   });

--- a/test/unit/agent/crl_validator/crl_signature_verifier_test.ts
+++ b/test/unit/agent/crl_validator/crl_signature_verifier_test.ts
@@ -1,11 +1,17 @@
 import assert from 'assert';
+import rfc5280 from 'asn1.js-rfc5280';
 import { createCertificateKeyPair, createTestCRL } from './test_utils';
 import {
   isCrlSignatureValid,
+  parseCertificateListForVerification,
   CRL_SIGNATURE_VERIFIERS,
 } from '../../../../lib/agent/crl_validator/crl_signature_verifier';
 import { ALGORITHM_OID } from '../../../../lib/agent/crl_validator/oids';
 import { HASH_OID_TO_NAME } from '../../../../lib/agent/crl_validator/rsassa_pss_parser';
+
+function encodeCrl(crl: rfc5280.CertificateListDecoded) {
+  return rfc5280.CertificateList.encode(crl, 'der');
+}
 
 describe('isCrlSignatureValid', () => {
   Object.keys(CRL_SIGNATURE_VERIFIERS)
@@ -14,7 +20,7 @@ describe('isCrlSignatureValid', () => {
       it(`passes validation for algorithm oid=${oid}`, () => {
         const issuerKeyPair = createCertificateKeyPair(oid);
         const crl = createTestCRL({ issuerKeyPair, signatureAlgorithmOid: oid });
-        const isValid = isCrlSignatureValid(crl, issuerKeyPair.publicKeyPem);
+        const isValid = isCrlSignatureValid(encodeCrl(crl), issuerKeyPair.publicKeyPem);
         assert.strictEqual(isValid, true);
       });
     });
@@ -27,7 +33,7 @@ describe('isCrlSignatureValid', () => {
         signatureAlgorithmOid: ALGORITHM_OID.RSASSA_PSS,
         rsassaPssHashOid: oid,
       });
-      const isValid = isCrlSignatureValid(crl, issuerKeyPair.publicKeyPem);
+      const isValid = isCrlSignatureValid(encodeCrl(crl), issuerKeyPair.publicKeyPem);
       assert.strictEqual(isValid, true);
     });
   });
@@ -36,7 +42,7 @@ describe('isCrlSignatureValid', () => {
     const crl = createTestCRL();
     crl.signatureAlgorithm.algorithm = [1, 2, 3, 4, 5];
     assert.throws(
-      () => isCrlSignatureValid(crl, 'public key'),
+      () => isCrlSignatureValid(encodeCrl(crl), 'public key'),
       /Unsupported signature algorithm: 1\.2\.3\.4\.5/,
     );
   });
@@ -44,7 +50,40 @@ describe('isCrlSignatureValid', () => {
   it('returns false for crl with invalid signature', () => {
     const unrelatedKeyPair = createCertificateKeyPair();
     const crl = createTestCRL();
-    const isValid = isCrlSignatureValid(crl, unrelatedKeyPair.publicKeyPem);
+    const isValid = isCrlSignatureValid(encodeCrl(crl), unrelatedKeyPair.publicKeyPem);
     assert.strictEqual(isValid, false);
+  });
+
+  it('returns false when the signed TBSCertList bytes are tampered with', () => {
+    const issuerKeyPair = createCertificateKeyPair();
+    const crl = createTestCRL({ issuerKeyPair });
+    const raw = encodeCrl(crl);
+    const { tbsCertList } = parseCertificateListForVerification(raw);
+    tbsCertList[tbsCertList.length - 1] ^= 0xff;
+    const isValid = isCrlSignatureValid(raw, issuerKeyPair.publicKeyPem);
+    assert.strictEqual(isValid, false);
+  });
+
+  it('throws when the raw CRL is not a DER SEQUENCE', () => {
+    assert.throws(
+      () => isCrlSignatureValid(Buffer.from([0x02, 0x01, 0x00]), 'public key'),
+      /Invalid CRL: expected a DER SEQUENCE/,
+    );
+  });
+});
+
+describe('parseCertificateListForVerification', () => {
+  it('extracts the exact DER bytes of the TBSCertList', () => {
+    const crl = createTestCRL();
+    const raw = encodeCrl(crl);
+    const { tbsCertList } = parseCertificateListForVerification(raw);
+    assert.deepStrictEqual(tbsCertList, rfc5280.TBSCertList.encode(crl.tbsCertList, 'der'));
+  });
+
+  it('extracts the signature matching the decoded CRL signature', () => {
+    const crl = createTestCRL();
+    const raw = encodeCrl(crl);
+    const { signature } = parseCertificateListForVerification(raw);
+    assert.deepStrictEqual(signature, crl.signature.data);
   });
 });


### PR DESCRIPTION
### Description

#### Result

Before:
http://crl3.digicert.com/DigiCertGlobalG2TLSRSASHA2562020CA1-1.crl: 634.674ms
http://crl4.digicert.com/DigiCertGlobalG2TLSRSASHA2562020CA1-1.crl: 635.855ms


After:
http://crl3.digicert.com/DigiCertGlobalG2TLSRSASHA2562020CA1-1.crl: 6.327ms
http://crl4.digicert.com/DigiCertGlobalG2TLSRSASHA2562020CA1-1.crl: 6.417ms

#### How?

By storing the raw CRL bytes in the cache and verifying the signature against them directly, instead of re-encoding the TBSCertList from the decoded CRL on every check.

#### Note on re-parsing the algorithm

The signature algorithm is re-parsed from the raw bytes rather than reused from the decoded CRL. This overhead is insignificant (measured and confirmed), and keeping verification self-contained on the raw bytes lets us easily move it before writing to the cache in the future if we want.

### Checklist

- [x] Create tests which fail without the change (if possible)
- [x] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [x] Extend the types in index.d.ts file (if necessary)
- [x] Extend the README / documentation and ensure is properly displayed (if necessary)
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message