### PR TITLE
SNOW-4065118 Update toml dependency to 5.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Upcoming Release
 
-- TBA
+Dependencies:
+
+- Bumped `toml` dependency to `^5.0.0` (snowflakedb/snowflake-connector-nodejs#1477)
 
 ## 3.3.0
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "oauth4webapi": "^3.0.1",
     "open": "^7.3.1",
     "simple-lru-cache": "^0.0.2",
-    "toml": "^3.0.0",
+    "toml": "^5.0.0",
     "winston": "^3.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
### Description

Update toml dependency to 5.x to address https://github.com/snowflakedb/snowflake-connector-nodejs/issues/1476

5.x breaking change is fine for us as we don't have connection options where we expect numbers higher than `MAX_SAFE_INTEGER`

### Checklist

- [x] Create tests which fail without the change (if possible)
- [x] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [x] Extend the types in index.d.ts file (if necessary)
- [x] Extend the README / documentation and ensure is properly displayed (if necessary)
- [x] Provide JIRA issue id (if possible) or GitHub issue id in commit message
