### PR TITLE
Logging hardening: correct SAS masking + extend cloud-URL query-param masking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Upcoming Release
 
-- TBA
+Changes:
+
+- Cloud storage response logs now list header names instead of full header objects, keeping header values out of the logs (snowflakedb/snowflake-connector-nodejs#1471)
 
 ## 3.2.0
 
@@ -10,7 +12,6 @@ Changes:
 
 - Marked `RowStatement.fetchRows()` as deprecated. This method will be removed in the next major version; use `streamRows()` instead (snowflakedb/snowflake-connector-nodejs#1463)
 - Removed the `getRowValue()` and `getRowValueAsString()` methods from the `Column` interface. These methods required an internal row representation that is never exposed publicly, so calling them on user-visible rows always threw a runtime error (snowflakedb/snowflake-connector-nodejs#1463)
-- Reduced what is written when the driver logs the responses it receives from cloud storage while downloading large result sets: the debug and trace messages now list the response header names instead of the whole header object, so header values are no longer part of the log output
 
 Bugfixes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Changes:
 
 - Marked `RowStatement.fetchRows()` as deprecated. This method will be removed in the next major version; use `streamRows()` instead (snowflakedb/snowflake-connector-nodejs#1463)
 - Removed the `getRowValue()` and `getRowValueAsString()` methods from the `Column` interface. These methods required an internal row representation that is never exposed publicly, so calling them on user-visible rows always threw a runtime error (snowflakedb/snowflake-connector-nodejs#1463)
+- Reduced what is written when the driver logs the responses it receives from cloud storage while downloading large result sets: the debug and trace messages now list the response header names instead of the whole header object, so header values are no longer part of the log output
 
 Bugfixes:
 

--- a/lib/file_transfer_agent/gcs_util.js
+++ b/lib/file_transfer_agent/gcs_util.js
@@ -6,6 +6,7 @@ const ProxyUtil = require('../proxy_util');
 const Util = require('../util');
 const { lstrip } = require('../util');
 const Logger = require('../logger').default;
+const { stripQueryString } = require('../logger/logging_util');
 const GlobalConfigTyped = require('../global_config_typed').default;
 const { MULTIPART_THRESHOLD_BYTES, MULTIPART_PART_SIZE_BYTES, readChunk } = require('./multipart');
 
@@ -470,7 +471,7 @@ function GCSUtil(connectionConfig, httpClient) {
           });
         });
       Logger().debug(
-        `Sent Get Request to ${downloadUrl}, destination: ${fullDstPath}, http status: ${response.status}`,
+        `Sent Get Request to ${stripQueryString(downloadUrl)}, destination: ${fullDstPath}, http status: ${response.status}`,
       );
 
       encryptionDataprop = response.headers[GCS_METADATA_ENCRYPTIONDATAPROP];

--- a/lib/file_transfer_agent/remote_storage_util.js
+++ b/lib/file_transfer_agent/remote_storage_util.js
@@ -8,6 +8,7 @@ const ExecutionTimer = require('../logger/execution_timer');
 const SnowflakeEncryptionUtil = new (require('./encrypt_util').EncryptUtil)();
 const resultStatus = require('../file_util').resultStatus;
 const Logger = require('../logger').default;
+const { stripQueryString } = require('../logger/logging_util');
 
 const DEFAULT_CONCURRENCY = 1;
 const DEFAULT_MAX_RETRY = 5;
@@ -382,7 +383,7 @@ function RemoteStorageUtil(connectionConfig) {
         return;
       } else if (meta['resultStatus'] === resultStatus.RENEW_PRESIGNED_URL) {
         Logger().debug(
-          `Need to renew presigned URL for downloading. file: ${meta.dstFileName}, presignedUrl: ${meta.presignedUrl}`,
+          `Need to renew presigned URL for downloading. file: ${meta.dstFileName}, presignedUrl: ${stripQueryString(meta.presignedUrl)}`,
         );
         return;
       } else if (meta['resultStatus'] === resultStatus.NEED_RETRY_WITH_LOWER_CONCURRENCY) {

--- a/lib/logger/logging_util.js
+++ b/lib/logger/logging_util.js
@@ -2,6 +2,7 @@ const Util = require('../util');
 
 const PROVIDED_TEXT = 'provided';
 const NOT_PROVIDED_TEXT = 'not provided';
+const NO_HEADERS_TEXT = 'none';
 
 /**
  * Describes the presence of a given value. If the value is not empty (as a string),
@@ -61,4 +62,36 @@ exports.describeAttributes = function (
     attributesWithoutValues,
   );
   return `[${attributesDescription}]`;
+};
+
+/**
+ * Describes a set of HTTP headers by listing their names only. Header values can
+ * carry credential material (session tokens, encryption keys, cookies), so they
+ * must never reach the logs.
+ *
+ * Works with any header container whose own enumerable properties are the header
+ * names - both the plain objects the driver builds for requests and the
+ * AxiosHeaders instances axios attaches to responses.
+ *
+ * @param {Object} [headers] - The headers to describe, may be missing or empty.
+ * @returns {string} Comma-separated header names in alphabetical order, or
+ * 'none' when there is nothing to describe.
+ */
+exports.headerNames = function (headers) {
+  if (!headers || typeof headers !== 'object') {
+    return NO_HEADERS_TEXT;
+  }
+  const names = Object.keys(headers).sort();
+  return names.length === 0 ? NO_HEADERS_TEXT : names.join(', ');
+};
+
+/**
+ * @param {string} url - The URL to strip the query string from.
+ * @returns {string} The URL without the query string.
+ */
+exports.stripQueryString = function (url) {
+  if (!url) {
+    return url;
+  }
+  return url ? url.split('?')[0] : url;
 };

--- a/lib/secret_detector.js
+++ b/lib/secret_detector.js
@@ -61,7 +61,18 @@ function SecretDetector(customPatterns, mock) {
     'gi',
   );
   const SAS_TOKEN_PATTERN = new RegExp(
-    String.raw`(sig|signature|AWSAccessKeyId|password|passcode)=(\?P<secret>[a-z0-9%/+]{16,})`,
+    String.raw`(sig|signature|AWSAccessKeyId|password|passcode)=([a-z0-9%/+]{16,})`,
+    'gi',
+  );
+  // Masks the X-Amz-Credential / X-Amz-Security-Token query params
+  // (X-Amz-Signature is covered by SAS_TOKEN_PATTERN).
+  const AWS_SIGV4_PARAM_PATTERN = new RegExp(
+    String.raw`(x-amz-credential|x-amz-security-token)=([a-z0-9%/+=._-]{8,})`,
+    'gi',
+  );
+  // Masks the S3 SSE-C customer-key header value if present in log text.
+  const SSE_C_KEY_PATTERN = new RegExp(
+    String.raw`(x-amz-server-side-encryption-customer-key)((?:\s*,?\s*value)?\s*[:=]\s*)([a-z0-9+/]{16,}={0,2})`,
     'gi',
   );
   const PRIVATE_KEY_PATTERN = new RegExp(
@@ -106,6 +117,14 @@ function SecretDetector(customPatterns, mock) {
 
   function maskSasToken(text) {
     return text.replace(SAS_TOKEN_PATTERN, String.raw`$1=****`);
+  }
+
+  function maskAwsSigV4(text) {
+    return text.replace(AWS_SIGV4_PARAM_PATTERN, String.raw`$1=****`);
+  }
+
+  function maskSseCKey(text) {
+    return text.replace(SSE_C_KEY_PATTERN, String.raw`$1$2****`);
   }
 
   function maskPrivateKey(text) {
@@ -165,7 +184,11 @@ function SecretDetector(customPatterns, mock) {
         maskPasscode(
           maskConnectionToken(
             maskPassword(
-              maskPrivateKeyData(maskPrivateKey(maskAwsToken(maskSasToken(maskAwsKeys(text))))),
+              maskPrivateKeyData(
+                maskPrivateKey(
+                  maskAwsToken(maskSasToken(maskAwsSigV4(maskSseCKey(maskAwsKeys(text))))),
+                ),
+              ),
             ),
           ),
         ),

--- a/lib/services/large_result_set.js
+++ b/lib/services/large_result_set.js
@@ -2,6 +2,7 @@ const EventEmitter = require('events').EventEmitter;
 const Util = require('../util');
 const Errors = require('../errors');
 const Logger = require('../logger');
+const LoggingUtil = require('../logger/logging_util');
 const ErrorCodes = Errors.codes;
 
 // NOTE:
@@ -68,7 +69,7 @@ function LargeResultSetService(connectionConfig, httpClient) {
         const logErr = err
           ? JSON.stringify(err, Object.getOwnPropertyNames(err))
           : `status: ${JSON.stringify(response.status)} ${JSON.stringify(response.statusText)}` +
-            ` headers: ${JSON.stringify(response.headers)}`;
+            ` header names: ${LoggingUtil.headerNames(response.headers)}`;
         Logger.getInstance().debug(
           'Encountered an error when getting data from cloud storage: ' + logErr,
         );
@@ -107,7 +108,9 @@ function LargeResultSetService(connectionConfig, httpClient) {
         }
       }
       if (response) {
-        Logger.getInstance().trace(`Response headers are: ${JSON.stringify(response.headers)}`);
+        Logger.getInstance().trace(
+          `Response header names are: ${LoggingUtil.headerNames(response.headers)}`,
+        );
       }
       // if we have an error, clear the body
       if (err) {

--- a/test/unit/logger/logging_util_test.js
+++ b/test/unit/logger/logging_util_test.js
@@ -1,0 +1,77 @@
+const assert = require('assert');
+const { AxiosHeaders } = require('axios');
+const LoggingUtil = require('./../../../lib/logger/logging_util');
+
+describe('LoggingUtil.headerNames', () => {
+  it('returns the header names in alphabetical order', () => {
+    const headers = {
+      'x-amz-id-2': 'some-id',
+      'content-type': 'application/xml',
+      date: 'Tue, 01 Jul 2025 10:20:30 GMT',
+      'accept-ranges': 'bytes',
+    };
+
+    assert.strictEqual(
+      LoggingUtil.headerNames(headers),
+      'accept-ranges, content-type, date, x-amz-id-2',
+    );
+  });
+
+  it('returns the same names for the same headers added in a different order', () => {
+    const first = { 'content-type': 'application/xml', date: 'Tue, 01 Jul 2025 10:20:30 GMT' };
+    const second = { date: 'Tue, 01 Jul 2025 10:20:30 GMT', 'content-type': 'application/xml' };
+
+    assert.strictEqual(LoggingUtil.headerNames(first), LoggingUtil.headerNames(second));
+    assert.strictEqual(LoggingUtil.headerNames(first), 'content-type, date');
+  });
+
+  it('does not include header values', () => {
+    const sensitiveValue = 'this-value-must-not-be-described';
+    const headers = {
+      'x-amz-security-token': sensitiveValue,
+      'x-amz-server-side-encryption-customer-key': sensitiveValue,
+      'set-cookie': [`session=${sensitiveValue}`],
+      'content-type': 'application/xml',
+    };
+
+    const described = LoggingUtil.headerNames(headers);
+
+    assert.ok(
+      !described.includes(sensitiveValue),
+      `Expected no header value in '${described}' but the value was described`,
+    );
+    assert.strictEqual(
+      described,
+      'content-type, set-cookie, x-amz-security-token, x-amz-server-side-encryption-customer-key',
+    );
+  });
+
+  it('describes the response headers of an axios response', () => {
+    // Axios exposes response headers as an AxiosHeaders instance, not as a plain
+    // object, so the names have to be read from the own enumerable properties.
+    const sensitiveValue = 'this-value-must-not-be-described';
+    const headers = AxiosHeaders.from({
+      'content-type': 'application/xml',
+      'x-amz-security-token': sensitiveValue,
+      'set-cookie': [`session=${sensitiveValue}`],
+    });
+
+    const described = LoggingUtil.headerNames(headers);
+
+    assert.ok(
+      !described.includes(sensitiveValue),
+      `Expected no header value in '${described}' but the value was described`,
+    );
+    assert.strictEqual(described, 'content-type, set-cookie, x-amz-security-token');
+  });
+
+  it("describes an empty or missing set of headers as 'none'", () => {
+    [{}, undefined, null, ''].forEach((headers) => {
+      assert.strictEqual(
+        LoggingUtil.headerNames(headers),
+        'none',
+        `Unexpected description for ${JSON.stringify(headers)}`,
+      );
+    });
+  });
+});

--- a/test/unit/secret_detector_test.js
+++ b/test/unit/secret_detector_test.js
@@ -47,7 +47,7 @@ describe('Secret Detector', function () {
     assert.strictEqual(result.errstr, errstr.toString());
   });
 
-  it('test - mask token', async function () {
+  it('mask token', async function () {
     const longToken =
       '_Y1ZNETTn5/qfUWj3Jedby7gipDzQs=U' +
       'KyJH9DS=nFzzWnfZKGV+C7GopWCGD4Lj' +
@@ -90,7 +90,7 @@ describe('Secret Detector', function () {
     assert.strictEqual(result.errstr, null);
   });
 
-  it('test - false positive', async function () {
+  it('false positive', async function () {
     const falsePositiveToken =
       '2020-04-30 23:06:04,069 - MainThread auth.py:397' +
       ' - write_temporary_credential() - DEBUG - no ID ' +
@@ -102,7 +102,7 @@ describe('Secret Detector', function () {
     assert.strictEqual(result.errstr, null);
   });
 
-  it('test - password', async function () {
+  it('password', async function () {
     const randomPassword = 'Fh[+2J~AcqeqW%?';
 
     let randomPasswordWithPrefix = 'password:' + randomPassword;
@@ -136,7 +136,7 @@ describe('Secret Detector', function () {
     assert.strictEqual(result.errstr, null);
   });
 
-  it('test - token password', async function () {
+  it('token password', async function () {
     const longToken =
       '_Y1ZNETTn5/qfUWj3Jedby7gipDzQs=U' +
       'KyJH9DS=nFzzWnfZKGV+C7GopWCGD4Lj' +
@@ -293,7 +293,7 @@ describe('Secret Detector', function () {
     }
   });
 
-  it('test - passcode masking', async function () {
+  it('passcode masking', async function () {
     const fourDigitPasscode = 'passcode=1234';
     let result = SecretDetector.maskSecrets(fourDigitPasscode);
     assert.strictEqual(result.masked, true);
@@ -325,7 +325,7 @@ describe('Secret Detector', function () {
     assert.strictEqual(result.errstr, null);
   });
 
-  it('test - url token masking', async function () {
+  it('url token masking', async function () {
     const TEST_TOKEN_VALUE =
       'ETMsDgAAAZNi6aPlABRBRVMvQ0JDL1BLQ1M1UGFkZGluZwEAABAAEExQLlI3h9PIi9TcCRVdwlEAAABQLsgIQdJ0%2B8eQhDMjViFuY5v03Daxt235tNHYVLNoIqM70yLw4zyVdPlkEi208dS88lSqRvPdgQ/RACU7u%2Bn9gWLiTZ79dkZwl4zQactAKJgAFCUrvbxA2tnUP%2BsX6nPBNBzVWnK5';
     const TEST_TOKEN_VERSION_PREFIX = 'ver:1';
@@ -387,7 +387,7 @@ describe('Secret Detector', function () {
     assert.strictEqual(result.maskedtxt, 'token=****');
     assert.strictEqual(result.errstr, null);
   });
-  describe('test - oauthClientId masking', async function () {
+  describe('oauthClientId masking', async function () {
     const randomOauthClientIdValue = 'Fh[+2J~AcqeqW%?';
 
     const testCases = [
@@ -422,7 +422,7 @@ describe('Secret Detector', function () {
     ];
 
     testCases.forEach(({ name, outhClientIdString, maskedtxt, maskedFlag, errstr }) => {
-      it(`test - ${name}`, async function () {
+      it(`${name}`, async function () {
         const result = SecretDetector.maskSecrets(outhClientIdString);
         assert.strictEqual(result.masked, maskedFlag);
         assert.strictEqual(result.maskedtxt, maskedtxt);
@@ -431,7 +431,7 @@ describe('Secret Detector', function () {
     });
   });
 
-  describe('test - oauthClientSecret masking', async function () {
+  describe('oauthClientSecret masking', async function () {
     const randomOauthClientIdValue = 'Fh[+2J~AcqeqW%?';
 
     const testCases = [
@@ -466,7 +466,7 @@ describe('Secret Detector', function () {
     ];
 
     testCases.forEach(({ name, outhClientSecretString, maskedtxt, maskedFlag, errstr }) => {
-      it(`test - ${name}`, async function () {
+      it(`${name}`, async function () {
         const result = SecretDetector.maskSecrets(outhClientSecretString);
         assert.strictEqual(result.masked, maskedFlag);
         assert.strictEqual(result.maskedtxt, maskedtxt);
@@ -475,7 +475,7 @@ describe('Secret Detector', function () {
     });
   });
 
-  describe('test - clientSecret masking', async function () {
+  describe('clientSecret masking', async function () {
     const randomOauthClientIdValue = 'Fh[+2J~AcqeqW%?';
 
     const testCases = [
@@ -510,12 +510,92 @@ describe('Secret Detector', function () {
     ];
 
     testCases.forEach(({ name, clientSecretString, maskedtxt, maskedFlag, errstr }) => {
-      it(`test - ${name}`, async function () {
+      it(`${name}`, async function () {
         const result = SecretDetector.maskSecrets(clientSecretString);
         assert.strictEqual(result.masked, maskedFlag);
         assert.strictEqual(result.maskedtxt, maskedtxt);
         assert.strictEqual(result.errstr, errstr);
       });
     });
+  });
+
+  // Additional cloud-storage URL query-param and SSE-C header masking cases
+  // (SAS `sig`, X-Amz-Signature/Credential/Security-Token, X-Goog-Signature,
+  // full presigned URL, SSE-C header). See Finding #4 for context.
+  it('Azure SAS sig token masking', async function () {
+    const sig = 'a1B2c3D4e5F6g7H8i9J0kLmNoPqRsTuVwXyZ0123456';
+    const result = SecretDetector.maskSecrets('sig=' + sig);
+    assert.strictEqual(result.masked, true);
+    assert.strictEqual(result.maskedtxt, 'sig=****');
+    assert.ok(!result.maskedtxt.includes(sig), 'sig value must be masked');
+    assert.strictEqual(result.errstr, null);
+  });
+
+  it('S3 X-Amz-Signature masking', async function () {
+    const sig = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+    const result = SecretDetector.maskSecrets('X-Amz-Signature=' + sig);
+    assert.strictEqual(result.masked, true);
+    assert.strictEqual(result.maskedtxt, 'X-Amz-Signature=****');
+    assert.ok(!result.maskedtxt.includes(sig), 'signature value must be masked');
+    assert.strictEqual(result.errstr, null);
+  });
+
+  it('GCS X-Goog-Signature masking', async function () {
+    const sig = 'fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210';
+    const result = SecretDetector.maskSecrets('X-Goog-Signature=' + sig);
+    assert.strictEqual(result.masked, true);
+    assert.strictEqual(result.maskedtxt, 'X-Goog-Signature=****');
+    assert.ok(!result.maskedtxt.includes(sig), 'signature value must be masked');
+    assert.strictEqual(result.errstr, null);
+  });
+
+  it('S3 X-Amz-Credential masking', async function () {
+    const cred = 'AKIAIOSFODNN7EXAMPLE%2F20130524%2Fus-east-1%2Fs3%2Faws4_request';
+    const result = SecretDetector.maskSecrets('X-Amz-Credential=' + cred);
+    assert.strictEqual(result.masked, true);
+    assert.strictEqual(result.maskedtxt, 'X-Amz-Credential=****');
+    assert.ok(!result.maskedtxt.includes(cred), 'credential value must be masked');
+    assert.strictEqual(result.errstr, null);
+  });
+
+  it('S3 X-Amz-Security-Token masking', async function () {
+    const token = 'FQoGZXIvYXdzEND%2F%2F%2F%2F%2F%2FwEaDF9wZXhhbXBsZXRva2Vu';
+    const result = SecretDetector.maskSecrets('X-Amz-Security-Token=' + token);
+    assert.strictEqual(result.masked, true);
+    assert.strictEqual(result.maskedtxt, 'X-Amz-Security-Token=****');
+    assert.ok(!result.maskedtxt.includes(token), 'security token value must be masked');
+    assert.strictEqual(result.errstr, null);
+  });
+
+  it('full presigned S3 URL masking', async function () {
+    const sig = 'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789';
+    const cred = 'AKIAIOSFODNN7EXAMPLE%2F20130524%2Fus-east-1%2Fs3%2Faws4_request';
+    const url =
+      'https://mybucket.s3.us-east-1.amazonaws.com/path/to/file.csv?' +
+      'X-Amz-Algorithm=AWS4-HMAC-SHA256' +
+      '&X-Amz-Credential=' +
+      cred +
+      '&X-Amz-Date=20130524T000000Z&X-Amz-Expires=86400&X-Amz-SignedHeaders=host' +
+      '&X-Amz-Signature=' +
+      sig;
+    const result = SecretDetector.maskSecrets(url);
+    assert.strictEqual(result.masked, true);
+    assert.ok(!result.maskedtxt.includes(sig), 'signature value must be masked');
+    assert.ok(!result.maskedtxt.includes(cred), 'credential value must be masked');
+    assert.ok(result.maskedtxt.includes('****'), 'masked marker must be present');
+    assert.ok(
+      result.maskedtxt.includes('mybucket.s3.us-east-1.amazonaws.com'),
+      'non-secret host must be preserved',
+    );
+    assert.strictEqual(result.errstr, null);
+  });
+
+  it('SSE-C customer key masking', async function () {
+    const key = 'c2VjcmV0S2V5Rm9yU1NFQ0N1c3RvbWVyMzJieXRlc3g=';
+    const result = SecretDetector.maskSecrets('x-amz-server-side-encryption-customer-key=' + key);
+    assert.strictEqual(result.masked, true);
+    assert.strictEqual(result.maskedtxt, 'x-amz-server-side-encryption-customer-key=****');
+    assert.ok(!result.maskedtxt.includes(key), 'SSE-C customer key must be masked');
+    assert.strictEqual(result.errstr, null);
   });
 });


### PR DESCRIPTION
## Logging hardening 

Tightens how the driver's log masking handles cloud-storage URLs and headers. Log output already
flows through `SecretDetector.maskSecrets` centrally; this closes a few gaps in that masking.

- `lib/secret_detector.js`: correct the SAS/`sig` masking rule so it matches as intended, and
  extend coverage to the AWS SigV4 (`X-Amz-Credential`, `X-Amz-Security-Token`) and S3 SSE-C
  header forms. `X-Amz-Signature` / `X-Goog-Signature` are covered by the corrected
  `signature`/`sig` rule.
- `lib/file_transfer_agent/remote_storage_util.js`, `gcs_util.js`: trim the query string from
  URLs before they reach debug logs (mirrors the existing `azure_util.js` handling).
- Tests added in `test/unit/secret_detector_test.js` for the above.
